### PR TITLE
mobile first media queries

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -30,7 +30,7 @@
     "max-nesting-depth": 2,
 
     "scale-unlimited/declaration-strict-value": ["/color/", {
-      "ignoreKeywords": "inherit"
+      "ignoreKeywords": ["inherit", "transparent"]
     }],
 
     "declaration-empty-line-before": null

--- a/meinberlin/assets/scss/components/_filter_bar.scss
+++ b/meinberlin/assets/scss/components/_filter_bar.scss
@@ -22,11 +22,10 @@
     }
 
     .filter-bar__ordering {
-        @media (min-width: $breakpoint) {
-            float: right;
-        }
+        float: right;
 
         @media (max-width: $breakpoint) {
+            float: none;
             // push to the right
             // NOTE: needs to overwrite grid-tiles
             @include grid-position(6);

--- a/meinberlin/assets/scss/components/_fixed_side.scss
+++ b/meinberlin/assets/scss/components/_fixed_side.scss
@@ -1,4 +1,5 @@
 .fixed-side {
+    display: none;
     position: fixed;
     right: 0;
     transform: rotate(90deg);
@@ -6,7 +7,7 @@
     top: 45%;
     z-index: 1;
 
-    @media (max-width: $breakpoint) {
-        display: none;
+    @media (min-width: $breakpoint) {
+        display: block;
     }
 }

--- a/meinberlin/assets/scss/components/_header.scss
+++ b/meinberlin/assets/scss/components/_header.scss
@@ -12,32 +12,35 @@
     text-decoration: none;
 
     img {
-        width: 6em;
-        margin-top: -2em;
-        margin-bottom: -2.85em;
+        margin: 0;
+        width: 3em;
+        vertical-align: middle;
 
-        @media screen and (max-width: $breakpoint) {
-            margin: 0;
-            width: 3em;
-            vertical-align: middle;
+        @media screen and (min-width: $breakpoint) {
+            width: 6em;
+            margin-top: -2em;
+            margin-bottom: -2.85em;
         }
     }
 }
 
 .main-nav__menu-wrapper {
-    @media screen and (max-width: $breakpoint) {
-        padding: 0.5em $padding 0;
-        border-bottom: 1px solid $border-color;
+    padding: 0.5em $padding 0;
+    border-bottom: 1px solid $border-color;
 
-        position: absolute;
-        left: 0;
-        right: 0;
-        z-index: 1;
+    position: absolute;
+    left: 0;
+    right: 0;
+    z-index: 1;
 
-        background-color: $body-bg;
-    }
+    background-color: $body-bg;
 
     @media screen and (min-width: $breakpoint) {
+        padding: 0;
+        border: 0;
+        position: static;
+        background-color: transparent;
+
         &.collapse {
             display: inline-block;
         }
@@ -45,49 +48,55 @@
 }
 
 .main-nav__list {
-    display: inline-block;
     list-style: none;
     padding: 0;
     margin: 0;
 
-    @media screen and (max-width: $breakpoint) {
-        display: block;
+    @media screen and (min-width: $breakpoint) {
+        display: inline-block;
     }
 }
 
 .main-nav__item {
-    display: inline;
+    display: block;
+    border-top: 1px solid $border-color;
 
-    @media screen and (max-width: $breakpoint) {
-        display: block;
-        border-top: 1px solid $border-color;
+    &:last-child {
+        border-bottom: 1px solid $border-color;
+    }
+
+    @media screen and (min-width: $breakpoint) {
+        display: inline;
+        border: 0;
 
         &:last-child {
-            border-bottom: 1px solid $border-color;
+            border: 0;
         }
     }
 }
 
 .main-nav__link {
-    padding: 0.2em 0.4em;
+    display: block;
+    padding: 0.5em 0;
     color: inherit;
     text-decoration: none;
 
     &:hover,
     &:focus {
-        text-decoration: underline;
-        color: inherit;
+        text-decoration: none;
+        background-color: $bg-secondary;
+        color: $brand-secondary;
     }
 
-    @media screen and (max-width: $breakpoint) {
-        display: block;
-        padding: 0.5em 0;
+    @media screen and (min-width: $breakpoint) {
+        display: inline;
+        padding: 0.2em 0.4em;
 
         &:hover,
         &:focus {
-            text-decoration: none;
-            background-color: $bg-secondary;
-            color: $brand-secondary;
+            text-decoration: underline;
+            background-color: transparent;
+            color: inherit;
         }
     }
 }

--- a/meinberlin/assets/scss/components/_header.scss
+++ b/meinberlin/assets/scss/components/_header.scss
@@ -116,8 +116,10 @@
         right: $padding;
     }
 
-    // overwrite dropdown style on mobile
-    @media screen and (max-width: $breakpoint) {
+    // min-width and max-width can't have the same breakpoint
+    @media screen and (max-width: $breakpoint - 0.1em) {
+        // overwrite dropdown style on mobile
+
         .dropdown {
             margin-bottom: 0;
         }

--- a/meinberlin/assets/scss/components/_hero_unit.scss
+++ b/meinberlin/assets/scss/components/_hero_unit.scss
@@ -17,6 +17,7 @@
         content: "";
         width: 100%;
         height: 14em;
+        max-height: 100%;
 
         position: absolute;
         bottom: 0;

--- a/meinberlin/assets/scss/components/_resource_header.scss
+++ b/meinberlin/assets/scss/components/_resource_header.scss
@@ -2,14 +2,14 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 3em 0 4em;
+    padding: 1.3em 0;
     position: relative;
     margin-bottom: 1em;
 
     text-align: center;
 
-    @media (max-width: $breakpoint) {
-        padding: 1.3em 0;
+    @media (min-width: $breakpoint) {
+        padding: 3em 0 4em;
     }
 }
 
@@ -42,10 +42,10 @@
 .resource-header__title {
     margin-top: 0.3rem;
     margin-bottom: 1.2rem;
-    font-size: $font-size-xxl;
+    font-size: $font-size-lg;
 
-    @media (max-width: $breakpoint) {
-        font-size: $font-size-lg;
+    @media (min-width: $breakpoint) {
+        font-size: $font-size-xxl;
     }
 }
 


### PR DESCRIPTION
In media queries, we sometimes use `min-width` and sometimes `max-width`. This results in issues like #259. This pull request fixes this by using `min-width` wherever possible. i chose `min-width` rather than `max-width` according to the "mobile first" approach.

The notable exception is `.main-header__user .dropdown`. I have no clue how we can fix that case because the mobile and desktop styles are so different.

Media Queries Level 4 (working draft) adds [a new syntax](https://drafts.csswg.org/mediaqueries-4/#mq-range-context) that would fix this issue. But it is not widely available yet.