### PR TITLE
Fix signup terms of use translation

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -1738,10 +1738,12 @@ msgid ""
 "\n"
 "                I accept the <a href=\"%(terms_of_use_url)s\" target=\"_blank"
 "\">terms of use</a>.\n"
+"                "
 msgstr ""
 "\n"
 "  Ich akzeptiere die <a href=\"%(terms_of_use_url)s\" target=\"_blank"
 "\">Nutzungsbedingungen</a>.\n"
+"                "
 
 #: meinberlin/templates/base.html.py:8
 msgid "meinBerlin"


### PR DESCRIPTION
The msgid has to be exactly the same in all translations.
And unfortunatly it is not possible to have the origin of the translated
string to end on a newline while the actual translation does not. Thus
it is necessary to add an empty line to translation.
