### PR TITLE
(un-)pin js dependencies

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -20,7 +20,6 @@
     "block-closing-brace-empty-line-before": "never",
     "block-closing-brace-newline-after": "always",
     "block-closing-brace-newline-before": "always-multi-line",
-    "block-no-single-line": true,
     "block-opening-brace-newline-after": "always",
     "block-opening-brace-space-before": "always",
 
@@ -46,15 +45,14 @@
 
     "selector-list-comma-newline-after": "always",
 
-    "rule-nested-empty-line-before": [ "always", {
+    "rule-empty-line-before": [ "always", {
       "except": ["first-nested"]
     }],
-    "rule-non-nested-empty-line-before": "always",
 
     "at-rule-empty-line-before": [ "always", {
       "except": ["first-nested"],
       "ignore": [
-        "blockless-group"
+        "blockless-after-blockless"
       ]
     }],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "htmlhint": "^0.9.13",
     "husky": "^0.11.4",
     "polylint.sh": "^0.0.0",
-    "stylelint": "^7.5.0",
+    "stylelint": "^7.8.0",
     "stylelint-declaration-strict-value": "^1.0.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-react": "^6.4.1",
     "eslint-plugin-standard": "^2.0.1",
-    "htmlhint": "0.9.13",
-    "husky": "0.11.4",
-    "polylint.sh": "0.0.0",
+    "htmlhint": "^0.9.13",
+    "husky": "^0.11.4",
+    "polylint.sh": "^0.0.0",
     "stylelint": "^7.5.0",
     "stylelint-declaration-strict-value": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "dependencies": {
     "adhocracy4": "liqd/adhocracy4#master",
 
-    "autoprefixer": "^6.5.2",
-    "babel-core": "^6.17.0",
-    "babel-loader": "^6.2.5",
-    "babel-preset-es2015": "^6.16.0",
-    "babel-preset-react": "^6.16.0",
-    "css-loader": "^0.25.0",
-    "extract-text-webpack-plugin": "^1.0.1",
-    "file-loader": "^0.9.0",
+    "autoprefixer": "6.5.2",
+    "babel-core": "6.17.0",
+    "babel-loader": "6.2.5",
+    "babel-preset-es2015": "6.16.0",
+    "babel-preset-react": "6.16.0",
+    "css-loader": "0.25.0",
+    "extract-text-webpack-plugin": "1.0.1",
+    "file-loader": "0.9.0",
     "node-sass": "3.10.1",
-    "postcss-loader": "^1.1.0",
+    "postcss-loader": "1.1.0",
     "sass-loader": "4.0.2",
     "style-loader": "0.13.1",
     "webpack": "1.13.1",
@@ -21,7 +21,7 @@
     "font-awesome": "4.6.3",
     "bootstrap": "4.0.0-alpha.6",
     "sass-planifolia": "xi/sass-planifolia#0.3.1",
-    "react-flip-move": "^2.6.1"
+    "react-flip-move": "2.6.1"
   },
   "devDependencies": {
     "eslint": "^3.7.1",


### PR DESCRIPTION
The use of `^` in `package.json` is currently inconsitent. I changed it so that all dependencies are pinned and all devDependencies are not pinned.

You can update all devDependencies by simply running `npm update`.

I also updated our stylelint config to remove deprected keywords.