### PR TITLE
change styling of wagtail images

### DIFF
--- a/meinberlin/assets/scss/components/_simple_page.scss
+++ b/meinberlin/assets/scss/components/_simple_page.scss
@@ -1,13 +1,14 @@
 .richtext-image {
+    display: block;
     margin-bottom: $spacer;
+    margin-left: auto;
+    margin-right: auto;
 
     &.left {
-        float: left;
-        margin-right: $padding;
+        margin-left: 0;
     }
 
     &.right {
-        float: right;
-        margin-left: $padding;
+        margin-right: 0;
     }
 }


### PR DESCRIPTION
- center by default
- no floating

The changes are inspired by https://mein.berlin.de/hilfe/