### PR TITLE
add missing zoom controls to map list

### DIFF
--- a/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
@@ -27,13 +27,23 @@
                 {% include "meinberlin_contrib/includes/map_filter_and_sort.html" with filter=view.filter mode=view.mode %}
             </div>
         </div>
-        <div
-            style="height: 300px;"
-            data-map="display_points"
-            data-baseurl="{{ map_url }}"
-            data-point="{{ mapitems_json }}"
-            data-polygon="{{ polygon }}"
-        ></div>
+        <div class="map-list">
+            <div class="map-list__controls">
+                <div class="l-wrapper">
+                    <div class="leaflet-control-zoom leaflet-bar leaflet-control">
+                        <a class="leaflet-control-zoom-in" id="zoom-in" href="#" title="Zoom in">+</a>
+                        <a class="leaflet-control-zoom-out leaflet-disabled" id="zoom-out" href="#" title="Zoom out">-</a>
+                    </div>
+                </div>
+            </div>
+            <div
+                style="height: 300px;"
+                data-map="display_points"
+                data-baseurl="{{ map_url }}"
+                data-point="{{ mapitems_json }}"
+                data-polygon="{{ polygon }}"
+            ></div>
+        </div>
     {% else %}
         <div class="list list--highlight">
             <div class="l-wrapper">

--- a/meinberlin/assets/scss/components/_map.scss
+++ b/meinberlin/assets/scss/components/_map.scss
@@ -15,3 +15,16 @@
 .map-popup-comments-count {
     margin-right: 0.5em;
 }
+
+.map-list {
+    position: relative;
+}
+
+.map-list__controls {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    padding: $padding 0;
+}


### PR DESCRIPTION
I would like to refactor how this is handled in core, but for now I just added the missing controls here.