### PR TITLE
Use allauth routes and overwrite templates

### DIFF
--- a/apps/account/templates/meinberlin_account/account_dashboard.html
+++ b/apps/account/templates/meinberlin_account/account_dashboard.html
@@ -17,22 +17,22 @@
             {% with request.resolver_match.url_name as url_name %}
                 <ul class="dashboard-nav__pages">
                     <li class="dashboard-nav__page">
-                        <a href="{% url 'account-profile' %}"
-                           class="dashboard-nav__item dashboard-nav__item--interactive {% ifequal view.menu_item 'profile' %}is-active{% endifequal %}">
+                        <a href="{% url 'account_profile' %}"
+                           class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == "account_profile" %}is-active{% endif %}">
                             <i class="fa fa-user" aria-hidden="true"></i>
                             {% trans 'Profile' %}
                         </a>
                     </li>
                     <li class="dashboard-nav__page">
-                        <a href="{% url 'account-password' %}"
-                           class="dashboard-nav__item dashboard-nav__item--interactive {% ifequal view.menu_item 'password' %}is-active{% endifequal %}">
+                        <a href="{% url 'account_change_password' %}"
+                           class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == "account_change_password" %}is-active{% endif %}">
                             <i class="fa fa-lock" aria-hidden="true"></i>
                             {% trans 'Change password' %}
                         </a>
                     </li>
                     <li class="dashboard-nav__page">
-                        <a href="{% url 'account-email' %}"
-                           class="dashboard-nav__item dashboard-nav__item--interactive {% ifequal view.menu_item 'email' %}is-active{% endifequal %}">
+                        <a href="{% url 'account_email' %}"
+                           class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == "account_email" %}is-active{% endif %}">
                             <i class="fa fa-envelope" aria-hidden="true"></i>
                             {% trans 'Email addresses' %}
                         </a>

--- a/apps/account/urls.py
+++ b/apps/account/urls.py
@@ -1,18 +1,13 @@
 from django.conf.urls import url
 
+
 from . import views
 
 urlpatterns = [
     url(r'^$',
-        views.ProfileUpdateView.as_view(),
+        views.AccountView.as_view(),
         name='account'),
     url(r'^profile/$',
         views.ProfileUpdateView.as_view(),
-        name='account-profile'),
-    url(r'^change_password/$',
-        views.ChangePasswordView.as_view(),
-        name='account-password'),
-    url(r'^email/$',
-        views.AccountEmailView.as_view(),
-        name='account-email'),
+        name='account_profile'),
 ]

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -1,40 +1,29 @@
-from allauth.account import views as account_views
 from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext as _
 from django.views import generic
+from django.views.generic.base import RedirectView
 
 from apps.users.models import User
 from . import forms
 
 
-class AccountBaseMixin:
-    def get_success_url(self):
-        return self.request.path
+class AccountView(RedirectView):
+    pattern_name = 'account_profile'
+    # Placeholder View to be replaced if we want to use a custom account
+    # dashboard function overview.
 
 
-class AccountEmailView(AccountBaseMixin,
-                       account_views.EmailView):
-    template_name = 'meinberlin_account/email.html'
-    menu_item = 'email'
-
-
-class ProfileUpdateView(AccountBaseMixin,
-                        SuccessMessageMixin,
+class ProfileUpdateView(SuccessMessageMixin,
                         generic.UpdateView):
 
     model = User
     template_name = "meinberlin_account/profile.html"
     form_class = forms.ProfileForm
     success_message = _("Your profile was successfully updated.")
-    menu_item = 'profile'
 
     def get_object(self):
         return get_object_or_404(User, pk=self.request.user.id)
 
-
-class ChangePasswordView(AccountBaseMixin,
-                         account_views.PasswordChangeView):
-    menu_item = 'password'
-    template_name = 'meinberlin_account/password.html'
-    menu_item = 'password'
+    def get_success_url(self):
+        return self.request.path

--- a/meinberlin/assets/scss/_shame.scss
+++ b/meinberlin/assets/scss/_shame.scss
@@ -42,15 +42,3 @@
 .map-list [data-map] {
     min-height: 500px;
 }
-
-// used by allauth (login/register)
-.signup > button[type="submit"],
-.primaryAction {
-    @extend .button;
-    @extend .button--primary;
-}
-
-.secondaryAction {
-    @extend .button;
-    @extend .button--secondary;
-}

--- a/meinberlin/settings/base.py
+++ b/meinberlin/settings/base.py
@@ -229,7 +229,6 @@ ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 
 LOGIN_URL = 'account_login'
-LOGOUT_URL = 'account_logout'
 LOGIN_REDIRECT_URL = '/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/meinberlin/settings/base.py
+++ b/meinberlin/settings/base.py
@@ -228,6 +228,8 @@ ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT = 300  # seconds
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = True
 
+LOGIN_URL = 'account_login'
+LOGOUT_URL = 'account_logout'
 LOGIN_REDIRECT_URL = '/'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/meinberlin/templates/account/base.html
+++ b/meinberlin/templates/account/base.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}{% block head_title %}{% endblock %}{% endblock %}
+
 {% block super_content %}
 <div class="l-wrapper">
     <div class="l-center-6">

--- a/meinberlin/templates/account/email.html
+++ b/meinberlin/templates/account/email.html
@@ -8,7 +8,7 @@
 {% block dashboard_content %}
 <h1>{% trans 'Email Addresses' %}</h1>
 
-<form class="multiform" action="{% url 'account-email' %}?next={{ request.path }}" method="post">
+<form class="multiform" action="{% url 'account_email' %}?next={{ request.path }}" method="post">
     {% csrf_token %}
     {% for emailaddress in user.emailaddress_set.all %}
     <div class="form-check">
@@ -34,7 +34,7 @@
     <button class="button button--secondary" type="submit" name="action_remove" >{% trans 'Remove' %}</button>
 </form>
 
-<form class="multiform" method="post" action="{% url 'account-email' %}">
+<form class="multiform" method="post" action="{% url 'account_email' %}">
     {% csrf_token %}
     {% if form.non_field_errors %}
     <div class="form-errors">

--- a/meinberlin/templates/account/email_confirm.html
+++ b/meinberlin/templates/account/email_confirm.html
@@ -17,7 +17,7 @@
             <button class="button button--primary" type="submit">{% trans 'Confirm' %}</button>
         </form>
     {% else %}
-        {% url 'account-email' as email_url %}
+        {% url 'account_email' as email_url %}
         <p>{% blocktrans %}This e-mail confirmation link expired or is invalid.
             Please <a href="{{ email_url }}">issue a new e-mail confirmation
                 request</a>.{% endblocktrans %}</p>

--- a/meinberlin/templates/account/password_change.html
+++ b/meinberlin/templates/account/password_change.html
@@ -9,7 +9,7 @@
 
     <div class="general-form">
         <div class="row">
-            <form name="PasswordChangeForm" action="{% url 'account-password' %}" method="post" class="l-col-2">
+            <form name="PasswordChangeForm" action="{% url 'account_change_password' %}" method="post" class="l-col-2">
                 {% csrf_token %}
 
                 {% if form.non_field_errors %}

--- a/meinberlin/urls.py
+++ b/meinberlin/urls.py
@@ -59,13 +59,17 @@ ct_router.register(r'ratings', RatingViewSet, base_name='ratings')
 urlpatterns = [
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^dashboard/', include(dashboard_urls)),
-    url(r'^account/', include(account_urls)),
     url(r'^embed/', include(embed_urls)),
 
     url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^accounts/', include(allauth_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^projects/', include(projects_urls)),
+
+    url(r'^accounts/', include(account_urls)),
+    url(r'^accounts/', include(allauth_urls)),
+    url(r'^accounts/', include(account_urls)),
+    # url(r'^accounts/', include(allauth_urls)),
+
 
     url(r'^ideas/', include(ideas_urls,
                             namespace='meinberlin_ideas')),

--- a/meinberlin/urls.py
+++ b/meinberlin/urls.py
@@ -59,17 +59,13 @@ ct_router.register(r'ratings', RatingViewSet, base_name='ratings')
 urlpatterns = [
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^dashboard/', include(dashboard_urls)),
+    url(r'^account/', include(account_urls)),
     url(r'^embed/', include(embed_urls)),
 
     url(r'^admin/', include(wagtailadmin_urls)),
+    url(r'^accounts/', include(allauth_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^projects/', include(projects_urls)),
-
-    url(r'^accounts/', include(account_urls)),
-    url(r'^accounts/', include(allauth_urls)),
-    url(r'^accounts/', include(account_urls)),
-    # url(r'^accounts/', include(allauth_urls)),
-
 
     url(r'^ideas/', include(ideas_urls,
                             namespace='meinberlin_ideas')),


### PR DESCRIPTION
Followup to #429

Use the allauth default routes and overwrite the allauth templates
instead of using a new view. The templates relevant for the account-
dashboard are inheriting from the account_dashboard.html to display the
navigation.