### PR TITLE
avoid to translate variables

### DIFF
--- a/apps/contrib/templates/meinberlin_contrib/includes/form_checkbox_field.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/form_checkbox_field.html
@@ -3,11 +3,11 @@
 <div class="form-check">
     <label class="form-check__label">
         {{ field }}
-        {% trans field.label %}
+        {{ field.label }}
     </label>
     {% if field.help_text %}
     <div class="form-hint">
-        {% trans field.help_text %}
+        {{ field.help_text }}
     </div>
     {% endif %}
     {{ field.errors }}

--- a/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
@@ -1,12 +1,12 @@
-{% load i18n widget_tweaks %}
+{% load widget_tweaks %}
 
 <div class="form-group">
     <label for="{{ field.id_for_label }}">
-        {% trans field.label %}
+        {{ field.label }}
     </label>
     {% if field.help_text %}
     <div class="form-hint">
-        {% trans field.help_text %}
+        {{ field.help_text }}
     </div>
     {% endif %}
     <div class="widget widget--{{ field|widget_type }}">

--- a/apps/contrib/templates/meinberlin_contrib/includes/form_field_with_addon.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/form_field_with_addon.html
@@ -1,12 +1,12 @@
-{% load i18n widget_tweaks %}
+{% load widget_tweaks %}
 
 <div class="form-group">
     <label for="{{ field.id_for_label }}">
-        {% trans field.label %}
+        {{ field.label }}
     </label>
     {% if field.help_text %}
     <div class="form-hint">
-        {% trans field.help_text %}
+        {{ field.help_text }}
     </div>
     {% endif %}
     <div class="widget widget--{{ field|widget_type }} input-addon">

--- a/apps/dashboard/templates/meinberlin_dashboard/includes/phase_form.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/phase_form.html
@@ -1,7 +1,7 @@
-{% load i18n form_tags %}
+{% load form_tags %}
 
 {% get_phase_name form.type.value as phasename %}
-<h3>{% trans phasename %}</h3>
+<h3>{{ phasename }}</h3>
 
 {% include 'meinberlin_contrib/includes/form_field.html' with field=form.name %}
 

--- a/apps/dashboard/templates/meinberlin_dashboard/project_moderators.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/project_moderators.html
@@ -12,11 +12,11 @@
         {% csrf_token %}
         <div class="form-group">
             <label for="{{ form.add_moderators.id_for_label }}">
-                {% trans form.add_moderators.label %}
+                {{ form.add_moderators.label }}
             </label>
             {% if form.add_moderators.help_text %}
             <div class="form-hint">
-                {% trans form.add_moderators.help_text %}
+                {{ form.add_moderators.help_text }}
             </div>
             {% endif %}
             <div class="button-group input-addon">


### PR DESCRIPTION
This is more of a proposal.

I think that translating variables can mask missing translations in other places. It is better to translate string literals directly. A common case is verbose names on model fields (see https://github.com/liqd/adhocracy4/pull/101)