### PR TITLE
make projects created via dashboard public

### DIFF
--- a/apps/dashboard/forms.py
+++ b/apps/dashboard/forms.py
@@ -32,8 +32,7 @@ class ProjectForm(forms.ModelForm):
 
     class Meta:
         model = project_models.Project
-        fields = ['name', 'description', 'image', 'information', 'is_public',
-                  'result']
+        fields = ['name', 'description', 'image', 'information', 'result']
 
     def save(self, commit=True):
         self.instance.is_draft = 'save_draft' in self.data


### PR DESCRIPTION
Removes the `is_public` field from the project form such that the model default (`True`) is used.