### PR TITLE
tackle header margin problem

### DIFF
--- a/meinberlin/assets/scss/components/_alert.scss
+++ b/meinberlin/assets/scss/components/_alert.scss
@@ -1,5 +1,5 @@
 .messages {
-    margin: 0;
+    margin: 0 0 2.5em;
     padding: 0;
 
     li {

--- a/meinberlin/assets/scss/components/_alert.scss
+++ b/meinberlin/assets/scss/components/_alert.scss
@@ -1,5 +1,7 @@
+$messages-margin-bottom: 2.5em;
+
 .messages {
-    margin: 0 0 2.5em;
+    margin: 0 0 $messages-margin-bottom;
     padding: 0;
 
     li {
@@ -43,5 +45,13 @@
     // additional padding to the default value (see above).
     &:first-child {
         padding-top: calc(16px + #{$padding * 1.2});
+    }
+}
+
+// compensate for margin-bottom on messages
+.resource-header,
+.hero-unit {
+    .messages + & {
+        margin-top: -$messages-margin-bottom;
     }
 }

--- a/meinberlin/assets/scss/components/_alert.scss
+++ b/meinberlin/assets/scss/components/_alert.scss
@@ -1,4 +1,4 @@
-$messages-margin-bottom: 2.5em;
+$messages-margin-bottom: 25px;
 
 .messages {
     margin: 0 0 $messages-margin-bottom;

--- a/meinberlin/assets/scss/components/_header.scss
+++ b/meinberlin/assets/scss/components/_header.scss
@@ -201,9 +201,3 @@ $header-overlap: -2.5em;
         margin-top: $header-overlap - $header-margin-bottom;
     }
 }
-
-// compensate for margin-bottom on messages
-.messages + .resource-header,
-.messages + .hero-unit {
-    margin-top: $header-overlap;
-}

--- a/meinberlin/assets/scss/components/_header.scss
+++ b/meinberlin/assets/scss/components/_header.scss
@@ -1,4 +1,4 @@
-$header-margin-bottom: 2em;
+$header-margin-bottom: 25px;
 
 .main-header {
     position: relative;
@@ -192,7 +192,7 @@ $header-margin-bottom: 2em;
 
 // compensate for generic margin-bottom on header and move those elements
 // underneath the "dialograhmen"
-$header-overlap: -2.5em;
+$header-overlap: -35px;
 
 .messages,
 .hero-unit,

--- a/meinberlin/assets/scss/components/_header.scss
+++ b/meinberlin/assets/scss/components/_header.scss
@@ -1,6 +1,9 @@
+$header-margin-bottom: 2em;
+
 .main-header {
     position: relative;
     z-index: 1;
+    margin-bottom: $header-margin-bottom;
 }
 
 .main-nav {
@@ -187,10 +190,20 @@
     }
 }
 
+// compensate for generic margin-bottom on header and move those elements
+// underneath the "dialograhmen"
+$header-overlap: -2.5em;
+
 .messages,
 .hero-unit,
 .resource-header {
     &:first-child {
-        margin-top: -35px;
+        margin-top: $header-overlap - $header-margin-bottom;
     }
+}
+
+// compensate for margin-bottom on messages
+.messages + .resource-header,
+.messages + .hero-unit {
+    margin-top: $header-overlap;
 }

--- a/meinberlin/assets/scss/components/_menu_layout.scss
+++ b/meinberlin/assets/scss/components/_menu_layout.scss
@@ -1,6 +1,5 @@
 .menu-layout__menu,
 .menu-layout__content {
-    margin-top: 2em;
     margin-bottom: 2em;
 }
 


### PR DESCRIPTION
I gave the header a generic `margin-bottom` now, which added some necessary space underneath the header. This allowed me to remove the `margin-top` for the dashboard layout, following the logic that we prefer `margin-bottom` over `margin-top`. 

This fixes #82.