### PR TITLE
Import ugettext_lazy as _ if used as a class property

### DIFF
--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -1,6 +1,6 @@
 from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from django.views.generic.base import RedirectView
 
@@ -19,9 +19,9 @@ class ProfileUpdateView(SuccessMessageMixin,
                         generic.UpdateView):
 
     model = User
-    template_name = "meinberlin_account/profile.html"
+    template_name = 'meinberlin_account/profile.html'
     form_class = forms.ProfileForm
-    success_message = _("Your profile was successfully updated.")
+    success_message = _('Your profile was successfully updated.')
 
     def get_object(self):
         return get_object_or_404(User, pk=self.request.user.id)

--- a/apps/budgeting/views.py
+++ b/apps/budgeting/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
 from adhocracy4.filters import filters as a4_filters
@@ -71,7 +71,7 @@ class ProposalUpdateView(module_views.ItemUpdateView):
 
 class ProposalDeleteView(module_views.ItemDeleteView):
     model = models.Proposal
-    success_message = _("Your budget request has been deleted")
+    success_message = _('Your budget request has been deleted')
     permission_required = 'meinberlin_budgeting.change_proposal'
     template_name = 'meinberlin_budgeting/proposal_confirm_delete.html'
 

--- a/apps/dashboard/filtersets.py
+++ b/apps/dashboard/filtersets.py
@@ -1,5 +1,5 @@
 import django_filters
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 from adhocracy4.filters.filters import DefaultsFilterSet

--- a/apps/dashboard/forms.py
+++ b/apps/dashboard/forms.py
@@ -4,8 +4,8 @@ from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.forms import modelformset_factory
-from django.utils.translation import ugettext as _
-from django.utils.translation import ngettext
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ungettext
 
 from adhocracy4.categories import models as category_models
 from adhocracy4.modules import models as module_models
@@ -325,7 +325,7 @@ class AddModeratorForm(forms.ModelForm):
         if users:
             messages.success(
                 self.request,
-                ngettext(
+                ungettext(
                     '{} moderator added.',
                     '{} moderators added.', len(users)
                 ).format(len(users))

--- a/apps/dashboard/mixins.py
+++ b/apps/dashboard/mixins.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
 from django.utils import functional
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from rules.compat import access_mixins as mixins
 

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -2,7 +2,7 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseNotFound
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from django.views.generic.detail import SingleObjectMixin
 

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.modules import views as module_views
@@ -64,7 +64,7 @@ class IdeaUpdateView(module_views.ItemUpdateView):
 
 class IdeaDeleteView(module_views.ItemDeleteView):
     model = models.Idea
-    success_message = _("Your Idea has been deleted")
+    success_message = _('Your Idea has been deleted')
     permission_required = 'meinberlin_ideas.change_idea'
     template_name = 'meinberlin_ideas/idea_confirm_delete.html'
 

--- a/apps/kiezkasse/views.py
+++ b/apps/kiezkasse/views.py
@@ -1,6 +1,6 @@
 import django_filters
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
 from adhocracy4.modules import views as module_views
@@ -72,7 +72,7 @@ class ProposalUpdateView(module_views.ItemUpdateView):
 
 class ProposalDeleteView(module_views.ItemDeleteView):
     model = models.Proposal
-    success_message = _("Your budget request has been deleted")
+    success_message = _('Your budget request has been deleted')
     permission_required = 'meinberlin_kiezkasse.change_proposal'
     template_name = 'meinberlin_kiezkasse/proposal_confirm_delete.html'
 

--- a/apps/mapideas/forms.py
+++ b/apps/mapideas/forms.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.categories import forms as category_forms
 from adhocracy4.maps import widgets as maps_widgets

--- a/apps/mapideas/views.py
+++ b/apps/mapideas/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.modules import views as module_views
@@ -70,7 +70,7 @@ class MapIdeaUpdateView(module_views.ItemUpdateView):
 
 class MapIdeaDeleteView(module_views.ItemDeleteView):
     model = models.MapIdea
-    success_message = _("Your Idea has been deleted")
+    success_message = _('Your Idea has been deleted')
     permission_required = 'meinberlin_mapideas.change_idea'
     template_name = 'meinberlin_mapideas/mapidea_confirm_delete.html'
 

--- a/apps/topicprio/views.py
+++ b/apps/topicprio/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.filters import views as filter_views
@@ -126,7 +126,7 @@ class TopicMgmtUpdateView(module_views.ItemUpdateView):
 
 class TopicMgmtDeleteView(module_views.ItemDeleteView):
     model = models.Topic
-    success_message = _("The topic has been deleted")
+    success_message = _('The topic has been deleted')
     permission_required = 'a4projects.add_project'
     template_name = 'meinberlin_topicprio/topic_mgmt_confirm_delete.html'
     menu_item = 'project'

--- a/apps/users/fields.py
+++ b/apps/users/fields.py
@@ -2,7 +2,7 @@ import re
 from django.core.validators import RegexValidator
 from django.forms.fields import Field
 from django.forms.widgets import Input
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 
 class CommaSeparatedEmailField(Field):

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.auth import forms as auth_forms
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 User = get_user_model()
 


### PR DESCRIPTION
Class properties may be evaluated on module load time when the users
locale is not available yet. Thus it is necessary to use ugettext_lazy
to show a correct translation.

For consistency the ugettext_lazy method is imported as `_` if it is
required in a single case. This is in accordance with the django docs
[1,2].

ugettext_lazy can be used as a replacement of ugettext in most cases, as it acts like a **unicode** string object. But it can't be used if the string is handled as a _bytestring_ (**str** object). 

In templates string operations on lazily translated strings can be used as usual.

*Attention*: If a default `LANGUAGE_CODE="de-de"` is set in the `local.py` settings, the failures may not be reproducible.

[1] https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#standard-translation
[2] https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#lazy-
translation