### PR TITLE
use template filter to get translated blueprint name

### DIFF
--- a/apps/dashboard/blueprints.py
+++ b/apps/dashboard/blueprints.py
@@ -169,4 +169,8 @@ blueprints = [
 class BlueprintMixin:
     @property
     def blueprint(self):
-        return dict(blueprints)[self.kwargs['blueprint_slug']]
+        return dict(blueprints)[self.blueprint_key]
+
+    @property
+    def blueprint_key(self):
+        return self.kwargs['blueprint_slug']

--- a/apps/dashboard/forms.py
+++ b/apps/dashboard/forms.py
@@ -142,7 +142,8 @@ class ProjectEditFormBase(multiform.MultiModelForm):
 
 class ProjectCreateForm(ProjectEditFormBase):
 
-    def __init__(self, blueprint, organisation, creator, *args, **kwargs):
+    def __init__(self, blueprint, blueprint_key, organisation, creator,
+                 *args, **kwargs):
         kwargs['phases__queryset'] = phase_models.Phase.objects.none()
         kwargs['phases__initial'] = [
             {'phase_content': phase,
@@ -153,6 +154,7 @@ class ProjectCreateForm(ProjectEditFormBase):
 
         self.organisation = organisation
         self.blueprint = blueprint
+        self.blueprint_key = blueprint_key
         self.creator = creator
 
         self.base_forms = [
@@ -191,7 +193,7 @@ class ProjectCreateForm(ProjectEditFormBase):
 
         project = objects['project']
         project.organisation = self.organisation
-        project.typ = self.blueprint.title
+        project.typ = self.blueprint_key
         if commit:
             project.save()
             project.moderators.add(self.creator)
@@ -363,17 +365,19 @@ class ExternalProjectBaseForm(forms.ModelForm):
 
 class ExternalProjectCreateForm(ExternalProjectBaseForm):
 
-    def __init__(self, organisation, creator, blueprint, *args, **kwargs):
+    def __init__(self, organisation, creator, blueprint, blueprint_key,
+                 *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.organisation = organisation
         self.creator = creator
         self.blueprint = blueprint
+        self.blueprint_key = blueprint_key
 
     def save(self, commit=True):
         project = self.instance
         project.information = _('External projects require no information.')
         project.organisation = self.organisation
-        project.typ = self.blueprint.title
+        project.typ = self.blueprint_key
         project = super().save(commit)
 
         if commit:
@@ -428,17 +432,19 @@ class BplanProjectBaseForm(ExternalProjectBaseForm):
 
 class BplanProjectCreateForm(BplanProjectBaseForm):
 
-    def __init__(self, organisation, creator, blueprint, *args, **kwargs):
+    def __init__(self, organisation, creator, blueprint, blueprint_key,
+                 *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.organisation = organisation
         self.creator = creator
         self.blueprint = blueprint
+        self.blueprint_key = blueprint_key
 
     def save(self, commit=True):
         project = self.instance
         project.information = _('Bplan projects require no information.')
         project.organisation = self.organisation
-        project.typ = self.blueprint.title
+        project.typ = self.blueprint_key
         project = super().save(commit)
 
         if commit:

--- a/apps/dashboard/mixins.py
+++ b/apps/dashboard/mixins.py
@@ -65,6 +65,7 @@ class DashboardProjectCreateMixin(DashboardProjectBaseMixin,
     def get_form_kwargs(self):
         kwargs = super(DashboardProjectCreateMixin, self).get_form_kwargs()
         kwargs['blueprint'] = self.blueprint
+        kwargs['blueprint_key'] = self.blueprint_key
         kwargs['organisation'] = self.organisation
         kwargs['creator'] = self.request.user
         return kwargs

--- a/apps/dashboard/templates/meinberlin_dashboard/includes/external_project_list_item.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/external_project_list_item.html
@@ -1,7 +1,7 @@
-{% load i18n project_tags %}
+{% load i18n project_tags dashboard_tags %}
 
 <div class="list-item">
-    <p class="list-item__subtitle">{{ project.typ }}</p>
+    <p class="list-item__subtitle">{{ project.typ|get_blueprint_title }}</p>
     <h3 class="list-item__title">
         <a href="{{ project.externalproject.url }}">
         {{ project.name }}

--- a/apps/dashboard/templates/meinberlin_dashboard/includes/project_list_item.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/project_list_item.html
@@ -1,7 +1,7 @@
 {% load i18n project_tags extproject_tags dashboard_tags %}
 
 <div class="list-item">
-    <p class="list-item__subtitle">{{ project.typ }}</p>
+    <p class="list-item__subtitle">{{ project.typ|get_blueprint_title }}</p>
     <h3 class="list-item__title">
         {{ project.name }}
     </h3>

--- a/apps/dashboard/templatetags/dashboard_tags.py
+++ b/apps/dashboard/templatetags/dashboard_tags.py
@@ -1,5 +1,6 @@
 from django import template
 
+from ..blueprints import blueprints
 from ..views import get_management_view
 
 register = template.Library()
@@ -8,3 +9,11 @@ register = template.Library()
 @register.filter
 def has_management_view(project):
     return get_management_view(project) is not None
+
+
+@register.filter
+def get_blueprint_title(key):
+    for k, blueprint in blueprints:
+        if k == key:
+            return blueprint.title
+    return key

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -55,20 +55,18 @@ class DashboardProjectCreateView(mixins.DashboardProjectCreateMixin,
     template_name = 'meinberlin_dashboard/project_create_form.html'
 
 
-class DashboardExternalProjectCreateView(mixins.DashboardProjectCreateMixin):
+class DashboardExternalProjectCreateView(mixins.DashboardProjectCreateMixin,
+                                         blueprints.BlueprintMixin):
     model = extproject_models.ExternalProject
     form_class = forms.ExternalProjectCreateForm
     template_name = 'meinberlin_dashboard/external_project_create_form.html'
 
-    blueprint = dict(blueprints.blueprints)['external-project']
 
-
-class DashboardBplanProjectCreateView(mixins.DashboardProjectCreateMixin):
+class DashboardBplanProjectCreateView(mixins.DashboardProjectCreateMixin,
+                                      blueprints.BlueprintMixin):
     model = bplan_models.Bplan
     form_class = forms.BplanProjectCreateForm
     template_name = 'meinberlin_dashboard/bplan_project_create_form.html'
-
-    blueprint = dict(blueprints.blueprints)['bplan']
 
 
 class DashboardProjectCreateViewDispatcher(generic.View):

--- a/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n rules react_follows thumbnail wagtailcore_tags %}
+{% load i18n rules react_follows thumbnail wagtailcore_tags dashboard_tags %}
 
 {% block title %}{{view.project.name}} &mdash; {{ block.super }}{% endblock %}
 
@@ -9,7 +9,7 @@
                {% endif %}">
     <div class="l-wrapper">
         <div class="l-center-6">
-            <div class="project-header__type">{{ view.project.typ }}</div>
+            <div class="project-header__type">{{ view.project.typ|get_blueprint_title }}</div>
             <h1 class="project-header__title">{{ view.project.name }}</h1>
             <div class="project-header__action">
                 {% block project_action %}{% endblock %}

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -55,7 +55,7 @@ class TypeWidget(DropdownLinkWidget):
     def __init__(self, attrs=None):
         choices = (('', _('Any')),)
         for blueprintname, blueprint in blueprints.blueprints:
-            choices += (blueprint.title, blueprint.title),
+            choices += (blueprintname, blueprint.title),
         super().__init__(attrs, choices)
 
 

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -54,8 +54,8 @@ class TypeWidget(DropdownLinkWidget):
 
     def __init__(self, attrs=None):
         choices = (('', _('Any')),)
-        for blueprintname, blueprint in blueprints.blueprints:
-            choices += (blueprintname, blueprint.title),
+        for blueprint_key, blueprint in blueprints.blueprints:
+            choices += (blueprint_key, blueprint.title),
         super().__init__(attrs, choices)
 
 


### PR DESCRIPTION
We currently store `blueprint.title` as `project.typ` when creating a
project. Unfortunately, this will write the translation that is used for
the creator into the database.

This pull request adds a filter that maps a blueprint key to the
translated title. This way, we can store the key into the database and
get the ranslation in the template where it is displayed.