### PR TITLE
add ids to paragraphs

### DIFF
--- a/apps/documents/templates/meinberlin_documents/document_detail.html
+++ b/apps/documents/templates/meinberlin_documents/document_detail.html
@@ -8,7 +8,7 @@
 
             {% for paragraph in object.paragraphs.all %}
 
-                <section class="commenting">
+                <section class="commenting" id="paragraph-{{ object.pk }}-{{ paragraph.pk }}">
                     <div class="commenting__content">
                         <h2 class="commenting__title">
                             {{ paragraph.name }}


### PR DESCRIPTION
this allows to link to individual paragraphs

I would have liked to have semi-human-readable ids that are generated from the paragraph title, but I could not find a utility function that does the conversion just yet.