### PR TITLE
Fix pydocstyle for pyup until flake8-docstrings is fixed

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ flake8_docstrings==1.0.3
 django-debug-toolbar==1.7
 freezegun==0.3.8
 isort==4.2.5
-pydocstyle==1.1.1
+pydocstyle==1.1.1 # pyup: >=1.1.1,<2.0
 pytest-django==3.1.2
 pytest-cov==2.4.0
 pytest-factoryboy==1.3.1


### PR DESCRIPTION
Currently flake8-docstrings is broken with pydocstyle 2.0.0
This prevents pyup from updating pydocstyle. This is only temporary
required until the bug is fixed in flake8-docstrings

[0] https://gitlab.com/pycqa/flake8-docstrings/issues/19