### PR TITLE
Permission naming

### DIFF
--- a/apps/budgeting/rules.py
+++ b/apps/budgeting/rules.py
@@ -12,7 +12,7 @@ rules.add_perm(
 
 
 rules.add_perm(
-    'meinberlin_budgeting.create_proposal',
+    'meinberlin_budgeting.add_proposal',
     module_predicates.is_allowed_add_item(models.Proposal)
 )
 

--- a/apps/budgeting/views.py
+++ b/apps/budgeting/views.py
@@ -59,7 +59,7 @@ class ProposalDetailView(module_views.ItemDetailView):
 class ProposalCreateView(module_views.ItemCreateView):
     model = models.Proposal
     form_class = forms.ProposalForm
-    permission_required = 'meinberlin_budgeting.create_proposal'
+    permission_required = 'meinberlin_budgeting.add_proposal'
     template_name = 'meinberlin_budgeting/proposal_create_form.html'
 
 

--- a/apps/dashboard/mixins.py
+++ b/apps/dashboard/mixins.py
@@ -91,7 +91,7 @@ class DashboardModRemovalMixin:
             user = get_object_or_404(User, pk=pk)
             project = self.get_object()
             can_edit = request.user.has_perm(
-                'meinberlin_organisations.initiate_project',
+                'a4projects.add_project',
                 project
             )
             if not can_edit:

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -165,7 +165,7 @@ class DashboardOrganisationUpdateView(dashboard_mixins.DashboardBaseMixin,
     slug_url_kwarg = 'organisation_slug'
     template_name = 'meinberlin_dashboard/organisation_form.html'
     success_message = _('Organisation successfully updated.')
-    permission_required = 'meinberlin_organisations.modify_organisation'
+    permission_required = 'meinberlin_organisations.change_organisation'
     menu_item = 'organisation'
 
 

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -27,7 +27,7 @@ class DashboardProjectListView(dashboard_mixins.DashboardBaseMixin,
     paginate_by = 12
     filter_set = DashboardProjectFilterSet
     template_name = 'meinberlin_dashboard/project_list.html'
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
     def get_queryset(self):
@@ -41,7 +41,7 @@ class DashboardBlueprintListView(dashboard_mixins.DashboardBaseMixin,
                                  generic.TemplateView):
     template_name = 'meinberlin_dashboard/blueprint_list.html'
     blueprints = blueprints.blueprints
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
 
@@ -54,7 +54,7 @@ class DashboardProjectCreateView(dashboard_mixins.DashboardBaseMixin,
     form_class = forms.ProjectCreateForm
     template_name = 'meinberlin_dashboard/project_create_form.html'
     success_message = _('Project succesfully created.')
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
     def get_form_kwargs(self):
@@ -78,7 +78,7 @@ class DashboardExternalProjectCreateView(dashboard_mixins.DashboardBaseMixin,
     form_class = forms.ExternalProjectCreateForm
     template_name = 'meinberlin_dashboard/external_project_create_form.html'
     success_message = _('Project succesfully created.')
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
     def get_form_kwargs(self):
@@ -102,7 +102,7 @@ class DashboardProjectUpdateView(dashboard_mixins.DashboardBaseMixin,
     form_class = forms.ProjectUpdateForm
     template_name = 'meinberlin_dashboard/project_update_form.html'
     success_message = _('Project successfully updated.')
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
     def get_queryset(self):
@@ -140,7 +140,7 @@ class DashboardExternalProjectUpdateView(dashboard_mixins.DashboardBaseMixin,
     form_class = forms.ExternalProjectUpdateForm
     template_name = 'meinberlin_dashboard/external_project_update_form.html'
     success_message = _('Project successfully updated.')
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
     def get_queryset(self):
@@ -177,7 +177,7 @@ class DashboardProjectModeratorsView(dashboard_mixins.DashboardBaseMixin,
     model = project_models.Project
     form_class = forms.AddModeratorForm
     template_name = 'meinberlin_dashboard/project_moderators.html'
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
     def get_form_kwargs(self):
@@ -191,7 +191,7 @@ class DashboardProjectManagementView(dashboard_mixins.DashboardBaseMixin,
                                      SingleObjectMixin,
                                      generic.View):
     model = project_models.Project
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     menu_item = 'project'
 
     def dispatch(self, request, *args, **kwargs):

--- a/apps/mapideas/rules.py
+++ b/apps/mapideas/rules.py
@@ -11,7 +11,7 @@ rules.add_perm(
 )
 
 rules.add_perm(
-    'meinberlin_mapideas.create_idea',
+    'meinberlin_mapideas.add_idea',
     module_predicates.is_allowed_add_item(models.MapIdea)
 )
 

--- a/apps/mapideas/views.py
+++ b/apps/mapideas/views.py
@@ -58,7 +58,7 @@ class MapIdeaDetailView(module_views.ItemDetailView):
 class MapIdeaCreateView(module_views.ItemCreateView):
     model = models.MapIdea
     form_class = forms.MapIdeaForm
-    permission_required = 'meinberlin_mapideas.create_idea'
+    permission_required = 'meinberlin_mapideas.add_idea'
     template_name = 'meinberlin_mapideas/mapidea_create_form.html'
 
 

--- a/apps/organisations/rules.py
+++ b/apps/organisations/rules.py
@@ -3,5 +3,5 @@ from rules.predicates import is_superuser
 
 from .predicates import is_initiator
 
-rules.add_perm('meinberlin_organisations.modify_organisation',
+rules.add_perm('meinberlin_organisations.change_organisation',
                is_superuser | is_initiator)

--- a/apps/organisations/rules.py
+++ b/apps/organisations/rules.py
@@ -5,6 +5,3 @@ from .predicates import is_initiator
 
 rules.add_perm('meinberlin_organisations.modify_organisation',
                is_superuser | is_initiator)
-
-rules.add_perm('meinberlin_organisations.initiate_project',
-               is_superuser | is_initiator)

--- a/apps/polls/views.py
+++ b/apps/polls/views.py
@@ -25,7 +25,7 @@ class PollManagementView(DashboardBaseMixin,
                          generic.FormView):
     template_name = 'meinberlin_polls/poll_management_form.html'
     form_class = forms.PollForm
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
 
     # Dashboard related attributes
     menu_item = 'project'

--- a/apps/topicprio/views.py
+++ b/apps/topicprio/views.py
@@ -69,7 +69,7 @@ class TopicMgmtView(DashboardBaseMixin,
     model = models.Topic
     template_name = 'meinberlin_topicprio/topic_mgmt_list.html'
     filter_set = TopicCreateFilterSet
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
 
     # Dashboard related attributes
     menu_item = 'project'
@@ -95,7 +95,7 @@ class TopicMgmtView(DashboardBaseMixin,
 class TopicMgmtCreateView(module_views.ItemCreateView):
     model = models.Topic
     form_class = forms.TopicForm
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     template_name = 'meinberlin_topicprio/topic_mgmt_create_form.html'
     menu_item = 'project'
 
@@ -112,7 +112,7 @@ class TopicMgmtCreateView(module_views.ItemCreateView):
 class TopicMgmtUpdateView(module_views.ItemUpdateView):
     model = models.Topic
     form_class = forms.TopicForm
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     template_name = 'meinberlin_topicprio/topic_mgmt_update_form.html'
     menu_item = 'project'
 
@@ -129,7 +129,7 @@ class TopicMgmtUpdateView(module_views.ItemUpdateView):
 class TopicMgmtDeleteView(module_views.ItemDeleteView):
     model = models.Topic
     success_message = _("The topic has been deleted")
-    permission_required = 'meinberlin_organisations.initiate_project'
+    permission_required = 'a4projects.add_project'
     template_name = 'meinberlin_topicprio/topic_mgmt_confirm_delete.html'
     menu_item = 'project'
 


### PR DESCRIPTION
We have decided on permission naming in core. See https://github.com/liqd/adhocracy4/pull/79

Changes:
- use  `add_project` core permission in dashboard
- use  `add` instead of `create`
