### PR TITLE
avoid overflow in hero unit (fixes #371)

### DIFF
--- a/meinberlin/assets/scss/components/_hero_unit.scss
+++ b/meinberlin/assets/scss/components/_hero_unit.scss
@@ -1,5 +1,8 @@
 .hero-unit {
     min-height: $hero-height-mobile;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
 
     position: relative;
 
@@ -27,10 +30,7 @@
 }
 
 .hero-unit__wrapper {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    overflow: hidden;  // clear margins
 }
 
 .hero-unit__subtitle {


### PR DESCRIPTION

![screenshot from 2017-05-17 17-20-49](https://cloud.githubusercontent.com/assets/202576/26161809/4226d212-3b25-11e7-8c39-90f4584c2853.png)

note that the bottom-alignment (and therefore the color contrast) now depends on flexbox.