### PR TITLE
Add missing permission rule to allow user comments

### DIFF
--- a/apps/ideas/rules.py
+++ b/apps/ideas/rules.py
@@ -6,6 +6,7 @@ from adhocracy4.modules.predicates import is_context_member
 from adhocracy4.modules.predicates import is_context_moderator
 from adhocracy4.modules.predicates import is_owner
 from adhocracy4.modules.predicates import is_public_context
+from adhocracy4.phases.predicates import phase_allows_comment
 from adhocracy4.phases.predicates import phase_allows_create
 from adhocracy4.phases.predicates import phase_allows_modify
 from adhocracy4.phases.predicates import phase_allows_rate
@@ -26,6 +27,10 @@ rules.add_perm('meinberlin_ideas.propose_idea',
 rules.add_perm('meinberlin_ideas.rate_idea',
                is_superuser | is_context_moderator | is_context_initiator |
                (is_context_member & phase_allows_rate))
+
+rules.add_perm('meinberlin_ideas.comment_idea',
+               is_superuser | is_context_moderator | is_context_initiator |
+               (is_context_member & phase_allows_comment))
 
 
 rules.add_perm('meinberlin_ideas.modify_idea',


### PR DESCRIPTION
Used by the comment widget in `react_comments.py:30`