### PR TITLE
Fix webpack development dependency resolving

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,9 @@ module.exports = {
     // against the local directory.
     root: path.resolve('./node_modules')
   },
+  resolveLoader: {
+    root: path.resolve('./node_modules')
+  },
   plugins: [
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),


### PR DESCRIPTION
Webpack does not find dependencies for `npm link`ed modules
that are available in the currently build module.
This is documented at
http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-
don-t-find-their-dependencies

If modules are available in the linked module, as well as the
currently build module, dependencies may be included twice if
the proposed `fallback` option is used.
Setting resolve[Loader].root forces webpack to resolve all
dependencies only once against the local directory.