### PR TITLE
tweak poll alert closing behavior

### DIFF
--- a/apps/contrib/static/js/Alert.jsx
+++ b/apps/contrib/static/js/Alert.jsx
@@ -1,6 +1,5 @@
-/* global django */
-
 var React = require('react')
+var django = require('django')
 
 const Alert = ({type, message, onClick}) => {
   if (type) {

--- a/apps/contrib/static/js/Alert.jsx
+++ b/apps/contrib/static/js/Alert.jsx
@@ -1,11 +1,18 @@
+/* global django */
+
 var React = require('react')
 
-const Alert = ({type, message}) => {
+const Alert = ({type, message, onClick}) => {
   if (type) {
     return (
-      <p className={`alert ${type}`}>
-        {message}
-      </p>
+      <div className={`alert ${type}`} role="alert" onClick={onClick}>
+        <div className="l-wrapper">
+          {message}
+          <button className="alert__close" title={django.gettext('Close')}>
+            <i className="fa fa-times" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
     )
   }
 

--- a/apps/polls/assets/PollManagement.jsx
+++ b/apps/polls/assets/PollManagement.jsx
@@ -184,8 +184,6 @@ let PollManagement = React.createClass({
   render: function () {
     return (
       <form onSubmit={this.handleSubmit} onChange={this.removeAlert}>
-        <Alert onClick={this.removeAlert} {...this.state.alert} />
-
         <FlipMove easing="cubic-bezier(0.25, 0.5, 0.75, 1)">
           {
             this.state.questions.map((question, index) => {

--- a/apps/polls/assets/PollManagement.jsx
+++ b/apps/polls/assets/PollManagement.jsx
@@ -142,7 +142,7 @@ let PollManagement = React.createClass({
   |--------------------------------------------------------------------------
   */
 
-  handleFormChange: function () {
+  removeAlert: function () {
     this.setState({
       alert: null
     })
@@ -183,8 +183,8 @@ let PollManagement = React.createClass({
 
   render: function () {
     return (
-      <form onSubmit={this.handleSubmit} onChange={this.handleFormChange}>
-        <Alert {...this.state.alert} />
+      <form onSubmit={this.handleSubmit} onChange={this.removeAlert}>
+        <Alert onClick={this.removeAlert} {...this.state.alert} />
 
         <FlipMove easing="cubic-bezier(0.25, 0.5, 0.75, 1)">
           {
@@ -219,7 +219,7 @@ let PollManagement = React.createClass({
           </button>
         </p>
 
-        <Alert {...this.state.alert} />
+        <Alert onClick={this.removeAlert} {...this.state.alert} />
 
         <button type="submit" className="button button--primary">{django.gettext('save')}</button>
       </form>

--- a/apps/polls/assets/Question.jsx
+++ b/apps/polls/assets/Question.jsx
@@ -17,19 +17,6 @@ var Question = React.createClass({
     }
   },
 
-  setStateWithAlert: function (state, alert, timeout) {
-    state['alert'] = alert
-    this.setState(state, () => {
-      if (timeout) {
-        setTimeout(() => {
-          this.setState({
-            alert: null
-          })
-        }, timeout)
-      }
-    })
-  },
-
   findOwnChoice: function (choices) {
     let ownChoice = null
     choices.forEach(function (choice, i) {
@@ -77,24 +64,26 @@ var Question = React.createClass({
           counts[this.state.ownChoice]--
         }
 
-        this.setStateWithAlert({
+        this.setState({
           showResult: true,
           ownChoice: newChoice,
           selectedChoice: newChoice,
-          counts: counts
-        }, {
-          type: 'success',
-          message: django.gettext('Vote counted')
-        }, 1500)
+          counts: counts,
+          alert: {
+            type: 'success',
+            message: django.gettext('Vote counted')
+          }
+        })
       })
       .fail((xhr, status, err) => {
-        this.setStateWithAlert({
+        this.setState({
           showResult: false,
-          selectedChoice: newChoice
-        }, {
-          type: 'danger',
-          message: django.gettext('Vote has not been counted due to a server error.')
-        }, 1500)
+          selectedChoice: newChoice,
+          alert: {
+            type: 'danger',
+            message: django.gettext('Vote has not been counted due to a server error.')
+          }
+        })
       })
   },
 

--- a/apps/polls/assets/Question.jsx
+++ b/apps/polls/assets/Question.jsx
@@ -87,6 +87,12 @@ var Question = React.createClass({
       })
   },
 
+  removeAlert: function () {
+    this.setState({
+      alert: null
+    })
+  },
+
   handleOnChange: function (event) {
     this.setState({
       selectedChoice: parseInt(event.target.value)
@@ -167,7 +173,7 @@ var Question = React.createClass({
           }
         </div>
 
-        <Alert {...this.state.alert} />
+        <Alert onClick={this.removeAlert} {...this.state.alert} />
         { footer }
       </form>
     )


### PR DESCRIPTION
-   do not close alerts automatically after timeout
-   allow users to close alert manually (like in embed shell)
-   the alerts in the document app should be adapted in a similar way
-   the poll alerts (both in mgmt and detail) should have a margin-bottom. I could not think of a quick way to do this.

https://en.wikipedia.org/wiki/Issus,_Cilicia