### PR TITLE
RFC: embed: keep url on login

### DIFF
--- a/apps/embed/templates/meinberlin_embed/embed.html
+++ b/apps/embed/templates/meinberlin_embed/embed.html
@@ -17,7 +17,7 @@
     {% block header %}{% endblock %}
 </head>
 
-<body data-url="{% url 'project-detail' slug %}">
+<body data-url="{{ view.initial_url }}">
     <header class="embed-header">
         {% if request.user.is_anonymous %}
             <a href="{% url 'account_login' %}">{% trans 'Login' %}</a>

--- a/apps/embed/views.py
+++ b/apps/embed/views.py
@@ -1,3 +1,4 @@
+from django.core.urlresolvers import reverse
 from django.views import generic
 from django.views.decorators.clickjacking import xframe_options_exempt
 
@@ -10,3 +11,9 @@ class EmbedView(generic.base.TemplateView):
 
 class EmbedProjectView(EmbedView):
     template_name = "meinberlin_embed/embed.html"
+
+    @xframe_options_exempt
+    def dispatch(self, request, *args, **kwargs):
+        default = reverse('project-detail', args=[self.kwargs['slug']])
+        self.initial_url = request.GET.get('initialUrl', default)
+        return super().dispatch(request, *args, **kwargs)

--- a/meinberlin/static/embed.js
+++ b/meinberlin/static/embed.js
@@ -96,7 +96,7 @@ $(document).ready(function () {
     $.post(
       '/accounts/logout/',
       function () {
-        location.reload()
+        location.href = location.pathname + '?' + $.param({initialUrl: currentPath})
       }
     )
   })
@@ -109,7 +109,7 @@ $(document).ready(function () {
 
       if (data.name === 'popup-close' && popup) {
         popup.close()
-        location.reload()
+        location.href = location.pathname + '?' + $.param({initialUrl: currentPath})
       }
     }
   }, false)


### PR DESCRIPTION
This change would allow users to stay on the same view after login/logout. This is nice for users, but it requires an extension to the embed API that would allow attackers to embed anything, not just project detail pages. What do we prefer?