### PR TITLE
fix broken variable name in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
   },
   devtool: 'eval',
   output: {
-    libraryTarget: 'var',
+    libraryTarget: 'this',
     library: '[name]',
     path: './meinberlin/static/',
     publicPath: '/static/',


### PR DESCRIPTION
fixes #334

Before this, webpack would generate the following (invalid) code:

    var leaflet.draw = …

Now, the it will be more like this:

    this['leaflet.draw'] = …

Since this code is executed in the global scope (and this therefore refers to `window`), it should result in the same thing, just with valid syntax.