### PR TITLE
Add default ordering by id to poll choices

### DIFF
--- a/apps/polls/models.py
+++ b/apps/polls/models.py
@@ -60,6 +60,9 @@ class Choice(models.Model):
 
     objects = ChoiceQuerySet.as_manager()
 
+    class Meta:
+        ordering = ['id']
+
     def __str__(self):
         return '%s @%s' % (self.label, self.question)
 


### PR DESCRIPTION
SQL does *not* give any guarantees on the row order, so an explicit order command is required even to sort on the primary key / id.
Unfortunately i can't reproduce the ordering problem on my local system with sqlite, as it does sort by default on the the. But the explicit order should fix the problem with postgres.

Fixes #373