### PR TITLE
refactor tiles

### DIFF
--- a/apps/dashboard/templates/meinberlin_dashboard/blueprint_list.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/blueprint_list.html
@@ -18,7 +18,7 @@
 
 <h3 class="menu-layout__title">{% trans "New Project" %}</h3>
 
-<div class="l-tile-wrapper">
+<div class="l-tiles-2">
     {% for blueprint_slug, blueprint in view.blueprints %}
         {% include "meinberlin_dashboard/includes/blueprint_list_tile.html" with blueprint=blueprint %}
     {% endfor %}

--- a/apps/dashboard/templates/meinberlin_dashboard/includes/blueprint_list_tile.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/blueprint_list_tile.html
@@ -1,6 +1,6 @@
 {% load i18n static %}
 
-<div class="l-tile-2 tile">
+<div class="tile">
     <h3 class="tile-title">{{ blueprint.title }}</h3>
     <img class="tile-image" src="{% static blueprint.image %}">
     <div class="tile-description">

--- a/apps/projects/templates/a4projects/includes/project_list_tile.html
+++ b/apps/projects/templates/a4projects/includes/project_list_tile.html
@@ -1,6 +1,6 @@
 {% load i18n project_tags thumbnail %}
 
-<div class="l-tile-4 tile">
+<div class="tile">
     {% get_days project.days_left as days %}
     {% if project.has_finished %}
     <span class="label">{% trans "Finished" %}</span>

--- a/apps/projects/templates/a4projects/project_list.html
+++ b/apps/projects/templates/a4projects/project_list.html
@@ -5,7 +5,7 @@
     <div class="l-wrapper">
         {% include "meinberlin_contrib/includes/sort.html" %}
 
-        <div class="l-tile-wrapper">
+        <div class="l-tiles-4">
             {% for project in project_list %}
 
             {% has_perm 'a4projects.view_project' request.user project as show %}

--- a/meinberlin/assets/scss/_layout.scss
+++ b/meinberlin/assets/scss/_layout.scss
@@ -1,3 +1,21 @@
+@mixin grid-tiles($n, $settings: ()) {
+    > * {
+        @include grid-same-width($n, $settings);
+    }
+
+    @supports (display: grid) {
+        display: grid;
+        grid-column-gap: _grid-get('gutter', $settings);
+        grid-template-columns: repeat($n, 1fr);
+
+        > * {
+            margin-left: 0 !important;
+            margin-right: 0 !important;
+            width: auto !important;
+        }
+    }
+}
+
 .l-wrapper {
     position: relative;
     max-width: 70rem;
@@ -20,30 +38,11 @@
         @include grid-width(6);
     }
 
-    .l-tile-2 {
-        @include grid-same-width(2);
+    .l-tiles-2 {
+        @include grid-tiles(2);
     }
 
-    .l-tile-4 {
-        @include grid-same-width(4);
-    }
-
-    @supports (display: flex) {
-        .l-tile-wrapper {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: space-between;
-        }
-
-        // HACK to make this more specific than the grid-same-width selector
-        .l-tile-2.l-tile-2 {
-            margin-left: 0;
-            margin-right: 0;
-        }
-
-        .l-tile-4.l-tile-4 {
-            margin-left: 0;
-            margin-right: 0;
-        }
+    .l-tiles-4 {
+        @include grid-tiles(4);
     }
 }


### PR DESCRIPTION
The flex implementation head the issue that the layout in incomplete lines was broken:

    1 2 3 4
    5     6

    1 2 3 4
    5  6  7

We thought about using the bootstrap grid which does not have that issue. That would have meant to move all layout into the template, which we ultimately decided against (or at least postponed for now).

This new implementation uses `display: grid`. This is even newer than flex: The [candiate recommendation](https://www.w3.org/TR/css-grid-1/) has been published few weeks ago and the feature is not enabled in any major browser (though [it soon will be](http://caniuse.com/#search=grid)).

To test this, you should enable the experimental feature via a browser flag.