### PR TITLE
proper project tiles

### DIFF
--- a/apps/projects/templates/a4projects/includes/project_list_tile.html
+++ b/apps/projects/templates/a4projects/includes/project_list_tile.html
@@ -1,15 +1,36 @@
-{% load i18n project_tags thumbnail %}
+{% load i18n project_tags thumbnail static %}
 
 <div class="tile">
-    {% get_days project.days_left as days %}
-    {% if project.has_finished %}
-    <span class="label">{% trans "Finished" %}</span>
-    {% elif days %}
-    <span class="label">{{ days }}</span>
-    {% endif %}
+    <div class="tile__head">
+        <a href="{% url 'project-detail' project.slug %}">
+            <img src="http://placehold.it/285x170" alt="{{ project.name }}">
+            <img src="{% static 'images/LOGO.png' %}" alt="Mein Berlin" class="tile__badge">
+        </a>
+        {% get_days project.days_left as days %}
+        {% if project.has_finished %}
+            <span class="label">{% trans "Finished" %}</span>
+        {% elif days %}
+            <span class="label">{{ days }}</span>
+        {% endif %}
+    </div>
 
-    <h3 class="list-item__title">
-        <a href="{% url 'project-detail' project.slug %}">{{ project.name }}</a>
-    </h3>
-    <p>{{ project.description }}</p>
+    <div class="tile__body">
+        <h3 class="list-item__title">
+            <a href="{% url 'project-detail' project.slug %}">{{ project.name }}</a>
+        </h3>
+        <p class="tile__text">{{ project.description }}</p>
+        {% if project.active_phase %}
+            <p class="tile__hint">
+                {% blocktrans with project.active_phase.end_date|date:'j.m.Y' as date %}
+                    Participation possible until {{ date }}
+                {% endblocktrans %}
+            </p>
+        {% elif project.future_phases %}
+            <p class="tile__hint">
+                {% blocktrans with project.future_phases.0.start_date|date:'j.m.Y' as date %}
+                    Participation starting from {{ date }}
+                {% endblocktrans %}
+            </p>
+        {% endif %}
+    </div>
 </div>

--- a/apps/projects/templates/a4projects/includes/project_list_tile.html
+++ b/apps/projects/templates/a4projects/includes/project_list_tile.html
@@ -3,7 +3,7 @@
 <div class="tile">
     <div class="tile__head">
         <a href="{% url 'project-detail' project.slug %}">
-            <img src="http://placehold.it/285x170" alt="{{ project.name }}">
+            <img src="http://placehold.it/285x170" alt="">
             <img src="{% static 'images/LOGO.png' %}" alt="Mein Berlin" class="tile__badge">
         </a>
         {% get_days project.days_left as days %}

--- a/meinberlin/assets/scss/components/_tile.scss
+++ b/meinberlin/assets/scss/components/_tile.scss
@@ -1,5 +1,48 @@
 .tile {
-    padding: $padding;
+    display: flex;
+    flex-direction: column;
     border: 1px solid $border-color;
     margin-bottom: $padding;
+}
+
+.tile__hint {
+    margin-bottom: 0;
+
+    color: $brand-danger;
+    font-size: $font-size-sm;
+}
+
+.tile__head {
+    position: relative;
+
+    &:before {
+        content: ' ';
+        width: 100%;
+        height: 6em;
+
+        position: absolute;
+        bottom: 0;
+
+        background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.8));
+    }
+}
+
+.tile__badge {
+    height: 3.4em;
+    width: 3.4em;
+
+    position: absolute;
+    bottom: 0.8em;
+    right: 0.8em;
+}
+
+.tile__body {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    padding: $padding;
+}
+
+.tile__text {
+    flex-grow: 1;
 }

--- a/meinberlin/assets/scss/components/_tile.scss
+++ b/meinberlin/assets/scss/components/_tile.scss
@@ -14,6 +14,7 @@
 
 .tile__head {
     position: relative;
+    min-height: 6em;
 
     &:before {
         content: ' ';
@@ -37,12 +38,12 @@
 }
 
 .tile__body {
-    flex-grow: 1;
+    flex: 1 0 auto;
     display: flex;
     flex-direction: column;
     padding: $padding;
 }
 
 .tile__text {
-    flex-grow: 1;
+    flex: 1 0 auto;
 }


### PR DESCRIPTION
<img width="778" alt="screen shot 2017-02-23 at 09 44 06" src="https://cloud.githubusercontent.com/assets/16354712/23251194/a97aef94-f9ac-11e6-9e11-4b415765bb5a.png">

right now with placeholder images, obviously they should be replaced when we have project images.