### PR TITLE
Do not show rating elements if feature is not enabled

### DIFF
--- a/apps/contrib/mixins.py
+++ b/apps/contrib/mixins.py
@@ -1,5 +1,5 @@
 class ChoicesRequestMixin(object):
-    """Dynamic choces mixin.
+    """Dynamic choices mixin.
 
     Add callable functionality to filters that support the ``choices``
     argument. If the ``choices`` is callable, then it **must** accept the

--- a/apps/contrib/mixins.py
+++ b/apps/contrib/mixins.py
@@ -1,0 +1,37 @@
+class ChoicesRequestMixin(object):
+    """Dynamic choces mixin.
+
+    Add callable functionality to filters that support the ``choices``
+    argument. If the ``choices`` is callable, then it **must** accept the
+    ``request`` object as a single argument.
+
+    This is useful for dymanic ``choices`` determined properties on the
+    ``request`` object.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.choices = kwargs.get('choices')
+        super().__init__(*args, **kwargs)
+
+    def get_request(self):
+        try:
+            return self.parent.request
+        except AttributeError:
+            return None
+
+    def get_choices(self, request):
+        choices = self.choices
+
+        if callable(choices):
+            return choices(request)
+        return choices
+
+    @property
+    def field(self):
+        request = self.get_request()
+        choices = self.get_choices(request)
+
+        if choices is not None:
+            self.extra['choices'] = choices
+
+        return super(ChoicesRequestMixin, self).field

--- a/apps/ideas/templates/meinberlin_ideas/idea_detail.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n rules react_comments react_ratings %}
+{% load i18n module_tags rules react_comments react_ratings %}
 
 {% block title %}{{idea.name}}{% endblock %}
 {% block content %}
@@ -55,9 +55,12 @@
                 </div>
             {% endif %}
 
-            <div class="resource-header__action">
-                {% react_ratings idea %}
-            </div>
+            {% itemHasFeature idea "rate" as is_rating_enabled %}
+            {%  if is_rating_enabled %}}
+                <div class="resource-header__action">
+                    {% react_ratings idea %}
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/apps/ideas/templates/meinberlin_ideas/idea_detail.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_detail.html
@@ -55,8 +55,7 @@
                 </div>
             {% endif %}
 
-            {% itemHasFeature idea "rate" as is_rating_enabled %}
-            {%  if is_rating_enabled %}}
+            {% if idea|has_feature:"rate" %}
                 <div class="resource-header__action">
                     {% react_ratings idea %}
                 </div>

--- a/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -3,8 +3,7 @@
 <div class="list-item list-item--squashed">
     <div class="list-item__stats">
         {% spaceless %}
-        {% itemHasFeature idea "rate" as is_rating_enabled %}
-        {%  if is_rating_enabled %}
+        {% if idea|has_feature:"rate" %}}
             <span class="rating">
                 <span class="rating-button rating-up is-read-only" title="Positive Ratings">
                     {{ idea.positive_rating_count }}

--- a/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -1,16 +1,21 @@
+{% load module_tags %}
+
 <div class="list-item list-item--squashed">
     <div class="list-item__stats">
         {% spaceless %}
-        <span class="rating">
-            <span class="rating-button rating-up is-read-only" title="Positive Ratings">
-                {{ idea.positive_rating_count }}
-                <i class="fa fa-chevron-up" aria-hidden="true"></i>
+        {% itemHasFeature idea "rate" as is_rating_enabled %}
+        {%  if is_rating_enabled %}
+            <span class="rating">
+                <span class="rating-button rating-up is-read-only" title="Positive Ratings">
+                    {{ idea.positive_rating_count }}
+                    <i class="fa fa-chevron-up" aria-hidden="true"></i>
+                </span>
+                <span class="rating-button rating-down is-read-only" title="Negative Ratings">
+                    {{ idea.negative_rating_count }}
+                    <i class="fa fa-chevron-down" aria-hidden="true"></i>
+                </span>
             </span>
-            <span class="rating-button rating-down is-read-only" title="Negative Ratings">
-                {{ idea.negative_rating_count }}
-                <i class="fa fa-chevron-down" aria-hidden="true"></i>
-            </span>
-        </span>
+        {% endif %}
         <span title="Comments">
             {{ idea.comment_count }}
             <i class="fa fa-comment-o" aria-hidden="true"></i>

--- a/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -3,7 +3,7 @@
 <div class="list-item list-item--squashed">
     <div class="list-item__stats">
         {% spaceless %}
-        {% if idea|has_feature:"rate" %}}
+        {% if idea|has_feature:"rate" %}
             <span class="rating">
                 <span class="rating-button rating-up is-read-only" title="Positive Ratings">
                     {{ idea.positive_rating_count }}

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -9,6 +9,8 @@ from adhocracy4.contrib.views import FilteredListView
 from adhocracy4.contrib.views import PermissionRequiredMixin
 from adhocracy4.modules.models import Module
 from adhocracy4.projects import mixins
+
+from apps.contrib.mixins import ChoicesRequestMixin
 from apps.contrib.widgets import DropdownLinkWidget
 
 from . import models as idea_models
@@ -24,6 +26,16 @@ class OrderingWidget(DropdownLinkWidget):
     right = True
 
 
+class IdeaOrdering(ChoicesRequestMixin, django_filters.OrderingFilter):
+
+    def get_choices(self, request):
+        choices = (('-created', _('Most recent')),)
+        if self.parent.request.module.has_feature('rate', idea_models.Idea):
+            choices += ('-positive_rating_count', _('Most popular')),
+        choices += ('-comment_count', _('Most commented')),
+        return choices
+
+
 class CategoryFilterWidget(DropdownLinkWidget):
     label = _('Category')
 
@@ -35,12 +47,7 @@ class IdeaFilterSet(django_filters.FilterSet):
         widget=CategoryFilterWidget,
     )
 
-    ordering = django_filters.OrderingFilter(
-        choices=(
-            ('-created', _('Most recent')),
-            ('-positive_rating_count', _('Most popular')),
-            ('-comment_count', _('Most commented')),
-        ),
+    ordering = IdeaOrdering(
         empty_label=None,
         widget=OrderingWidget,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,11 +12,11 @@ register(factories.UserFactory)
 register(factories.UserFactory, 'user2')
 register(factories.AdminFactory, 'admin')
 register(factories.OrganisationFactory)
+register(factories.PhaseFactory)
 register(factories.ContentTypeFactory)
 
 register(a4_factories.ProjectFactory)
 register(a4_factories.ModuleFactory)
-register(a4_factories.PhaseFactory)
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -7,6 +7,8 @@ from django.core.files import base
 from django.core.files import images
 from PIL import Image
 
+from adhocracy4.test import factories
+
 
 class UserFactory(factory.django.DjangoModelFactory):
 
@@ -26,6 +28,10 @@ class AdminFactory(factory.django.DjangoModelFactory):
     username = factory.Faker('name')
     password = make_password('password')
     is_superuser = True
+
+
+class PhaseFactory(factories.PhaseFactory):
+    type = 'meinberlin_ideas:010:issue'
 
 
 class OrganisationFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Depends on https://github.com/liqd/adhocracy4/pull/46.

The brainstorming blueprint does not allow rating in its phases. In this case the rating element are not shown.