### PR TITLE
Use button styles for filters

### DIFF
--- a/apps/contrib/templates/meinberlin_contrib/widgets/dropdown_link.html
+++ b/apps/contrib/templates/meinberlin_contrib/widgets/dropdown_link.html
@@ -1,11 +1,12 @@
 <div class="dropdown {% if right %}dropdown--right{% endif %}" {{ attrs }}>
     <button
         type="button"
-        class="dropdown-toggle"
+        class="dropdown-toggle button button--select"
         data-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false"
         id="{{ id }}"
+        title="{{ label }}: {{ value_label }}"
     >
         {{ label }}: {{ value_label }}
         <i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -55,6 +55,32 @@
     @include button-color($brand-secondary, darken($brand-secondary, 15%));
 }
 
+.button--select {
+    // make it look like a select element
+    @include button-color($bg-secondary, $body-bg);
+    border: 1px solid $input-border-color;
+    font-weight: normal;
+
+    &:hover,
+    &:focus,
+    &:active {
+        border: 1px solid $input-border-color;
+    }
+
+    @include text-truncate;
+    max-width: 15em;
+
+    // leave space for caret
+    padding-right: 2.2em;
+    position: relative;
+
+    i {
+        position: absolute;
+        top: 0.4em;
+        right: 0.7em;
+    }
+}
+
 .button--huge {
     padding: 0.8em 2em;
 }

--- a/meinberlin/assets/scss/components/_dropdown.scss
+++ b/meinberlin/assets/scss/components/_dropdown.scss
@@ -18,7 +18,7 @@
     text-align: center;
 
     i {
-        font-size: $font-size-lg;
+        font-size: 1.25em;
     }
 }
 

--- a/meinberlin/assets/scss/components/_dropdown.scss
+++ b/meinberlin/assets/scss/components/_dropdown.scss
@@ -1,6 +1,7 @@
 .dropdown {
     position: relative;
     text-align: left;
+    margin-bottom: $spacer / 2;
 }
 
 .dropdown--right {
@@ -16,6 +17,7 @@
     display: inline-block;
     min-width: 1.4em;
     text-align: center;
+    margin-bottom: 0;
 
     i {
         font-size: 1.25em;

--- a/meinberlin/assets/scss/components/_filter_bar.scss
+++ b/meinberlin/assets/scss/components/_filter_bar.scss
@@ -1,5 +1,6 @@
 .filter-bar {
     @include clearfix;
+    font-size: $font-size-sm;
 
     .dropdown {
         display: inline-block;


### PR DESCRIPTION
This adds a new button modifier `.button--form` which looks like something between a button and an input (specifically, `select`).

This new kind of button is used for the filter dropdowns.