### PR TITLE
Fix map list UI

### DIFF
--- a/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
@@ -4,13 +4,13 @@
     {% if mode == 'map' %}
         {% combined_url_parameter request.GET mode='list' as url_par %}
         <a class="button button--light" href="{{ url_par }}">
-            <i class="fa fa-map" aria-hidden="true"></i>
+            <i class="fa fa-list" aria-hidden="true"></i>
             {% trans 'view' %}
         </a>
     {% else %}
         {% combined_url_parameter request.GET mode='map' as url_par %}
         <a class="button button--light" href="{{ url_par }}">
-            <i class="fa fa-list" aria-hidden="true"></i>
+            <i class="fa fa-map" aria-hidden="true"></i>
             {% trans 'view' %}
         </a>
     {% endif %}

--- a/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
@@ -3,13 +3,13 @@
 <div class="filter-bar">
     {% if mode == 'map' %}
         {% combined_url_parameter request.GET mode='list' as url_par %}
-        <a class="button button--select" href="{{ url_par }}">
+        <a class="button button--light" href="{{ url_par }}">
             <i class="fa fa-map" aria-hidden="true"></i>
             {% trans 'view' %}
         </a>
     {% else %}
         {% combined_url_parameter request.GET mode='map' as url_par %}
-        <a class="button button--select" href="{{ url_par }}">
+        <a class="button button--light" href="{{ url_par }}">
             <i class="fa fa-list" aria-hidden="true"></i>
             {% trans 'view' %}
         </a>

--- a/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
@@ -1,0 +1,29 @@
+{% load i18n contrib_tags %}
+
+<div class="filter-bar">
+    {% if mode == 'map' %}
+        {% combined_url_parameter request.GET mode='list' as url_par %}
+        <a class="button button--select" href="{{ url_par }}">
+            <i class="fa fa-map" aria-hidden="true"></i>
+            {% trans 'view' %}
+        </a>
+    {% else %}
+        {% combined_url_parameter request.GET mode='map' as url_par %}
+        <a class="button button--select" href="{{ url_par }}">
+            <i class="fa fa-list" aria-hidden="true"></i>
+            {% trans 'view' %}
+        </a>
+    {% endif %}
+
+    {% for field in filter.form %}
+        {% if field.name != 'ordering' %}
+            {{ field }}
+        {% endif %}
+    {% endfor %}
+
+    {% if mode != 'map' %}
+        <div class="filter-bar__ordering">
+            {{ filter.form.ordering }}
+        </div>
+    {% endif %}
+</div>

--- a/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
@@ -3,13 +3,13 @@
 <div class="filter-bar">
     {% if mode == 'map' %}
         {% combined_url_parameter request.GET mode='list' as url_par %}
-        <a class="button button--light" href="{{ url_par }}">
+        <a class="button button--light" href="{{ url_par }}" aria-label="{% trans 'view as list' %}">
             <i class="fa fa-list" aria-hidden="true"></i>
             {% trans 'view' %}
         </a>
     {% else %}
         {% combined_url_parameter request.GET mode='map' as url_par %}
-        <a class="button button--light" href="{{ url_par }}">
+        <a class="button button--light" href="{{ url_par }}" aria-label="{% trans 'view as map' %}">
             <i class="fa fa-map" aria-hidden="true"></i>
             {% trans 'view' %}
         </a>

--- a/apps/contrib/templates/meinberlin_contrib/includes/pagination.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/pagination.html
@@ -5,7 +5,7 @@
     <ul class="pagination">
         {% for page_number in page_obj.paginator.page_range %}
         <li class="pagination-item{% ifequal page_number page_obj.number %} active{% endifequal %}">
-            {% combinedUrlParameter request.GET page=page_number as url_par %}
+            {% combined_url_parameter request.GET page=page_number as url_par %}
             <a href="{{ url_par }}">{{ page_number }}</a>
         </li>
         {% endfor %}

--- a/apps/contrib/templates/meinberlin_contrib/widgets/dropdown_link.html
+++ b/apps/contrib/templates/meinberlin_contrib/widgets/dropdown_link.html
@@ -1,7 +1,7 @@
 <div class="dropdown {% if right %}dropdown--right{% endif %}" {{ attrs }}>
     <button
         type="button"
-        class="dropdown-toggle button button--select"
+        class="dropdown-toggle button button--light button--select"
         data-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false"

--- a/apps/contrib/templatetags/contrib_tags.py
+++ b/apps/contrib/templatetags/contrib_tags.py
@@ -5,13 +5,13 @@ register = template.Library()
 
 
 @register.assignment_tag
-def includeTemplateString(template, **kwargs):
+def include_template_string(template, **kwargs):
     rendered_template = render_to_string(template, kwargs)
     return str(rendered_template)
 
 
 @register.assignment_tag
-def combinedUrlParameter(request_query_dict, **kwargs):
+def combined_url_parameter(request_query_dict, **kwargs):
     combined_query_dict = request_query_dict.copy()
     for key in kwargs:
         combined_query_dict.setlist(key, [kwargs[key]])

--- a/apps/dashboard/templates/meinberlin_dashboard/includes/phase_form.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/phase_form.html
@@ -1,6 +1,6 @@
 {% load i18n form_tags %}
 
-{% getPhaseName form.type.value as phasename %}
+{% get_phase_name form.type.value as phasename %}
 <h3>{% trans phasename %}</h3>
 
 {% include 'meinberlin_contrib/includes/form_field.html' with field=form.name %}

--- a/apps/dashboard/templatetags/form_tags.py
+++ b/apps/dashboard/templatetags/form_tags.py
@@ -6,6 +6,6 @@ register = template.Library()
 
 
 @register.assignment_tag
-def getPhaseName(type):
+def get_phase_name(type):
     name = phases.content.__getitem__(type).name
     return name

--- a/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
@@ -24,7 +24,7 @@
     {% if view.mode == 'map' %}
         <div class="l-wrapper">
             <div class="l-center-8">
-                {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
+                {% include "meinberlin_contrib/includes/map_filter_and_sort.html" with filter=view.filter mode=view.mode %}
             </div>
         </div>
         <div
@@ -38,7 +38,7 @@
         <div class="list list--highlight">
             <div class="l-wrapper">
                 <div class="l-center-8">
-                    {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
+                    {% include "meinberlin_contrib/includes/map_filter_and_sort.html" with filter=view.filter mode=view.mode %}
 
                     <div class="list__container">
                         {% for mapidea in mapidea_list %}

--- a/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
@@ -21,38 +21,37 @@
 {% endblock %}
 
 {% block phase_content %}
-    <div class="l-center-8">
-        <div class="idea-map">
-            <div class="container idea-map-buttons">
-                <a href="#idea-list" class="btn btn-primary idea-map-buttons-list"><i class="fa fa-list" aria-hidden="true"></i>  {% trans 'view on list' %}</a>
-                <div class="idea-map-buttons-zoom">
-                    <div class="leaflet-control-zoom leaflet-bar leaflet-control">
-                        <a class="leaflet-control-zoom-in" id="zoom-in" href="#" title="Zoom in">+</a>
-                        <a class="leaflet-control-zoom-out leaflet-disabled" id="zoom-out" href="#" title="Zoom out">-</a>
+    {% if view.mode == 'map' %}
+        <div class="l-wrapper">
+            <div class="l-center-8">
+                {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
+            </div>
+        </div>
+        <div
+            style="height: 300px;"
+            data-map="display_points"
+            data-baseurl="{{ map_url }}"
+            data-point="{{ mapitems_json }}"
+            data-polygon="{{ polygon }}"
+        ></div>
+    {% else %}
+        <div class="list list--highlight">
+            <div class="l-wrapper">
+                <div class="l-center-8">
+                    {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
+
+                    <div class="list__container">
+                        {% for mapidea in mapidea_list %}
+                            {% include "meinberlin_mapideas/includes/mapidea_list_item.html" with object=mapidea %}
+                        {% endfor %}
                     </div>
+
+                    {% if mapidea_list.count == 0 %}
+                        {% trans "Nothing to show" %}
+                    {% endif %}
+                    {% include "meinberlin_contrib/includes/pagination.html" %}
                 </div>
             </div>
-            <div
-                style="height: 300px;"
-                data-map="display_points"
-                data-baseurl="{{ map_url }}"
-                data-point="{{ mapitems_json }}"
-                data-polygon="{{ polygon }}"
-            ></div>
         </div>
-
-        {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
-
-        <div >
-            {% for mapidea in mapidea_list %}
-            {% include "meinberlin_mapideas/includes/mapidea_list_item.html" with object=mapidea %}
-            {% endfor %}
-
-            {% if mapidea_list.count == 0 %}
-            {% trans "Nothing to show" %}
-            {% endif %}
-        </div>
-
-        {% include "meinberlin_contrib/includes/pagination.html" %}
-    </div>
+    {% endif %}
 {% endblock %}

--- a/apps/mapideas/views.py
+++ b/apps/mapideas/views.py
@@ -43,6 +43,10 @@ class MapIdeaListView(map_mixins.MapItemListMixin, module_views.ItemListView):
     model = models.MapIdea
     filter_set = MapIdeaFilterSet
 
+    def dispatch(self, request, **kwargs):
+        self.mode = request.GET.get('mode', 'list')
+        return super().dispatch(request, **kwargs)
+
 
 class MapIdeaDetailView(map_mixins.MapItemDetailMixin,
                         module_views.ItemDetailView):

--- a/apps/mapideas/views.py
+++ b/apps/mapideas/views.py
@@ -45,6 +45,8 @@ class MapIdeaListView(map_mixins.MapItemListMixin, module_views.ItemListView):
 
     def dispatch(self, request, **kwargs):
         self.mode = request.GET.get('mode', 'list')
+        if self.mode == 'map':
+            self.paginate_by = 0
         return super().dispatch(request, **kwargs)
 
 

--- a/apps/mapideas/views.py
+++ b/apps/mapideas/views.py
@@ -44,7 +44,7 @@ class MapIdeaListView(map_mixins.MapItemListMixin, module_views.ItemListView):
     filter_set = MapIdeaFilterSet
 
     def dispatch(self, request, **kwargs):
-        self.mode = request.GET.get('mode', 'list')
+        self.mode = request.GET.get('mode', 'map')
         if self.mode == 'map':
             self.paginate_by = 0
         return super().dispatch(request, **kwargs)

--- a/apps/projects/templates/meinberlin_projects/includes/phase_indicator.html
+++ b/apps/projects/templates/meinberlin_projects/includes/phase_indicator.html
@@ -8,7 +8,7 @@
 <div class="phase-list">
     <ul>
         {% for phase in project.phases %}
-            {% includeTemplateString "meinberlin_projects/includes/phase_popover.html" phase=phase phase_num=forloop.counter phase_count=phase_count as popover_content %}
+            {% include_template_string "meinberlin_projects/includes/phase_popover.html" phase=phase phase_num=forloop.counter phase_count=phase_count as popover_content %}
             <li>
                 <button
                     title="{{ phase.name }}"

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -65,17 +65,6 @@
 }
 
 .button--select {
-    // make it look like a select element
-    @include button-color($bg-secondary, $body-bg);
-    border: 1px solid $input-border-color;
-    font-weight: normal;
-
-    &:hover,
-    &:focus,
-    &:active {
-        border: 1px solid $input-border-color;
-    }
-
     @include text-truncate;
     max-width: 15em;
 


### PR DESCRIPTION
Most importantly, this allows to switch between list and map mode. All filters, ordering, and pagination are preserved. The pagination is ignored in map mode. The default mode is list.

Note that as part of this pull request, I refactored the button styling, notably the `button--select` modifier.

Some possible next steps:

-   define filters
-   when changing view, jump directly back to the list/map
-   zoom buttons on the map are missing
-   the leaftlet popups need styling
-   the filterbar should overlap the map (see #166)