### PR TITLE
limit bplan width

### DIFF
--- a/apps/bplan/templates/meinberlin_bplan/statement_create_form.html
+++ b/apps/bplan/templates/meinberlin_bplan/statement_create_form.html
@@ -2,27 +2,28 @@
 {% load i18n %}
 
 {% block title %}{% trans 'Submit a development plan statement' %}{% endblock %}
+
 {% block content %}
 <div class="l-wrapper">
-    <h1>{% trans 'Submit a development plan statement' %}</h1>
+    <div class="l-center-8">
+        <h1>{% trans 'Submit a development plan statement' %}</h1>
 
-    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-        {% csrf_token %}
-        {{ form.media }}
+        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+            {% csrf_token %}
+            {{ form.media }}
 
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=form.name %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.name %}
 
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=form.street_number %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.street_number %}
 
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=form.postal_code_city %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.postal_code_city %}
 
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=form.email %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.email %}
 
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=form.statement %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.statement %}
 
-        <input type="submit" class="button button--primary" value="{% trans 'Submit' %}" />
-    </form>
-
-
+            <input type="submit" class="button button--primary" value="{% trans 'Submit' %}" />
+        </form>
+    </div>
 </div>
 {% endblock %}

--- a/apps/bplan/templates/meinberlin_bplan/statement_sent.html
+++ b/apps/bplan/templates/meinberlin_bplan/statement_sent.html
@@ -2,13 +2,15 @@
 {% load i18n %}
 
 {% block title %}{% trans 'Statement sent' %}{% endblock %}
+
 {% block content %}
 <div class="l-wrapper">
-    <h1>{% trans 'Statement sent' %}</h1>
+    <div class="l-center-6">
+        <h1>{% trans 'Statement sent' %}</h1>
 
-    <p>
-        {% trans 'Thanks! Your statement has been sent! An answer will be send to your email address.' %}
-    </p>
-
+        <p>
+            {% trans 'Thanks! Your statement has been sent! An answer will be send to your email address.' %}
+        </p>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Improve line length on large displays (e.g. when used on the platform).
Note that I did not use `l-center-6` because it would not use all available space on small screens (e.g. small iframes).

side node: with all possible error messages displayed, the embed needs a height of ~1024px on my system in order not to require scrollbars.