### PR TITLE
Add point_label field to mapideas

### DIFF
--- a/apps/budgeting/forms.py
+++ b/apps/budgeting/forms.py
@@ -10,7 +10,8 @@ class ProposalForm(MapIdeaForm):
 
     class Meta:
         model = models.Proposal
-        fields = ['name', 'description', 'category', 'budget', 'point']
+        fields = ['name', 'description', 'category', 'budget', 'point',
+                  'point_label']
 
 
 class ModeratorFeedbackForm(forms.ModelForm):

--- a/apps/budgeting/migrations/0002_proposal_point_label.py
+++ b/apps/budgeting/migrations/0002_proposal_point_label.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meinberlin_budgeting', '0001_squashed_0004_auto_20170420_1456'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='proposal',
+            name='point_label',
+            field=models.CharField(max_length=255, verbose_name='Label of the ideas location', help_text='The label of the ideas location. This could be an address or the name of a landmark.', blank=True, default=''),
+        ),
+    ]

--- a/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_form.html
+++ b/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_form.html
@@ -11,6 +11,8 @@
 
     {% include 'meinberlin_contrib/includes/form_field.html' with field=form.point %}
 
+    {% include 'meinberlin_contrib/includes/form_field.html' with field=form.point_label %}
+
     {% if form.show_categories %}
         {% include 'meinberlin_contrib/includes/form_field.html' with field=form.category %}
     {% endif %}

--- a/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
+++ b/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
@@ -29,6 +29,10 @@
         {% if object.category %}
             <span class="label label--big">{{ object.category }}</span>
         {% endif %}
+        {% if object.point_label %}
+            <span class="label label--big"><i class="fa fa-map-marker" aria-hidden="true"></i> {{ object.point_label }}</span>
+        {% endif %}
+
         {% include 'meinberlin_moderatorfeedback/includes/moderatorfeedback.html' with item=object cls='list-item__label--moderator-feedback' %}
     </div>
     <span class="list-item__author">

--- a/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
+++ b/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
@@ -2,7 +2,8 @@
 {% load rules item_tags i18n humanize %}
 
 {% block additional_labels %}
-    <div class="label label--big">{{ proposal.budget|intcomma }}€</div>
+    {{ block.super }}
+    <span class="label label--big">{{ proposal.budget|intcomma }}€</span>
     {% include 'meinberlin_moderatorfeedback/includes/moderatorfeedback.html' with item=proposal %}
 {% endblock %}
 

--- a/apps/mapideas/forms.py
+++ b/apps/mapideas/forms.py
@@ -18,4 +18,4 @@ class MapIdeaForm(category_forms.CategorizableForm):
 
     class Meta:
         model = models.MapIdea
-        fields = ['name', 'description', 'category', 'point']
+        fields = ['name', 'description', 'category', 'point', 'point_label']

--- a/apps/mapideas/migrations/0002_mapidea_point_label.py
+++ b/apps/mapideas/migrations/0002_mapidea_point_label.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meinberlin_mapideas', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mapidea',
+            name='point_label',
+            field=models.CharField(max_length=255, verbose_name='Label of the ideas location', help_text='The label of the ideas location. This could be an address or the name of a landmark.', blank=True, default=''),
+        ),
+    ]

--- a/apps/mapideas/models.py
+++ b/apps/mapideas/models.py
@@ -1,4 +1,5 @@
 from django.core.urlresolvers import reverse
+from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.maps import fields as map_fields
@@ -11,6 +12,15 @@ class AbstractMapIdea(idea_models.AbstractIdea):
         verbose_name=_('Where can your idea be located on a map?'),
         help_text=_('Click inside marked area to set a marker. '
                     'Drag and drop marker to change place.'))
+
+    point_label = models.CharField(
+        blank=True,
+        default='',
+        max_length=255,
+        verbose_name=_('Label of the ideas location'),
+        help_text=_('The label of the ideas location. '
+                    'This could be an address or the name of a landmark.'),
+    )
 
     class Meta:
         abstract = True

--- a/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_form.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_form.html
@@ -9,6 +9,8 @@
 
     {% include 'meinberlin_contrib/includes/form_field.html' with field=form.point %}
 
+    {% include 'meinberlin_contrib/includes/form_field.html' with field=form.point_label %}
+
     {% if form.show_categories %}
         {% include 'meinberlin_contrib/includes/form_field.html' with field=form.category %}
     {% endif %}

--- a/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
@@ -27,6 +27,14 @@
         {{ object.name }}
         </a>
     </h3>
+    <div class="list-item__labels">
+        {% if object.category %}
+            <span class="label label--big">{{ object.category }}</span>
+        {% endif %}
+        {% if object.point_label %}
+            <span class="label label--big"><i class="fa fa-map-marker" aria-hidden="true"></i> {{ object.point_label }}</span>
+        {% endif %}
+    </div>
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>

--- a/apps/mapideas/templates/meinberlin_mapideas/mapidea_detail.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/mapidea_detail.html
@@ -10,6 +10,12 @@
     <link type="text/css" href="{% static 'leaflet.css'%}" rel="stylesheet" />
 {% endblock %}
 
+{% block additional_labels %}
+    {% if object.point_label %}
+        <span class="label label--big"><i class="fa fa-map-marker" aria-hidden="true"></i> {{ object.point_label }}</span>
+    {% endif %}
+{% endblock %}
+
 {% block additional_content %}
     {% if object.point %}
         {% map_display_point object.point object.module.areasettings_settings.polygon %}


### PR DESCRIPTION
The point label is an optional text field that can be used to describe the point selected on the map. for example "Alexanderplatz", "Rollbergstr. 15", "Liqd Büro" etc.