### PR TITLE
pagination

### DIFF
--- a/apps/contrib/templates/meinberlin_contrib/includes/pagination.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/pagination.html
@@ -5,7 +5,7 @@
     <ul class="pagination">
         {% for page_number in page_obj.paginator.page_range %}
         <li class="pagination-item{% ifequal page_number page_obj.number %} active{% endifequal %}">
-            <a href="?page={{ page_number }}">{{ page_number }}</a>
+            <a href="?ordering={{ view.get_ordering }}&page={{ page_number }}">{{ page_number }}</a>
         </li>
         {% endfor %}
     </ul>

--- a/apps/contrib/templates/meinberlin_contrib/includes/pagination.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/pagination.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+{% if is_paginated %}
+<nav aria-label="{% trans 'Page navigation' %}">
+    <ul class="pagination">
+        {% for page_number in page_obj.paginator.page_range %}
+        <li class="pagination-item{% ifequal page_number page_obj.number %} active{% endifequal %}">
+            <a href="?page={{ page_number }}">{{ page_number }}</a>
+        </li>
+        {% endfor %}
+    </ul>
+</nav>
+{% endif %}

--- a/apps/contrib/templates/meinberlin_contrib/includes/sort.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/sort.html
@@ -9,7 +9,7 @@
             aria-expanded="false"
             id="sorts"
     >
-        {{ view.get_current_ordering_name}}
+        {{ view.get_ordering_name }}
         <i class="fa fa-caret-down" aria-hidden="true"></i>
     </button>
     <ul class="dropdown-menu" aria-labelledby="sorts">

--- a/apps/ideas/templates/meinberlin_ideas/idea_list.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_list.html
@@ -8,10 +8,15 @@
         {% trans 'Submit idea' %}
     </a>
 {% endif %}
+
 {% include "meinberlin_contrib/includes/sort.html" %}
+
  <div>
     {% for idea in idea_list %}
     {% include "meinberlin_ideas/includes/idea_list_tile.html" with idea=idea %}
     {% endfor %}
 </div>
+
+{% include "meinberlin_contrib/includes/pagination.html" %}
+
 {% endblock %}

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -28,6 +28,10 @@ class IdeaListView(mixins.ProjectMixin, SortableListView):
             .annotate_negative_rating_count() \
             .annotate_comment_count()
 
+    # FIXME: remove once https://github.com/liqd/adhocracy4/pull/27 is merged
+    def get_ordering(self):
+        return self.ordering[0]
+
 
 class IdeaDetailView(PermissionRequiredMixin, generic.DetailView):
     model = idea_models.Idea

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -28,10 +28,6 @@ class IdeaListView(mixins.ProjectMixin, SortableListView):
             .annotate_negative_rating_count() \
             .annotate_comment_count()
 
-    # FIXME: remove once https://github.com/liqd/adhocracy4/pull/27 is merged
-    def get_ordering(self):
-        return self.ordering[0]
-
 
 class IdeaDetailView(PermissionRequiredMixin, generic.DetailView):
     model = idea_models.Idea

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -14,6 +14,7 @@ from . import forms
 
 class IdeaListView(mixins.ProjectMixin, SortableListView):
     model = idea_models.Idea
+    paginate_by = 15
     ordering = ['-created']
     orderings_supported = [
         ('-created', _('Most recent')),

--- a/meinberlin/assets/scss/components/_pagination.scss
+++ b/meinberlin/assets/scss/components/_pagination.scss
@@ -1,0 +1,33 @@
+.pagination {
+    @include clearfix;
+    display: inline-block;
+    padding: 0;
+    padding-right: 1px;
+    background-color: $body-bg;
+}
+
+.pagination-item {
+    float: left;
+    display: inline-block;
+
+    a {
+        display: inline-block;
+        min-width: 1.4em + 2 * 0.5em;
+        margin-right: -1px;
+        padding: 0.5em;
+        border: 1px solid $border-color;
+        text-align: center;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+            background-color: $bg-secondary;
+        }
+    }
+
+    &.active a {
+        background: $link-color;
+        color: contrast-color($link-color);
+        border-color: $link-color;
+    }
+}

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -18,6 +18,7 @@
 @import 'components/dropdown';
 @import 'components/header';
 @import 'components/label';
+@import 'components/pagination';
 @import 'components/rating';
 @import 'components/resource_header';
 @import 'components/list_item';


### PR DESCRIPTION
Note that ddfdf04 uses the `contrast-color()` function from #31. There is no build error, but the styling looks a bit off without it.

The UI can be expanded later (e.g. previous/next links) but I went with a minimal solution for now.

To test, it is easiest to reduce `IdeaListView.paginate_by` to 1.