### PR TITLE
switch to BEM CSS naming convention

### DIFF
--- a/apps/dashboard/templates/meinberlin_dashboard/blueprint_list.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/blueprint_list.html
@@ -5,7 +5,7 @@
 {% block dashboard_content %}
 
 <div class="resource-navigation">
-    <nav class="resource-navigation-breadcrumbs breadcrumbs">
+    <nav class="resource-navigation__breadcrumbs breadcrumbs">
         <ul>
             <li>
                 <a href="{% url 'dashboard-project-list' view.organisation.slug %}">
@@ -16,7 +16,7 @@
     </nav>
 </div>
 
-<h3 class="menuLayout-title">{% trans "New Project" %}</h3>
+<h3 class="menu-layout__title">{% trans "New Project" %}</h3>
 
 <div class="l-tile-wrapper">
     {% for blueprint_slug, blueprint in view.blueprints %}

--- a/apps/dashboard/templates/meinberlin_dashboard/dashboard_base.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/dashboard_base.html
@@ -6,9 +6,9 @@
 {% block content %}
 
 <div class="l-wrapper">
-    <div class="menuLayout">
+    <div class="menu-layout">
 
-        <div class="menuLayout-menu">
+        <div class="menu-layout__menu">
             <div class="dropdown">
                 <button
                         title="{% trans 'Organisations' %}"
@@ -37,7 +37,7 @@
             </div>
         </div>
 
-        <div class="menuLayout-content">
+        <div class="menu-layout__content">
             {% block dashboard_content %}{% endblock %}
         </div>
 

--- a/apps/dashboard/templates/meinberlin_dashboard/includes/project_list_tile.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/project_list_tile.html
@@ -1,7 +1,7 @@
 {% load i18n project_tags %}
 
-<div class="listItem">
-    <div class="listItem-actions">
+<div class="list-item">
+    <div class="list-item__actions">
         <span>
             <a href="{% url 'dashboard-project-edit' organisation_slug=view.organisation.slug slug=project.slug %}"
                class="button">
@@ -9,12 +9,12 @@
             </a>
         </span>
     </div>
-    <h3 class="listItem-title">
+    <h3 class="list-item__title">
         <a href="{% url 'project-detail' project.slug %}">
         {{ project.name }}
         </a>
     </h3>
-    <div class="listItem-status">
+    <div class="list-item__status">
         {% if project.has_finished %}
             {% trans 'Finished' %}
         {% elif project.active_phase %}

--- a/apps/dashboard/templates/meinberlin_dashboard/project_create_form.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/project_create_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block dashboard_content %}
-    <nav class="resource-navigation-breadcrumbs breadcrumbs">
+    <nav class="resource-navigation__breadcrumbs breadcrumbs">
         <ul>
             <li>
                 <a href="{% url 'dashboard-project-list' view.organisation.slug %}">

--- a/apps/dashboard/templates/meinberlin_dashboard/project_list.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/project_list.html
@@ -4,7 +4,7 @@
 {% block dashboard_content %}
 
 <div>
-    <span class="menuLayout-title">{% trans "Projects" %}</span>
+    <span class="menu-layout__title">{% trans "Projects" %}</span>
     <a href="{% url 'dashboard-blueprint-list' organisation_slug=view.organisation.slug %}" class="button">
         {% trans 'New Project' %}
     </a>

--- a/apps/dashboard/templates/meinberlin_dashboard/project_update_form.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/project_update_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block dashboard_content %}
-    <nav class="resource-navigation-breadcrumbs breadcrumbs">
+    <nav class="resource-navigation__breadcrumbs breadcrumbs">
         <ul>
             <li>
                 <a href="{% url 'dashboard-project-list' view.organisation.slug %}">

--- a/apps/documents/assets/Paragraph.jsx
+++ b/apps/documents/assets/Paragraph.jsx
@@ -74,7 +74,7 @@ var Paragraph = React.createClass({
         </button>
 
         <div className="commenting">
-          <div className="commenting-content">
+          <div className="commenting__content">
             <div className="form-group">
               <label
                 htmlFor={'id_paragraphs-' + this.props.id + '-name'}>
@@ -116,7 +116,7 @@ var Paragraph = React.createClass({
             </div>
           </div>
 
-          <div className="commenting-actions buttonGroup">
+          <div className="commenting__actions button-group">
             <button
               className="button"
               onClick={this.up}

--- a/apps/documents/templates/meinberlin_documents/document_detail.html
+++ b/apps/documents/templates/meinberlin_documents/document_detail.html
@@ -8,13 +8,13 @@
         {% for paragraph in object.paragraphs.all %}
 
         <section class="commenting">
-            <div class="commenting-content">
-                <h2 class="commenting-title">
+            <div class="commenting__content">
+                <h2 class="commenting__title">
                     {{ paragraph.name }}
                 </h2>
                 {{ paragraph.text|safe }}
             </div>
-            <div class="commenting-actions">
+            <div class="commenting__actions">
                 <a
                     class="button"
                     title="{% trans 'Comments for this Paragraph' %}"

--- a/apps/documents/templates/meinberlin_documents/paragraph_detail.html
+++ b/apps/documents/templates/meinberlin_documents/paragraph_detail.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="l-wrapper">
     <div class="resource-navigation">
-        <nav class="resource-navigation-breadcrumbs breadcrumbs">
+        <nav class="resource-navigation__breadcrumbs breadcrumbs">
             <ul>
                 <li>
                     <a href="{% url 'project-detail' paragraph.document.module.project.slug %}">

--- a/apps/ideas/templates/meinberlin_ideas/idea_detail.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_detail.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="resource-navigation">
     <div class="l-wrapper">
-        <nav class="resource-navigation-breadcrumbs breadcrumbs">
+        <nav class="resource-navigation__breadcrumbs breadcrumbs">
             <ul>
                 <li>
                     <a href="{% url 'project-detail' idea.project.slug %}">
@@ -17,7 +17,7 @@
 
         {% has_perm 'euth_ideas.modify_idea' request.user idea as show_dropdown %}
         {% if show_dropdown %}
-        <div class="resource-navigation-actions dropdown dropdown--right">
+        <div class="resource-navigation__actions dropdown dropdown--right">
             <button
                 title="{% trans 'Actions' %}"
                 type="button"

--- a/apps/ideas/templates/meinberlin_ideas/includes/idea_list_tile.html
+++ b/apps/ideas/templates/meinberlin_ideas/includes/idea_list_tile.html
@@ -1,5 +1,5 @@
-<div class="listItem listItem--squashed">
-    <div class="listItem-stats">
+<div class="list-item list-item--squashed">
+    <div class="list-item__stats">
         <span class="rating">
             <span class="rating-up is-read-only" title="Positive Ratings">
                 {{ idea.positive_rating_count }}
@@ -15,15 +15,15 @@
             <i class="fa fa-comment-o" aria-hidden="true"></i>
         </span>
     </div>
-    <h3 class="listItem-title">
+    <h3 class="list-item__title">
         <a href="{% url 'idea-detail' idea.slug %}">
         {{ idea.name }}
         </a>
     </h3>
-    <span class="listItem-author">
+    <span class="list-item__author">
         {{ idea.creator.username }}
     </span>
-    <span class="listItem-date">
+    <span class="list-item__date">
         {{ idea.created | date }}
     </span>
 </div>

--- a/apps/projects/templates/meinberlin_projects/includes/phase_indicator.html
+++ b/apps/projects/templates/meinberlin_projects/includes/phase_indicator.html
@@ -28,16 +28,16 @@
 {% endif %}
 {% endwith %}
 
-<div class="phaseInfo">
+<div class="phase-info">
     <div class="l-center-6">
-        <h3 class="phaseInfo-title">
+        <h3 class="phase-info__title">
             {{ active_phase.name }}
         </h3>
-        <div class="phaseInfo-subtitle">
+        <div class="phase-info__subtitle">
             {% trans "from" %} {{ active_phase.start_date }}
             {% trans "to" %} {{ active_phase.end_date }}
         </div>
-        <div class="phaseInfo-description">
+        <div class="phase-info__description">
             {{ active_phase.description }}
         </div>
     </div>

--- a/apps/projects/templates/meinberlin_projects/includes/phase_indicator.html
+++ b/apps/projects/templates/meinberlin_projects/includes/phase_indicator.html
@@ -5,7 +5,7 @@
 {% with project.phases|length as phase_count %}
 {% if phase_count > 1 %}
 <script src="{% static 'js/popover.js' %}"></script>
-<div class="phaseList">
+<div class="phase-list">
     <ul>
         {% for phase in project.phases %}
             {% includeTemplateString "meinberlin_projects/includes/phase_popover.html" phase=phase phase_num=forloop.counter phase_count=phase_count as popover_content %}
@@ -13,7 +13,7 @@
                 <button
                     title="{{ phase.name }}"
                     id="phase-{{ phase.pk }}"
-                    class="phaseList-button {% if phase == active_phase %} is-active{% endif %}"
+                    class="phase-list__button {% if phase == active_phase %} is-active{% endif %}"
                     data-toggle="popover"
                     data-content="{{ popover_content }}"
                     data-placement="top"

--- a/apps/projects/templates/meinberlin_projects/includes/phase_popover.html
+++ b/apps/projects/templates/meinberlin_projects/includes/phase_popover.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <div>
-    <div class="popover-subtitle">
+    <div class="popover__subtitle">
         {% trans "Phase" %} {{  phase_num }} {% trans "of" %} {{ phase_count }}
     </div>
-    <div class="popover-text">
+    <div class="popover__text">
         {% trans "from" %} {{  phase.start_date }}<br>
         {% trans "to" %} {{  phase.end_date }}
     </div>

--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -3,7 +3,7 @@ label {
     margin-bottom: 0.2em;
 }
 
-%inputBase {
+%input-base {
     margin: 0 0 $spacer;
     border: 1px solid $input-border-color;
     padding: 0.4em 0.6em;
@@ -15,7 +15,7 @@ label {
 input,
 textarea,
 select {
-    @extend %inputBase;
+    @extend %input-base;
     display: block;
     background-color: $bg-secondary;
     color: contrast-color($bg-secondary);
@@ -53,7 +53,7 @@ select {
     margin: 0 0 $spacer;
 
     .django-ckeditor-widget,
-    %inputBase {
+    %input-base {
         width: 100%;
         margin: 0;
     }

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -27,8 +27,8 @@
     }
 }
 
-%buttonBase {
-    @extend %inputBase;
+%button-base {
+    @extend %input-base;
     border-radius: 0.3em;
     text-decoration: none;
     display: inline-block;
@@ -39,7 +39,7 @@
 }
 
 .button {
-    @extend %buttonBase;
+    @extend %button-base;
     @include button-color($link-color, $link-hover-color);
 }
 
@@ -82,7 +82,7 @@
     margin-bottom: $spacer;
 }
 
-.buttonGroup {
+.button-group {
     > :not(:first-child) {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;

--- a/meinberlin/assets/scss/components/_commenting.scss
+++ b/meinberlin/assets/scss/components/_commenting.scss
@@ -2,16 +2,16 @@
     margin-bottom: $spacer;
 }
 
-.commenting-content {
+.commenting__content {
     padding-right: $padding;
     border-right: 1px solid $brand-primary;
 }
 
-.commenting-actions {
+.commenting__actions {
     text-align: right;
 }
 
-.commenting-title {
+.commenting__title {
     margin-top: 0;
     font-size: 100%;
 }
@@ -21,11 +21,11 @@
         @include clearfix;
     }
 
-    .commenting-content {
+    .commenting__content {
         @include grid-span(9, 0);
     }
 
-    .commenting-actions {
+    .commenting__actions {
         @include grid-span(3, 9);
         text-align: left;
     }

--- a/meinberlin/assets/scss/components/_header.scss
+++ b/meinberlin/assets/scss/components/_header.scss
@@ -1,16 +1,16 @@
-.mainHeader {
+.main-header {
     position: relative;
     background: url('/static/images/bg-amplitude-blue.png') bottom right no-repeat;
     padding-bottom: 68px;
 }
 
-.mainHeader-user {
+.main-header__user {
     position: absolute;
     top: 0;
     right: 0;
 }
 
-.mainNav {
+.main-nav {
     font-size: $font-size-lg;
     line-height: 1;
 
@@ -36,12 +36,12 @@
     }
 }
 
-.mainNav-item,
-.mainNav-logo {
+.main-nav__item,
+.main-nav__logo {
     margin-right: 1em;
 }
 
-.mainNav-logo {
+.main-nav__logo {
     img {
         width: 7em;
         margin-top: -3em;
@@ -49,6 +49,6 @@
     }
 }
 
-.mainNav-item {
+.main-nav__item {
     padding: 0.2em 0.4em;
 }

--- a/meinberlin/assets/scss/components/_list_item.scss
+++ b/meinberlin/assets/scss/components/_list_item.scss
@@ -1,4 +1,4 @@
-.listItem {
+.list-item {
     padding: $padding;
     display: block;
     position: relative;
@@ -6,7 +6,7 @@
     margin-bottom: $spacer;
 }
 
-.listItem--squashed {
+.list-item--squashed {
     border-top: 0;
     margin-bottom: 0;
 
@@ -15,27 +15,27 @@
     }
 }
 
-.listItem-author,
-.listItem-stats,
-.listItem-title {
+.list-item__author,
+.list-item__stats,
+.list-item__title {
     margin: 0 0 0.8rem;
 }
 
-.listItem-title {
+.list-item__title {
     font-size: $font-size-lg;
 }
 
-.listItem-author {
+.list-item__author {
     font-size: $font-size-sm;
     font-weight: bold;
 }
 
-.listItem-date {
+.list-item__date {
     font-size: $font-size-xs;
 }
 
-.listItem-actions,
-.listItem-stats {
+.list-item__actions,
+.list-item__stats {
     font-size: $font-size-sm;
     float: right;
 }

--- a/meinberlin/assets/scss/components/_menu_layout.scss
+++ b/meinberlin/assets/scss/components/_menu_layout.scss
@@ -1,13 +1,13 @@
 @media (min-width: $breakpoint) {
-    .menuLayout {
+    .menu-layout {
         @include clearfix;
     }
 
-    .menuLayout-menu {
+    .menu-layout__menu {
         @include grid-span(3, 0);
     }
 
-    .menuLayout-content {
+    .menu-layout__content {
         @include grid-span(9, 3);
     }
 }

--- a/meinberlin/assets/scss/components/_phases.scss
+++ b/meinberlin/assets/scss/components/_phases.scss
@@ -1,4 +1,4 @@
-.phaseList {
+.phase-list {
     text-align: center;
     text-decoration: line-through;
     color: $link-color;
@@ -13,8 +13,8 @@
     }
 }
 
-.phaseList-button {
-    @extend %buttonBase;
+.phase-list__button {
+    @extend %button-base;
     font-size: $font-size-sm;
     border-radius: 1.3em;
     margin-bottom: 0;
@@ -35,16 +35,16 @@
     }
 }
 
-.phaseInfo {
+.phase-info {
     text-align: center;
     margin-bottom: $spacer * 2;
 }
 
-.phaseInfo-title {
+.phase-info__title {
     font-size: $font-size-lg;
     margin-bottom: $spacer;
 }
 
-.phaseInfo-subtitle {
+.phase-info__subtitle {
     font-size: $font-size-sm;
 }

--- a/meinberlin/assets/scss/components/_popover.scss
+++ b/meinberlin/assets/scss/components/_popover.scss
@@ -9,7 +9,7 @@
     margin-top: 0;
 }
 
-.popover-subtitle {
+.popover__subtitle {
     font-size: $font-size-sm;
     margin-bottom: $spacer;
 }

--- a/meinberlin/assets/scss/components/_resource_header.scss
+++ b/meinberlin/assets/scss/components/_resource_header.scss
@@ -5,12 +5,12 @@
     text-align: center;
 }
 
-.resource-header-meta,
-.resource-header-action {
+.resource-header__meta,
+.resource-header__action {
     margin-bottom: 1.5rem;
 }
 
-.resource-header-title {
+.resource-header__title {
     margin-bottom: 1.2rem;
     font-size: $font-size-xxl;
 }
@@ -19,10 +19,10 @@
     @include pie-clearfix;
 }
 
-.resource-navigation-breadcrumbs {
+.resource-navigation__breadcrumbs {
     display: inline-block;
 }
 
-.resource-navigation-actions {
+.resource-navigation__actions {
     float: right;
 }

--- a/meinberlin/templates/base.html
+++ b/meinberlin/templates/base.html
@@ -16,19 +16,19 @@
     {% block header %}{% endblock %}
 </head>
 <body>
-    <header class="mainHeader">
+    <header class="main-header">
         <div class="l-wrapper">
-            <nav class="mainNav">
-                <a href="/" class="mainNav-item" rel="home">{% trans 'Home' %}</a>
-                <a href="/" class="mainNav-logo" rel="home"><img src="{% static 'images/LOGO.png' %}" alt="mein.berlin" /></a>
+            <nav class="main-nav">
+                <a href="/" class="main-nav__item" rel="home">{% trans 'Home' %}</a>
+                <a href="/" class="main-nav__logo" rel="home"><img src="{% static 'images/LOGO.png' %}" alt="mein.berlin" /></a>
                 <ul>
                     {% get_menu "topnav" as topnav %}
                     {% for item in topnav %}
-                    <li><a class="mainNav-item" href="{{ item.url }}">{{ item.title }}</a></li>
+                    <li><a class="main-nav__item" href="{{ item.url }}">{{ item.title }}</a></li>
                     {% endfor %}
                 </ul>
             </nav>
-            <div class="mainHeader-user">
+            <div class="main-header__user">
                 {% userindicator %}
             </div>
         </div>


### PR DESCRIPTION
There are plenty of conventions for naming classes:

-   [code guide by mdo](http://codeguide.co/#css-classes)
-   [smacss](https://smacss.com/book/categorizing)
-   [bem](http://getbem.com/naming/)
-   [suit](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md)

We use a lot of the bootstrap class names which do not follow strict rules. My goal was to use a more strict system that is still mostly compatible with bootstrap.

The existing code mostly uses something a lot like suit:

    .myComponent-element--modifier.is-active
    .l-some-layout

I now think that the camelCase is actually doing more harm than good and propose to switch something more like bem:

    .my-component__element--modifier.is-active
    .l-some-layout

As you can see the only changes are that elements are now prefixed with `__` and dashes are used instead of camelCase.

Rationale:

-   bem is more popular than suit
-   bootstrap classes are dash-separated, so they can basically be interpresed as components
-   hopefully it is easy for people to adapt and stick to this style