### PR TITLE
refactor buttons

### DIFF
--- a/apps/dashboard/templates/meinberlin_dashboard/includes/project_form.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/project_form.html
@@ -14,10 +14,10 @@
     {% include 'meinberlin_dashboard/includes/project_form_tab_result.html' with form=form view=view %}
 
     {% if not project or project.is_draft %}
-        <input type="submit" name="save_draft" value="{% trans 'Save Draft'%}" />
+        <input type="submit" class="button button--secondary" name="save_draft" value="{% trans 'Save Draft'%}" />
     {% else %}
-        <input type="submit" name="save_draft" value="{% trans 'Unpublish'%}" />
+        <input type="submit" class="button button--secondary" value="{% trans 'Unpublish'%}" />
     {% endif %}
-    <input type="submit" name="publish" value="{% trans 'Save and Publish'%}" />
+    <input type="submit" class="button button--primary" name="publish" value="{% trans 'Save and Publish'%}" />
 
 </form>

--- a/apps/documents/assets/ParagraphBox.jsx
+++ b/apps/documents/assets/ParagraphBox.jsx
@@ -194,7 +194,7 @@ var ParagraphBox = React.createClass({
             {this.state.successMessage}
           </p> : null
         }
-        <button type="submit">{django.gettext('save')}</button>
+        <button type="submit" className="button button--primary">{django.gettext('save')}</button>
       </form>
     )
   }

--- a/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html
@@ -11,6 +11,6 @@
         {% csrf_token %}
         <input type="submit" class="button button--primary" value="{% trans 'Yes'%}" />
     </form>
-    <a href="{% url 'idea-detail' idea.slug %}" class="cancel-button">{% trans 'Cancel'%}</a>
+    <a href="{% url 'idea-detail' idea.slug %}" class="button button--light">{% trans 'Cancel'%}</a>
 </div>
 {% endblock %}

--- a/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html
@@ -9,7 +9,7 @@
 
     <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
         {% csrf_token %}
-        <input type="submit" value="{% trans 'Yes'%}" />
+        <input type="submit" class="button button--primary" value="{% trans 'Yes'%}" />
     </form>
     <a href="{% url 'idea-detail' idea.slug %}" class="cancel-button">{% trans 'Cancel'%}</a>
 </div>

--- a/apps/ideas/templates/meinberlin_ideas/includes/idea_form.html
+++ b/apps/ideas/templates/meinberlin_ideas/includes/idea_form.html
@@ -16,6 +16,6 @@
         {{ form.description}}
         {{ form.description.errors }}
     </div>
-    <input type="submit" value="{% trans 'Save'%}" />
+    <input type="submit" class="button button--primary" value="{% trans 'Save'%}" />
     <a href="{{ cancel }}" class="cancel-button">{% trans 'cancel'%}</a>
 </form>

--- a/apps/ideas/templates/meinberlin_ideas/includes/idea_form.html
+++ b/apps/ideas/templates/meinberlin_ideas/includes/idea_form.html
@@ -17,5 +17,5 @@
         {{ form.description.errors }}
     </div>
     <input type="submit" class="button button--primary" value="{% trans 'Save'%}" />
-    <a href="{{ cancel }}" class="cancel-button">{% trans 'cancel'%}</a>
+    <a href="{{ cancel }}" class="button button--light">{% trans 'cancel'%}</a>
 </form>

--- a/meinberlin/assets/scss/_base.scss
+++ b/meinberlin/assets/scss/_base.scss
@@ -98,7 +98,8 @@ ul {
     padding-left: 1.5rem;
 }
 
-button {
+button,
+[type="submit"] {
     appearance: none;
     padding: 0;
     margin: 0;

--- a/meinberlin/assets/scss/_shame.scss
+++ b/meinberlin/assets/scss/_shame.scss
@@ -5,3 +5,13 @@
 .cke_chrome {
     box-sizing: border-box !important;
 }
+
+// used by adhocracy4
+.submit-button {
+    @extend .button;
+}
+
+.cancel-button {
+    @extend .button;
+    @extend .button--light;
+}

--- a/meinberlin/assets/scss/_shame.scss
+++ b/meinberlin/assets/scss/_shame.scss
@@ -17,6 +17,7 @@
 }
 
 // used by allauth (login/register)
+.signup > button[type="submit"],
 .primaryAction {
     @extend .button;
     @extend .button--primary;

--- a/meinberlin/assets/scss/_shame.scss
+++ b/meinberlin/assets/scss/_shame.scss
@@ -15,3 +15,14 @@
     @extend .button;
     @extend .button--light;
 }
+
+// used by allauth (login/register)
+.primaryAction {
+    @extend .button;
+    @extend .button--primary;
+}
+
+.secondaryAction {
+    @extend .button;
+    @extend .button--secondary;
+}

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -40,7 +40,6 @@
 
 .button,
 .submit-button,
-input[type="button"],
 [type="submit"] {
     @extend %buttonBase;
     @include button-color($link-color, $link-hover-color);

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -38,14 +38,21 @@
     padding-right: 1em;
 }
 
-.button,
-[type="submit"] {
+.button {
     @extend %buttonBase;
     @include button-color($link-color, $link-hover-color);
 }
 
 .button--light {
     @include button-color($body-bg, $bg-secondary);
+}
+
+.button--primary {
+    @include button-color($brand-primary, darken($brand-primary, 15%));
+}
+
+.button--secondary {
+    @include button-color($brand-secondary, darken($brand-secondary, 15%));
 }
 
 .button--huge {

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -39,21 +39,19 @@
 }
 
 .button,
-.submit-button,
 [type="submit"] {
     @extend %buttonBase;
     @include button-color($link-color, $link-hover-color);
+}
+
+.button--light {
+    @include button-color($body-bg, $bg-secondary);
 }
 
 .button--huge {
     font-size: $font-size-lg;
     display: block;
     line-height: 2.5;
-}
-
-.cancel-button {
-    @extend %buttonBase;
-    @include button-color($body-bg, $bg-secondary);
 }
 
 .button--as-link {


### PR DESCRIPTION
I removed the type based button selectors, so now we use classes exclusively. This is a good idea in general, but the trigger to do this now was the mis-styling of the logout button.