### PR TITLE
preserve newlines in comment text

### DIFF
--- a/meinberlin/assets/scss/components/_comments.scss
+++ b/meinberlin/assets/scss/components/_comments.scss
@@ -51,6 +51,7 @@
 
 .comment-text {
     margin: 0.5em 0 0.8em;
+    white-space: pre-line;
 }
 
 .comment-author {


### PR DESCRIPTION
a3 did, opin does it, so we should do it too!

I did not find any other places where we use a single TextField for something that is actually visible in the UI.