### PR TITLE
overwrite inline styles of richtext images

### DIFF
--- a/meinberlin/assets/scss/_base.scss
+++ b/meinberlin/assets/scss/_base.scss
@@ -80,6 +80,10 @@ a {
 img {
     max-width: 100%;
     height: auto;
+
+    .rich-text & {
+        height: auto !important;
+    }
 }
 
 a:not([href]) {


### PR DESCRIPTION
example: https://mein.berlin.de/paragraphs/192/