### PR TITLE
Refactor: Remove margin-bottom from buttons

### DIFF
--- a/apps/dashboard/templates/meinberlin_dashboard/project_list.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/project_list.html
@@ -4,10 +4,12 @@
 {% block dashboard_content %}
 
 <div>
-    <span class="menu-layout__title">{% trans "Projects" %}</span>
-    <a href="{% url 'dashboard-blueprint-list' organisation_slug=view.organisation.slug %}" class="button">
-        {% trans 'New Project' %}
-    </a>
+    <p>
+        <span class="menu-layout__title">{% trans "Projects" %}</span>
+        <a href="{% url 'dashboard-blueprint-list' organisation_slug=view.organisation.slug %}" class="button">
+            {% trans 'New Project' %}
+        </a>
+    </p>
 
     {% if project_list|length == 0 %}
         <div>

--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -55,6 +55,11 @@ select {
     .django-ckeditor-widget,
     %input-base {
         width: 100%;
+
+        // FIXME: Generally, we would prefer to use .form-group everywhere and
+        // not have a margin on inputs at all. We do not control all HTML
+        // though (e.g. django standard forms or react components from
+        // adhocracy4 core).
         margin: 0;
     }
 }

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -36,6 +36,7 @@
     font-weight: bold;
     padding-left: 1em;
     padding-right: 1em;
+    margin: 0;
 }
 
 .button {

--- a/meinberlin/assets/scss/components/_dropdown.scss
+++ b/meinberlin/assets/scss/components/_dropdown.scss
@@ -17,7 +17,6 @@
     display: inline-block;
     min-width: 1.4em;
     text-align: center;
-    margin-bottom: 0;
 
     i {
         font-size: 1.25em;


### PR DESCRIPTION
In 497c8d84 I tried to make it possible to use button styles for a dropdown-toggle.

The solution I used there relied on source order: `.button` sets a margin-bottom, `.dropdown-toggle` removes it again. This is fragile because seemingly unrelated code changes could potentially break this.

The underlying issue seems to be that `.button` mixes [structure and skin](https://github.com/stubbornella/oocss/wiki#separate-structure-and-skin). So here I propose to remove the margin-bottom from `.button` instead.

I found only one place where this causes issues and fixed it by wrapping the button in a `<p>` element. There may be more tough.