### PR TITLE
Fix document detail layout

### DIFF
--- a/apps/documents/templates/meinberlin_documents/document_detail.html
+++ b/apps/documents/templates/meinberlin_documents/document_detail.html
@@ -2,7 +2,6 @@
 {% load i18n react_comments %}
 
 {% block phase_content %}
-<div class="l-wrapper document">
     <article>
         <h1>{{ object.name }}</h1>
 
@@ -32,5 +31,4 @@
 
     {% react_comments object %}
 
-</div>
 {% endblock %}

--- a/apps/ideas/templates/meinberlin_ideas/idea_list.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_list.html
@@ -2,6 +2,7 @@
 {% load i18n rules %}
 
 {% block phase_content %}
+<div class="l-center-8">
 {% has_perm 'meinberlin_ideas.propose_idea' request.user view.module as propose_allowed %}
 {% if propose_allowed %}
     <a href="{% url 'idea-create' slug=view.module.slug %}" class="button button--huge">
@@ -18,5 +19,5 @@
 </div>
 
 {% include "meinberlin_contrib/includes/pagination.html" %}
-
+</div>
 {% endblock %}

--- a/apps/ideas/templates/meinberlin_ideas/idea_list.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_list.html
@@ -3,21 +3,21 @@
 
 {% block phase_content %}
 <div class="l-center-8">
-{% has_perm 'meinberlin_ideas.propose_idea' request.user view.module as propose_allowed %}
-{% if propose_allowed %}
-    <a href="{% url 'idea-create' slug=view.module.slug %}" class="button button--huge">
-        {% trans 'Submit idea' %}
-    </a>
-{% endif %}
+    {% has_perm 'meinberlin_ideas.propose_idea' request.user view.module as propose_allowed %}
+    {% if propose_allowed %}
+        <a href="{% url 'idea-create' slug=view.module.slug %}" class="button button--huge">
+            {% trans 'Submit idea' %}
+        </a>
+    {% endif %}
 
-{% include "meinberlin_contrib/includes/sort.html" %}
+    {% include "meinberlin_contrib/includes/sort.html" %}
 
-<div>
-    {% for idea in idea_list %}
-    {% include "meinberlin_ideas/includes/idea_list_tile.html" with idea=idea %}
-    {% endfor %}
-</div>
+    <div>
+        {% for idea in idea_list %}
+        {% include "meinberlin_ideas/includes/idea_list_tile.html" with idea=idea %}
+        {% endfor %}
+    </div>
 
-{% include "meinberlin_contrib/includes/pagination.html" %}
+    {% include "meinberlin_contrib/includes/pagination.html" %}
 </div>
 {% endblock %}

--- a/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -48,14 +48,15 @@
 </div>
 
 <div class="l-wrapper">
-    <div class="l-center-8">
         <div
             class="tabpanel"
             id="tabpanel-project-{{ view.project.pk }}-information"
             role="tabpanel"
             aria-labelledby="tab-project-{{ view.project.pk }}-information"
             aria-expanded="false">
-            {{ view.project.information | safe }}
+            <div class="l-center-8">
+                {{ view.project.information | safe }}
+            </div>
         </div>
         <div
             class="tabpanel active"
@@ -71,8 +72,9 @@
             role="tabpanel"
             aria-labelledby="tab-project-{{ view.project.pk }}-result"
             aria-expanded="false">
-            {{ view.project.result | safe }}
+            <div class="l-center-8">
+                {{ view.project.result | safe }}
+            </div>
         </div>
-    </div>
 </div>
 {% endblock %}

--- a/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -48,33 +48,33 @@
 </div>
 
 <div class="l-wrapper">
-        <div
-            class="tabpanel"
-            id="tabpanel-project-{{ view.project.pk }}-information"
-            role="tabpanel"
-            aria-labelledby="tab-project-{{ view.project.pk }}-information"
-            aria-expanded="false">
-            <div class="l-center-8">
-                {{ view.project.information | safe }}
-            </div>
+    <div
+        class="tabpanel"
+        id="tabpanel-project-{{ view.project.pk }}-information"
+        role="tabpanel"
+        aria-labelledby="tab-project-{{ view.project.pk }}-information"
+        aria-expanded="false">
+        <div class="l-center-8">
+            {{ view.project.information | safe }}
         </div>
-        <div
-            class="tabpanel active"
-            id="tabpanel-project-{{ view.project.pk }}-participation"
-            role="tabpanel"
-            aria-labelledby="tab-project-{{ view.project.pk }}-participation"
-            aria-expanded="true">
-            {% block phase_content %}{% endblock %}
+    </div>
+    <div
+        class="tabpanel active"
+        id="tabpanel-project-{{ view.project.pk }}-participation"
+        role="tabpanel"
+        aria-labelledby="tab-project-{{ view.project.pk }}-participation"
+        aria-expanded="true">
+        {% block phase_content %}{% endblock %}
+    </div>
+    <div
+        class="tabpanel"
+        id="tabpanel-project-{{ view.project.pk }}-result"
+        role="tabpanel"
+        aria-labelledby="tab-project-{{ view.project.pk }}-result"
+        aria-expanded="false">
+        <div class="l-center-8">
+            {{ view.project.result | safe }}
         </div>
-        <div
-            class="tabpanel"
-            id="tabpanel-project-{{ view.project.pk }}-result"
-            role="tabpanel"
-            aria-labelledby="tab-project-{{ view.project.pk }}-result"
-            aria-expanded="false">
-            <div class="l-center-8">
-                {{ view.project.result | safe }}
-            </div>
-        </div>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
I already found the frist bug related to the new layout system (#40)!

To reproduce, notice that the comments on the [document detail page](https://meinberlin-dev.liqd.net/projects/text/) are to narrow.

This will probably have a git conflict with #49, but that should be easy to fix.