### PR TITLE
hide platform link and user indicator for bplan embed

### DIFF
--- a/apps/embed/templates/meinberlin_embed/embed.html
+++ b/apps/embed/templates/meinberlin_embed/embed.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load static i18n %}
+{% load static i18n extproject_tags %}
 <html class="embed">
 <head>
     <meta charset="utf-8" />
@@ -19,11 +19,13 @@
 
 <body data-url="{% url 'project-detail' object.slug %}">
     <header class="embed-header">
-        {% if request.user.is_anonymous %}
-            <a href="{% url 'account_login' %}" class="button button--light">{% trans 'Login' %}</a>
-        {% else %}
-            {% trans 'You are logged in as ' %} {{ request.user.username }}
-            <a href="{% url 'account_logout' %}" class="js-embed-logout button button--light" target="_blank">{% trans 'Logout' %}</a>
+        {% if not object|is_external %}
+            {% if request.user.is_anonymous %}
+                <a href="{% url 'account_login' %}" class="button button--light">{% trans 'Login' %}</a>
+            {% else %}
+                {% trans 'You are logged in as ' %} {{ request.user.username }}
+                <a href="{% url 'account_logout' %}" class="js-embed-logout button button--light" target="_blank">{% trans 'Logout' %}</a>
+            {% endif %}
         {% endif %}
         <div id="embed-status" class="embed-status"></div>
     </header>
@@ -32,7 +34,9 @@
         <a href="/" target="_blank">
             <img src="{% static 'images/logo_horizontal.svg' %}" alt="mein.berlin" class="embed-footer__logo">
         </a>
-        <a href="{% url 'project-detail' object.slug %}" data-embed-target="external">{% trans 'Go to platform' %}</a>
+        {% if not object|is_external %}
+            <a href="{% url 'project-detail' object.slug %}" data-embed-target="external">{% trans 'Go to platform' %}</a>
+        {% endif %}
     </footer>
     <div id="embed-confirm" class="modal" tabindex="-1" role="dialog" aria-label="{% trans 'Confirm login' %}" aria-hidden="true">
         <div class="modal-dialog">

--- a/apps/embed/templates/meinberlin_embed/embed.html
+++ b/apps/embed/templates/meinberlin_embed/embed.html
@@ -17,7 +17,7 @@
     {% block header %}{% endblock %}
 </head>
 
-<body data-url="{% url 'project-detail' slug %}">
+<body data-url="{% url 'project-detail' object.slug %}">
     <header class="embed-header">
         {% if request.user.is_anonymous %}
             <a href="{% url 'account_login' %}" class="button button--light">{% trans 'Login' %}</a>
@@ -32,7 +32,7 @@
         <a href="/" target="_blank">
             <img src="{% static 'images/logo_horizontal.svg' %}" alt="mein.berlin" class="embed-footer__logo">
         </a>
-        <a href="{% url 'project-detail' slug %}" data-embed-target="external">{% trans 'Go to platform' %}</a>
+        <a href="{% url 'project-detail' object.slug %}" data-embed-target="external">{% trans 'Go to platform' %}</a>
     </footer>
     <div id="embed-confirm" class="modal" tabindex="-1" role="dialog" aria-label="{% trans 'Confirm login' %}" aria-hidden="true">
         <div class="modal-dialog">

--- a/apps/embed/views.py
+++ b/apps/embed/views.py
@@ -1,12 +1,15 @@
 from django.views import generic
 from django.views.decorators.clickjacking import xframe_options_exempt
 
+from adhocracy4.projects import models as project_models
 
-class EmbedView(generic.DetailView):
+
+class EmbedView(generic.View):
     @xframe_options_exempt
     def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+        return super(EmbedView, self).dispatch(request, *args, **kwargs)
 
 
-class EmbedProjectView(EmbedView):
+class EmbedProjectView(generic.DetailView, EmbedView):
+    model = project_models.Project
     template_name = "meinberlin_embed/embed.html"

--- a/apps/embed/views.py
+++ b/apps/embed/views.py
@@ -2,7 +2,7 @@ from django.views import generic
 from django.views.decorators.clickjacking import xframe_options_exempt
 
 
-class EmbedView(generic.base.TemplateView):
+class EmbedView(generic.DetailView):
     @xframe_options_exempt
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
note that the criterium is whether the project is external, not if it is a bplan. This should work for now, but we may have to change it later on.