### PR TITLE
simple user profile

### DIFF
--- a/apps/users/templates/meinberlin_users/user_detail.html
+++ b/apps/users/templates/meinberlin_users/user_detail.html
@@ -10,6 +10,7 @@
                 {{ object.username }}
             </h1>
 
+            <h2>{% trans 'User participation' %}</h2>
             <div class="l-tiles-2">
                 {% for project in view.get_participated_projects %}
                     {% has_perm 'a4projects.view_project' request.user project as show %}
@@ -17,7 +18,7 @@
                         {% include 'meinberlin_projects/includes/project_list_tile.html' with project=project %}
                     {% endif %}
                 {% empty %}
-                    <p>{% blocktrans with username=object.username %}{{ username }} does not follow any projects.{% endblocktrans %}</p>
+                    <p>{% blocktrans with username=object.username %}{{ username }} did not participate in any projects.{% endblocktrans %}</p>
                 {% endfor %}
             </div>
         </div>

--- a/apps/users/templates/meinberlin_users/user_detail.html
+++ b/apps/users/templates/meinberlin_users/user_detail.html
@@ -10,7 +10,7 @@
                 {{ object.username }}
             </h1>
 
-            <h2>{% trans 'User participation' %}</h2>
+            <h2>{% blocktrans with username=object.username %}Projects {{username}} participated in{% endblocktrans %}</h2>
             <div class="l-tiles-2">
                 {% for project in view.get_participated_projects %}
                     {% has_perm 'a4projects.view_project' request.user project as show %}

--- a/apps/users/templates/meinberlin_users/user_detail.html
+++ b/apps/users/templates/meinberlin_users/user_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load rules i18n %}
 
 {% block title %}{{ object.username }} &mdash; {{ block.super }}{% endblock %}
 
@@ -10,6 +10,17 @@
                 {{ object.username }}
             </h1>
             <p>{% blocktrans with date=object.date_joined %}Joined on {{ date }}{% endblocktrans %}</p>
+
+            <div class="l-tiles-2">
+                {% for project in view.get_participated_projects %}
+                    {% has_perm 'a4projects.view_project' request.user project as show %}
+                    {% if show %}
+                        {% include 'meinberlin_projects/includes/project_list_tile.html' with project=project %}
+                    {% endif %}
+                {% empty %}
+                    <p>{% blocktrans with username=object.username %}{{ username }} does not follow any projects.{% endblocktrans %}</p>
+                {% endfor %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/apps/users/templates/meinberlin_users/user_detail.html
+++ b/apps/users/templates/meinberlin_users/user_detail.html
@@ -9,6 +9,7 @@
             <h1 class="herounit-title">
                 {{ object.username }}
             </h1>
+            <p>{% blocktrans with date=object.date_joined %}Joined on {{ date }}{% endblocktrans %}</p>
         </div>
     </div>
 {% endblock %}

--- a/apps/users/templates/meinberlin_users/user_detail.html
+++ b/apps/users/templates/meinberlin_users/user_detail.html
@@ -9,7 +9,6 @@
             <h1 class="herounit-title">
                 {{ object.username }}
             </h1>
-            <p>{% blocktrans with date=object.date_joined %}Joined on {{ date }}{% endblocktrans %}</p>
 
             <div class="l-tiles-2">
                 {% for project in view.get_participated_projects %}

--- a/apps/users/templates/meinberlin_users/user_detail.html
+++ b/apps/users/templates/meinberlin_users/user_detail.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{{ object.username }} &mdash; {{ block.super }}{% endblock %}
+
+{% block content %}
+    <div class="l-wrapper">
+        <div class="l-center-8">
+            <h1 class="herounit-title">
+                {{ object.username }}
+            </h1>
+        </div>
+    </div>
+{% endblock %}

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^(?P<slug>[-\w _.@+-]+)/$', views.ProfileView.as_view(),
+        name='profile'),
+]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,0 +1,8 @@
+from django.views.generic.detail import DetailView
+
+from . import models
+
+
+class ProfileView(DetailView):
+    model = models.User
+    slug_field = 'username'

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,4 +1,7 @@
+from django.db import models as django_models
 from django.views.generic.detail import DetailView
+
+from adhocracy4.projects.models import Project
 
 from . import models
 
@@ -6,3 +9,15 @@ from . import models
 class ProfileView(DetailView):
     model = models.User
     slug_field = 'username'
+
+    @property
+    def get_participated_projects(self):
+        user = self.object
+
+        qs = Project.objects.filter(
+            django_models.Q(follow__creator=user),
+            django_models.Q(follow__enabled=True) |
+            django_models.Q(participants=user)
+        ).distinct()
+
+        return qs

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,4 +1,3 @@
-from django.db import models as django_models
 from django.views.generic.detail import DetailView
 
 from adhocracy4.projects.models import Project
@@ -15,9 +14,7 @@ class ProfileView(DetailView):
         user = self.object
 
         qs = Project.objects.filter(
-            django_models.Q(follow__creator=user),
-            django_models.Q(follow__enabled=True) |
-            django_models.Q(participants=user)
+            action__actor=user
         ).distinct()
 
         return qs

--- a/meinberlin/urls.py
+++ b/meinberlin/urls.py
@@ -35,6 +35,7 @@ from apps.polls.api import PollViewSet
 from apps.polls.api import VoteViewSet
 from apps.projects import urls as projects_urls
 from apps.topicprio import urls as topicprio_urls
+from apps.users import urls as users_urls
 
 js_info_dict = {
     'packages': ('adhocracy4.comments',),
@@ -61,6 +62,7 @@ urlpatterns = [
     url(r'^dashboard/', include(dashboard_urls)),
     url(r'^account/', include(account_urls)),
     url(r'^embed/', include(embed_urls)),
+    url(r'^profile/', include(users_urls)),
 
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^accounts/', include(allauth_urls)),


### PR DESCRIPTION
This adds a simple user profile. Its main purpose is to fix the broken links on comments.

The information that is shown is username, join date and followed projects. Is this ok or should we keep some of that information private?

The implementation is based on a4-opin. I am not completely sure whether the selection of projects is useful in our context. Maybe it would also be good to ignore archived projects to not end up with hundrets o projects over time.