### PR TITLE
Webpack: Use absolute output path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
   output: {
     libraryTarget: 'this',
     library: '[name]',
-    path: './meinberlin/static/',
+    path: path.resolve('./meinberlin/static/'),
     publicPath: '/static/',
     filename: '[name].js'
   },


### PR DESCRIPTION
The docu states, that the output directory has to be an absolute path.
see https://webpack.github.io/docs/configuration.html#output-path