### PR TITLE
Refactor moderator feedback to act as an abstract model.

### DIFF
--- a/apps/budgeting/forms.py
+++ b/apps/budgeting/forms.py
@@ -1,5 +1,7 @@
 from apps.mapideas.forms import MapIdeaForm
 
+from apps.moderatorfeedback.forms import item_moderate_form_factory
+
 from . import models
 
 
@@ -9,3 +11,5 @@ class ProposalForm(MapIdeaForm):
         model = models.Proposal
         fields = ['name', 'description', 'category', 'budget', 'point',
                   'point_label']
+
+ProposalModerateForm = item_moderate_form_factory(models.Proposal)

--- a/apps/budgeting/forms.py
+++ b/apps/budgeting/forms.py
@@ -1,6 +1,3 @@
-from django import forms
-from multiform import MultiModelForm
-
 from apps.mapideas.forms import MapIdeaForm
 
 from . import models
@@ -12,52 +9,3 @@ class ProposalForm(MapIdeaForm):
         model = models.Proposal
         fields = ['name', 'description', 'category', 'budget', 'point',
                   'point_label']
-
-
-class ModeratorFeedbackForm(forms.ModelForm):
-
-    class Meta:
-        model = models.Proposal
-        fields = ['moderator_feedback']
-
-
-class ModeratorStatementForm(forms.ModelForm):
-
-    class Meta:
-        model = models.ModeratorStatement
-        fields = ['statement']
-
-
-class ProposalModerateForm(MultiModelForm):
-    base_forms = [
-        ('feedback', ModeratorFeedbackForm),
-        ('statement', ModeratorStatementForm),
-    ]
-
-    def __init__(self, creator, *args, **kwargs):
-        self.creator = creator
-        self.proposal = kwargs['instance']
-        super(ProposalModerateForm, self).__init__(*args, **kwargs)
-
-    def dispatch_init_instance(self, name, instance):
-        if name == 'feedback':
-            return instance
-
-        if name == 'statement':
-            try:
-                statement = instance.moderator_statement
-                return statement
-            except models.Proposal.moderator_statement\
-                    .RelatedObjectDoesNotExist:
-                return None
-
-        return super(ProposalModerateForm, self)\
-            .dispatch_init_instance(name, instance)
-
-    def save(self, commit=True):
-        statement_form = self.forms['statement']
-        if statement_form.instance.pk is None:
-            statement_form.instance.creator = self.creator
-            statement_form.instance.proposal = self.proposal
-
-        return super(ProposalModerateForm, self).save(commit)

--- a/apps/budgeting/migrations/0004_remove_moderator_statement_fields.py
+++ b/apps/budgeting/migrations/0004_remove_moderator_statement_fields.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meinberlin_budgeting', '0003_remove_category_related_name'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='moderatorstatement',
+            name='creator',
+        ),
+        migrations.RemoveField(
+            model_name='moderatorstatement',
+            name='proposal',
+        ),
+        migrations.RemoveField(
+            model_name='proposal',
+            name='moderator_feedback',
+        ),
+        migrations.DeleteModel(
+            name='ModeratorStatement',
+        ),
+    ]

--- a/apps/budgeting/migrations/0005_inherit_from_moderateable.py
+++ b/apps/budgeting/migrations/0005_inherit_from_moderateable.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import apps.moderatorfeedback.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meinberlin_moderatorfeedback', '__first__'),
+        ('meinberlin_budgeting', '0004_remove_moderator_statement_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='proposal',
+            name='moderator_feedback',
+            field=apps.moderatorfeedback.fields.ModeratorFeedbackField(null=True, choices=[('CONSIDERATION', 'Under consideration'), ('REJECTED', 'Rejected'), ('ACCEPTED', 'Accepted')], blank=True, default=None, max_length=254),
+        ),
+        migrations.AddField(
+            model_name='proposal',
+            name='moderator_statement',
+            field=models.OneToOneField(null=True, related_name='+', to='meinberlin_moderatorfeedback.ModeratorStatement'),
+        ),
+    ]

--- a/apps/budgeting/models.py
+++ b/apps/budgeting/models.py
@@ -3,9 +3,10 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from apps.mapideas import models as mapidea_models
+from apps.moderatorfeedback.models import Moderateable
 
 
-class Proposal(mapidea_models.AbstractMapIdea):
+class Proposal(mapidea_models.AbstractMapIdea, Moderateable):
     budget = models.PositiveIntegerField(
         default=0,
         help_text=_('Required Budget')

--- a/apps/budgeting/models.py
+++ b/apps/budgeting/models.py
@@ -1,12 +1,8 @@
-from ckeditor.fields import RichTextField
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from adhocracy4.models.base import UserGeneratedContentModel
-
 from apps.mapideas import models as mapidea_models
-from apps.moderatorfeedback.fields import ModeratorFeedbackField
 
 
 class Proposal(mapidea_models.AbstractMapIdea):
@@ -15,23 +11,6 @@ class Proposal(mapidea_models.AbstractMapIdea):
         help_text=_('Required Budget')
     )
 
-    moderator_feedback = ModeratorFeedbackField(
-        choices=(
-            ('CONSIDERATION', _('Under consideration')),
-            ('REJECTED', _('Rejected')),
-            ('ACCEPTED', _('Accepted'))
-        )
-    )
-
     def get_absolute_url(self):
         return reverse('meinberlin_budgeting:proposal-detail',
                        args=[str(self.slug)])
-
-
-class ModeratorStatement(UserGeneratedContentModel):
-    proposal = models.OneToOneField(
-        Proposal,
-        primary_key=True,
-        related_name="moderator_statement")
-
-    statement = RichTextField(blank=True)

--- a/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
+++ b/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
@@ -1,4 +1,4 @@
-{% load i18n item_tags %}
+{% load i18n item_tags moderatorfeedback_tags %}
 
 <div class="list-item list-item--squashed">
     <div class="list-item__stats">
@@ -33,7 +33,11 @@
             <span class="label label--big"><i class="fa fa-map-marker" aria-hidden="true"></i> {{ object.point_label }}</span>
         {% endif %}
 
-        {% include 'meinberlin_moderatorfeedback/includes/moderatorfeedback.html' with item=object cls='list-item__label--moderator-feedback' %}
+        {% if object.moderator_feedback %}
+            <span class="label label--big label--{{object.moderator_feedback|classify }} list-item__label--moderator-feedback">
+                {{ object.get_moderator_feedback_display }}
+            </span>
+        {% endif %}
     </div>
     <span class="list-item__author">
         {{ object.creator.username }}

--- a/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
+++ b/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
@@ -1,10 +1,16 @@
 {% extends "meinberlin_mapideas/mapidea_detail.html" %}
-{% load rules item_tags i18n humanize %}
+{% load rules item_tags moderatorfeedback_tags i18n humanize %}
 
 {% block additional_labels %}
     {{ block.super }}
     <span class="label label--big">{{ proposal.budget|intcomma }}€</span>
-    {% include 'meinberlin_moderatorfeedback/includes/moderatorfeedback.html' with item=proposal %}
+
+
+    {% if proposal.moderator_feedback %}
+        <span class="label label--big label--{{proposal.moderator_feedback|classify }}">
+            {{ proposal.get_moderator_feedback_display }}
+        </span>
+    {% endif %}
 {% endblock %}
 
 {% block moderator_statement %}

--- a/apps/budgeting/views.py
+++ b/apps/budgeting/views.py
@@ -1,8 +1,10 @@
 import django_filters
 from django.contrib import messages
 from django.utils.translation import ugettext as _
+from django.views import generic
 
 from adhocracy4.modules import views as module_views
+from adhocracy4.rules import mixins as rules_mixins
 from apps.contrib import filters
 
 from . import forms
@@ -77,3 +79,20 @@ class ProposalDeleteView(module_views.ItemDeleteView):
     def delete(self, request, *args, **kwargs):
         messages.success(self.request, self.success_message)
         return super(ProposalDeleteView, self).delete(request, *args, **kwargs)
+
+
+class ProposalModerateView(rules_mixins.PermissionRequiredMixin,
+                           generic.UpdateView):
+    model = models.Proposal
+    form_class = forms.ProposalModerateForm
+    permission_required = 'meinberlin_budgeting.moderate_proposal'
+    template_name = 'meinberlin_budgeting/proposal_moderate_form.html'
+
+    def get_success_url(self):
+        return self.get_object().get_absolute_url()
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['item'] = self.object
+        kwargs['creator'] = self.request.user
+        return kwargs

--- a/apps/budgeting/views.py
+++ b/apps/budgeting/views.py
@@ -1,10 +1,8 @@
 import django_filters
 from django.contrib import messages
 from django.utils.translation import ugettext as _
-from django.views import generic
 
 from adhocracy4.modules import views as module_views
-from adhocracy4.rules import mixins as rules_mixins
 from apps.contrib import filters
 
 from . import forms
@@ -79,19 +77,3 @@ class ProposalDeleteView(module_views.ItemDeleteView):
     def delete(self, request, *args, **kwargs):
         messages.success(self.request, self.success_message)
         return super(ProposalDeleteView, self).delete(request, *args, **kwargs)
-
-
-class ProposalModerateView(rules_mixins.PermissionRequiredMixin,
-                           generic.UpdateView):
-    model = models.Proposal
-    form_class = forms.ProposalModerateForm
-    permission_required = 'meinberlin_budgeting.moderate_proposal'
-    template_name = 'meinberlin_budgeting/proposal_moderate_form.html'
-
-    def get_success_url(self):
-        return self.get_object().get_absolute_url()
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs['creator'] = self.request.user
-        return kwargs

--- a/apps/moderatorfeedback/fields.py
+++ b/apps/moderatorfeedback/fields.py
@@ -1,12 +1,5 @@
-import re
-import unicodedata
-
-from django.core import checks
 from django.core.exceptions import FieldError
 from django.db import models
-from django.utils.encoding import force_text
-from django.utils.functional import curry
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -20,84 +13,22 @@ class ModeratorFeedbackField(models.CharField):
         kwargs['blank'] = True
         super(ModeratorFeedbackField, self).__init__(*args, **kwargs)
 
-    def check(self, **kwargs):
-        errors = super(ModeratorFeedbackField, self).check(**kwargs)
-        errors.extend(self._check_choices_attribute(**kwargs))
-        return errors
-
-    def _check_choices_attribute(self, **kwargs):
-        try:
-            choices = self.choices
-            if len(choices) == 0:
-                raise ValueError()
-        except TypeError:
-            return [
-                checks.Error(
-                    "ModeratorFeedbackField must define a 'choices' "
-                    "attribute.",
-                    obj=self,
-                )
-            ]
-        except ValueError:
-            return [
-                checks.Error(
-                    "'choices' may not be empty.",
-                    obj=self,
-                )
-            ]
-        else:
-            return []
-
     def contribute_to_class(self, cls, name, **kwargs):
-        """
-        Add field specific attributes to the enclosing model.
+        """Initialize choices from the enclosing model.
 
         This is called in the context of the enclosing model
-        and injects a method to the model which is used
-        to get the moderator feedback context.
-        As for each model at most one ModeratorFeedbackField
-        is allowed an exception will be raised if the method
-        is already injected to the model.
+        from which it may receive the feedback choices.
         """
+        # Get the feedback choices as defined in the model
+        if hasattr(cls, 'moderator_feedback_choices'):
+            self._choices = cls.moderator_feedback_choices
+
+        # Since the choices are initialized late,
+        # they have to be manually checked
+        errors = self._check_choices()
+        if errors:
+            raise FieldError(errors)
+
+        # Call the super method at last so that choices are already initialized
         super(ModeratorFeedbackField, self) \
             .contribute_to_class(cls, name, **kwargs)
-
-        if hasattr(cls, 'get_moderator_feedback'):
-            raise FieldError(
-                'Only one %r is allowed per model.' % (
-                    self.__class___.__name__
-                ))
-        setattr(cls, 'get_moderator_feedback',
-                curry(self._get_moderator_feedback, field=self))
-
-    @staticmethod
-    def _get_moderator_feedback(model, field):
-        value = getattr(model, field.attname)
-        display = force_text(
-            dict(field.flatchoices).get(value, value),
-            strings_only=True)
-        value_class = classify(value)
-
-        return {
-            'value': value,
-            'display': display,
-            'value_class': value_class
-        }
-
-
-def classify(value):
-    """
-    Create a valid CSS class name from a value.
-
-    Converts to ASCII. Converts spaces to dashes. Removes characters that
-    aren't alphanumerics, underscores, or hyphens.
-    Also strips leading and trailing whitespace.
-    """
-    if value is None:
-        return 'NONE'
-
-    value = force_text(value)
-    value = unicodedata.normalize('NFKD', value) \
-        .encode('ascii', 'ignore').decode('ascii')
-    value = re.sub('[^\w\s-]', '', value).strip()
-    return mark_safe(re.sub('[-\s]+', '-', value))

--- a/apps/moderatorfeedback/forms.py
+++ b/apps/moderatorfeedback/forms.py
@@ -1,0 +1,72 @@
+from django import forms
+from django.core.exceptions import ObjectDoesNotExist
+from multiform import MultiModelForm
+
+from . import models
+
+
+class ModeratorStatementForm(forms.ModelForm):
+    class Meta:
+        model = models.ModeratorStatement
+        fields = ['statement']
+
+
+def moderator_feedback_form_factory(model):
+    meta_cls = type('Meta',
+                    (AbstractModeratorFeedbackForm.Meta,),
+                    {'model': model})
+    form_cls = type('%sModeratorFeedbackForm' % model.__name__,
+                    (AbstractModeratorFeedbackForm,),
+                    {'Meta': meta_cls})
+    return form_cls
+
+
+class AbstractModeratorFeedbackForm(forms.ModelForm):
+    class Meta:
+        fields = ['moderator_feedback']
+
+
+def item_moderate_form_factory(model):
+    base_forms = [
+        ('feedback', moderator_feedback_form_factory(model)),
+        ('statement', ModeratorStatementForm),
+    ]
+
+    form_cls = type('%sProposalModerateForm' % model.__name__,
+                    (AbstractProposalModerateForm,),
+                    {'base_forms': base_forms})
+    return form_cls
+
+
+class AbstractProposalModerateForm(MultiModelForm):
+    def __init__(self, item, creator, *args, **kwargs):
+        self.item = item
+        self.creator = creator
+        super(AbstractProposalModerateForm, self).__init__(*args, **kwargs)
+
+    def dispatch_init_instance(self, name, instance):
+        if name == 'feedback':
+            return self.item
+
+        if name == 'statement':
+            try:
+                statement = self.item.moderator_statement
+                return statement
+            except ObjectDoesNotExist:
+                return None
+
+        return super(AbstractProposalModerateForm, self)\
+            .dispatch_init_instance(name, instance)
+
+    def save(self, commit=True):
+        statement = self.forms['statement'].instance
+
+        # If a new statement is created, it has to saved and
+        # stored to the item explicitly
+        if statement.pk is None:
+            statement.creator = self.creator
+            statement.save()
+            self.item.moderator_statement = statement
+            self.item.save()
+
+        return super(AbstractProposalModerateForm, self).save(commit)

--- a/apps/moderatorfeedback/models.py
+++ b/apps/moderatorfeedback/models.py
@@ -1,0 +1,32 @@
+from ckeditor.fields import RichTextField
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from adhocracy4.models.base import UserGeneratedContentModel
+
+from . import fields
+
+DEFAULT_CHOICES = (
+    ('CONSIDERATION', _('Under consideration')),
+    ('REJECTED', _('Rejected')),
+    ('ACCEPTED', _('Accepted')),
+)
+
+
+class ModeratorStatement(UserGeneratedContentModel):
+    statement = RichTextField(blank=True)
+
+
+class Moderateable(models.Model):
+    moderator_feedback_choices = DEFAULT_CHOICES
+
+    moderator_feedback = fields.ModeratorFeedbackField()
+
+    moderator_statement = models.OneToOneField(
+        ModeratorStatement,
+        related_name='+',
+        null=True,
+    )
+
+    class Meta:
+        abstract = True

--- a/apps/moderatorfeedback/templates/meinberlin_moderatorfeedback/includes/moderatorfeedback.html
+++ b/apps/moderatorfeedback/templates/meinberlin_moderatorfeedback/includes/moderatorfeedback.html
@@ -1,7 +1,0 @@
-{% with item.get_moderator_feedback as moderator_feedback %}
-    {% if moderator_feedback.value %}
-        <span class="label label--big label--{{ moderator_feedback.value_class }} {{ cls }}">
-            {{ moderator_feedback.display }}
-        </span>
-    {% endif %}
-{% endwith %}

--- a/apps/moderatorfeedback/templatetags/moderatorfeedback_tags.py
+++ b/apps/moderatorfeedback/templatetags/moderatorfeedback_tags.py
@@ -1,0 +1,27 @@
+import re
+import unicodedata
+
+from django import template
+from django.utils.encoding import force_text
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def classify(value):
+    """
+    Create a valid CSS class name from a value.
+
+    Converts to ASCII. Converts spaces to dashes. Removes characters that
+    aren't alphanumerics, underscores, or hyphens.
+    Also strips leading and trailing whitespace.
+    """
+    if value is None:
+        return 'NONE'
+
+    value = force_text(value)
+    value = unicodedata.normalize('NFKD', value) \
+        .encode('ascii', 'ignore').decode('ascii')
+    value = re.sub('[^\w\s-]', '', value).strip()
+    return mark_safe(re.sub('[-\s]+', '-', value))


### PR DESCRIPTION
A new abstract Moderateable model is introduces that add the moderator
statement and moderator feedback to an item.
The actual model may overwrite the default choices by setting
`moderator_feedback_choices`.
To generalize the forms a factory is required, as the actual item type
has to be known to build correct forms.