### PR TITLE
Filter wagtail project choice options

### DIFF
--- a/apps/cms/models.py
+++ b/apps/cms/models.py
@@ -49,6 +49,12 @@ class ProjectSelectionBlock(blocks.ChooserBlock):
             return value.pk
         return value
 
+    def value_from_form(self, value):
+        # if project became unavailable (unpublished), selection will become an
+        # empty string and cause a server error on save, so we give a fallback
+        value = value or None
+        return super().value_from_form(value)
+
 
 class ProjectsWrapperBlock(blocks.StructBlock):
     title = blocks.CharBlock(max_length=80)

--- a/apps/cms/models.py
+++ b/apps/cms/models.py
@@ -1,5 +1,6 @@
+from django import forms
 from django.db import models
-from django.forms import widgets
+from django.utils.functional import cached_property
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from wagtail.wagtailadmin import edit_handlers
@@ -30,7 +31,18 @@ class SimplePage(Page):
 
 class ProjectSelectionBlock(blocks.ChooserBlock):
     target_model = Project
-    widget = widgets.Select
+    widget = forms.widgets.Select
+
+    @cached_property
+    def field(self):
+        return forms.ModelChoiceField(
+            queryset=self.target_model.objects.filter(
+                is_draft=False,
+                is_archived=False,
+                is_public=True),
+            widget=self.widget,
+            required=self._required,
+            help_text=self._help_text)
 
     def value_for_form(self, value):
         if isinstance(value, Project):


### PR DESCRIPTION
fixes #422

While working on this, I found a bug in wagtail: When leaving the project choice widget empty, you will get a 500 error on submit. I was not yet able to reproduce that issue in an isolated unit test though.

This issue is relevant because with this pull request a project that was once available for selection may become unavailable. Users that try to edit the frontpage after that will run into the described issue.