### PR TITLE
embed: jump to top after navigation

### DIFF
--- a/meinberlin/static/embed.js
+++ b/meinberlin/static/embed.js
@@ -4,6 +4,7 @@ $(document).ready(function () {
   var currentPath
   var popup
   var patternsForPopup = /\/accounts\b/
+  var $top = $('<div tabindex="-1">')
 
   var headers = {
     'X-Embed': ''
@@ -21,8 +22,12 @@ $(document).ready(function () {
     currentPath = nextPath
 
     $main.empty()
+    $main.append($top)
     $main.append($root.children())
     onReady()
+
+    // jump to top after navigation
+    $top.focus()
   }
 
   var onReady = function () {


### PR DESCRIPTION
See https://stackoverflow.com/questions/18619186/#18631501

Note that this is also triggered on the initial page load, so the first item in the tab order is always inside of the main area. The header (login/logout) is skipped. I am not sure if this is an issue.