### PR TITLE
Mails: Add content_html block with a fallback that converts linebreaks

### DIFF
--- a/meinberlin/settings/base.py
+++ b/meinberlin/settings/base.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = (
     'easy_thumbnails',
     'ckeditor',
     'ckeditor_uploader',
+    'capture_tag',
 
     'adhocracy4.organisations.apps.OrganisationsConfig',
     'adhocracy4.projects.apps.ProjectsConfig',

--- a/meinberlin/templates/email_base.html
+++ b/meinberlin/templates/email_base.html
@@ -52,7 +52,15 @@
       <tr>
           <td style="text-align: center; padding-top:20px;">
               <h2>{% block headline %}{% endblock %}</h2>
-              <p>{% block content %}{% endblock %}</p>
+          </td>
+      </tr>
+      <tr>
+          <td>
+            {% block content_html %}
+                {% load capture_tags %}
+                {% capture as content silent %}{% block content %}{% endblock %}{% endcapture %}
+                {{ content|linebreaks }}
+            {% endblock %}
           </td>
       </tr>
       {% block cta %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,3 +14,4 @@ bleach==2.0.0
 # django multiform (released version 0.1 was too old)
 git+git://github.com/bmispelon/django-multiform.git@0e02f0d5729a80502a290070b474f3e3ac85c926
 jsonfield==2.0.1
+django-capture-tag==1.0


### PR DESCRIPTION
This introduces a new content_html block to the mail templates which can
be used to explictly define HTML emails.
If this block is not defined a fallback is used, that captures the
output of the standard text content and converts linebreaks to html.
For this feature a new dependency to django-capture-tag is introduced.