### PR TITLE
chapter styling

### DIFF
--- a/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block phase_content %}
-    <div class="filter-bar__top-overlap">
+    <div class="control-bar__top-overlap">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% include "meinberlin_contrib/includes/map_filter_and_sort.html" with filter=view.filter mode=view.mode %}

--- a/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -41,7 +41,7 @@
             {% map_display_points object_list view.module.settings_instance.polygon %}
         </div>
     {% else %}
-        <div class="list list--highlight">
+        <div class="module-content">
             <div class="l-wrapper">
                 <div class="l-center-8">
 

--- a/apps/contrib/templates/meinberlin_contrib/includes/filter_and_sort.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/filter_and_sort.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 
-<div class="filter-bar">
+<div class="control-bar">
     {% for field in filter.form %}
         {% if field.name != 'ordering' %}
             {{ field }}
         {% endif %}
     {% endfor %}
 
-    <div class="filter-bar__ordering">
+    <div class="control-bar__right">
         {{ filter.form.ordering }}
     </div>
 </div>

--- a/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
+++ b/apps/contrib/templates/meinberlin_contrib/includes/map_filter_and_sort.html
@@ -1,6 +1,6 @@
 {% load i18n contrib_tags %}
 
-<div class="filter-bar">
+<div class="control-bar">
     {% if mode == 'map' %}
         {% combined_url_parameter request.GET mode='list' as url_par %}
         <a class="button button--light" href="{{ url_par }}" aria-label="{% trans 'View as list' %}">
@@ -22,7 +22,7 @@
     {% endfor %}
 
     {% if mode != 'map' %}
-        <div class="filter-bar__ordering">
+        <div class="control-bar__right">
             {{ filter.form.ordering }}
         </div>
     {% endif %}

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -27,6 +27,22 @@ class Chapter(module_models.Item):
         from django.core.urlresolvers import reverse
         return reverse('project-detail', args=[str(self.project.slug)])
 
+    @cached_property
+    def prev(self):
+        return Chapter.objects\
+            .filter(module=self.module)\
+            .filter(weight__lt=self.weight)\
+            .order_by('-weight')\
+            .first()
+
+    @cached_property
+    def next(self):
+        return Chapter.objects\
+            .filter(module=self.module)\
+            .filter(weight__gt=self.weight)\
+            .order_by('weight')\
+            .first()
+
 
 class Paragraph(base.TimeStampedModel):
     name = models.CharField(max_length=120, blank=True)

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -13,34 +13,37 @@
     {% endfor %}
     </ol>
 
-    <div class="l-wrapper">
-        <article>
-            <h1>{{ object.name }}</h1>
+    <article class="list list--highlight">
+        <div class="l-wrapper">
+            <div class="l-center-8">
+            <h1 class="chapter-title">{{ object.name }}</h1>
 
             {% for paragraph in object.paragraphs.all %}
 
-                <section class="commenting" id="paragraph-{{ object.pk }}-{{ paragraph.pk }}">
-                    <div class="commenting__content">
-                        <h2 class="commenting__title">
+                <section class="paragraph" id="paragraph-{{ object.pk }}-{{ paragraph.pk }}">
+                    <div class="paragraph__content">
+                        <h2 class="paragraph__title">
                             {{ paragraph.name }}
                         </h2>
                         {{ paragraph.text|richtext }}
                     </div>
-                    <div class="commenting__actions">
+                    <div class="paragraph__actions">
                         <a
                                 class="button"
-                                title="{% trans 'Comments for this Paragraph' %}"
                                 href="{% url 'meinberlin_documents:paragraph-detail' paragraph.pk %}"
                         >
-                            {{ paragraph.comments.all|length }}
-                            <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
+                            <i class="fa fa-comment-o" aria-hidden="true"></i>
+                            {% blocktrans count count=paragraph.comments.all|length %}{{ count }} Comment{% plural %}{{ count }} Comments{% endblocktrans %}
                         </a>
                     </div>
                 </section>
 
             {% endfor %}
-        </article>
+            </div>
+        </div>
+    </article>
 
+    <div class="l-wrapper">
         <div class="l-center-6">
             {% react_comments object %}
         </div>

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -16,29 +16,29 @@
     <article class="list list--highlight">
         <div class="l-wrapper">
             <div class="l-center-8">
-            <h1 class="chapter-title">{{ object.name }}</h1>
+                <h1 class="chapter-title">{{ object.name }}</h1>
 
-            {% for paragraph in object.paragraphs.all %}
+                {% for paragraph in object.paragraphs.all %}
 
-                <section class="paragraph" id="paragraph-{{ object.pk }}-{{ paragraph.pk }}">
-                    <div class="paragraph__content">
-                        <h2 class="paragraph__title">
-                            {{ paragraph.name }}
-                        </h2>
-                        {{ paragraph.text|richtext }}
-                    </div>
-                    <div class="paragraph__actions">
-                        <a
-                                class="button"
-                                href="{% url 'meinberlin_documents:paragraph-detail' paragraph.pk %}"
-                        >
-                            <i class="fa fa-comment-o" aria-hidden="true"></i>
-                            {% blocktrans count count=paragraph.comments.all|length %}{{ count }} Comment{% plural %}{{ count }} Comments{% endblocktrans %}
-                        </a>
-                    </div>
-                </section>
+                    <section class="paragraph" id="paragraph-{{ object.pk }}-{{ paragraph.pk }}">
+                        <div class="paragraph__content">
+                            <h2 class="paragraph__title">
+                                {{ paragraph.name }}
+                            </h2>
+                            {{ paragraph.text|richtext }}
+                        </div>
+                        <div class="paragraph__actions">
+                            <a
+                                    class="button"
+                                    href="{% url 'meinberlin_documents:paragraph-detail' paragraph.pk %}"
+                            >
+                                <i class="fa fa-comment-o" aria-hidden="true"></i>
+                                {% blocktrans count count=paragraph.comments.all|length %}{{ count }} Comment{% plural %}{{ count }} Comments{% endblocktrans %}
+                            </a>
+                        </div>
+                    </section>
 
-            {% endfor %}
+                {% endfor %}
             </div>
         </div>
     </article>

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -3,6 +3,12 @@
 
 {% block phase_content %}
 
+    {% if chapter_list|length > 1 %}
+        <div class="filter-bar__top-overlap">
+            {% include 'meinberlin_documents/includes/nextprev.html' %}
+        </div>
+    {% endif %}
+
     <article class="module-content">
         <div class="l-wrapper">
             <div class="l-center-8">
@@ -46,6 +52,13 @@
             </div>
         </div>
     </article>
+
+    {% if chapter_list|length > 1 %}
+        <div class="filter-bar__bottom-overlap">
+            {% include 'meinberlin_documents/includes/nextprev.html' %}
+        </div>
+    {% endif %}
+
 
     <div class="l-wrapper">
         <div class="l-center-6">

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -3,19 +3,23 @@
 
 {% block phase_content %}
 
-    <ol>
-    {% for chapter in chapter_list %}
-        <li>
-            <a href="{% url 'meinberlin_documents:chapter-detail' chapter.pk %}">
-                {{ chapter.name }}
-            </a>
-        </li>
-    {% endfor %}
-    </ol>
-
     <article class="list list--highlight">
         <div class="l-wrapper">
             <div class="l-center-8">
+                {% if chapter_list|length > 1 %}
+                    <nav class="doc-toc" aria-label="{% trans 'Table of Contents' %}">
+                        <ol>
+                            {% for chapter in chapter_list %}
+                                <li>
+                                    <a href="{% url 'meinberlin_documents:chapter-detail' chapter.pk %}" {% if chapter.pk == object.pk %}class="active"{% endif %}>
+                                        {{ chapter.name }}
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ol>
+                    </nav>
+                {% endif %}
+
                 <h1 class="chapter-title">{{ object.name }}</h1>
 
                 {% for paragraph in object.paragraphs.all %}

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -3,7 +3,7 @@
 
 {% block phase_content %}
 
-    <article class="list list--highlight">
+    <article class="module-content">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% if chapter_list|length > 1 %}

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -4,7 +4,7 @@
 {% block phase_content %}
 
     {% if chapter_list|length > 1 %}
-        <div class="filter-bar__top-overlap">
+        <div class="control-bar__top-overlap">
             {% include 'meinberlin_documents/includes/nextprev.html' %}
         </div>
     {% endif %}
@@ -54,7 +54,7 @@
     </article>
 
     {% if chapter_list|length > 1 %}
-        <div class="filter-bar__bottom-overlap">
+        <div class="control-bar__bottom-overlap">
             {% include 'meinberlin_documents/includes/nextprev.html' %}
         </div>
     {% endif %}

--- a/apps/documents/templates/meinberlin_documents/includes/nextprev.html
+++ b/apps/documents/templates/meinberlin_documents/includes/nextprev.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+
+<div class="l-wrapper">
+    <div class="l-center-8">
+        <div class="filter-bar">
+            {% if view.prev %}
+                <a href="{% url 'meinberlin_documents:chapter-detail' view.prev.pk %}" class="button button--light">
+                    <i class="fa fa-chevron-left" aria-hidden="true"></i>
+                    {% trans "Previous Chapter" %}
+                </a>
+            {% else %}
+                <span class="button button--light is-disabled">
+                    <i class="fa fa-chevron-left" aria-hidden="true"></i>
+                    {% trans "Previous Chapter" %}
+                </span>
+            {% endif %}
+
+            {% if view.next %}
+                <a href="{% url 'meinberlin_documents:chapter-detail' view.next.pk %}" class="button button--light filter-bar__ordering">
+                    {% trans "Next Chapter" %}
+                    <i class="fa fa-chevron-right" aria-hidden="true"></i>
+                </a>
+            {% else %}
+                <span class="button button--light is-disabled filter-bar__ordering">
+                    {% trans "Next Chapter" %}
+                    <i class="fa fa-chevron-right" aria-hidden="true"></i>
+                </span>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/apps/documents/templates/meinberlin_documents/includes/nextprev.html
+++ b/apps/documents/templates/meinberlin_documents/includes/nextprev.html
@@ -2,7 +2,7 @@
 
 <div class="l-wrapper">
     <div class="l-center-8">
-        <div class="filter-bar">
+        <div class="control-bar">
             {% if view.prev %}
                 <a href="{% url 'meinberlin_documents:chapter-detail' view.prev.pk %}" class="button button--light">
                     <i class="fa fa-chevron-left" aria-hidden="true"></i>
@@ -16,12 +16,12 @@
             {% endif %}
 
             {% if view.next %}
-                <a href="{% url 'meinberlin_documents:chapter-detail' view.next.pk %}" class="button button--light filter-bar__ordering">
+                <a href="{% url 'meinberlin_documents:chapter-detail' view.next.pk %}" class="button button--light control-bar__right">
                     {% trans "Next Chapter" %}
                     <i class="fa fa-chevron-right" aria-hidden="true"></i>
                 </a>
             {% else %}
-                <span class="button button--light is-disabled filter-bar__ordering">
+                <span class="button button--light is-disabled control-bar__right">
                     {% trans "Next Chapter" %}
                     <i class="fa fa-chevron-right" aria-hidden="true"></i>
                 </span>

--- a/apps/documents/templates/meinberlin_documents/includes/nextprev.html
+++ b/apps/documents/templates/meinberlin_documents/includes/nextprev.html
@@ -3,8 +3,8 @@
 <div class="l-wrapper">
     <div class="l-center-8">
         <div class="control-bar">
-            {% if view.prev %}
-                <a href="{% url 'meinberlin_documents:chapter-detail' view.prev.pk %}" class="button button--light">
+            {% if object.prev %}
+                <a href="{% url 'meinberlin_documents:chapter-detail' object.prev.pk %}" class="button button--light">
                     <i class="fa fa-chevron-left" aria-hidden="true"></i>
                     {% trans "Previous Chapter" %}
                 </a>
@@ -15,8 +15,8 @@
                 </span>
             {% endif %}
 
-            {% if view.next %}
-                <a href="{% url 'meinberlin_documents:chapter-detail' view.next.pk %}" class="button button--light control-bar__right">
+            {% if object.next %}
+                <a href="{% url 'meinberlin_documents:chapter-detail' object.next.pk %}" class="button button--light control-bar__right">
                     {% trans "Next Chapter" %}
                     <i class="fa fa-chevron-right" aria-hidden="true"></i>
                 </a>

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -1,3 +1,4 @@
+from django.utils.functional import cached_property
 from django.views import generic
 
 from adhocracy4.modules import views as module_views
@@ -71,6 +72,20 @@ class ChapterDetailView(rules_mixins.PermissionRequiredMixin,
     @property
     def chapter_list(self):
         return models.Chapter.objects.filter(module=self.module)
+
+    @cached_property
+    def prev(self):
+        return self.chapter_list\
+            .filter(weight__lt=self.object.weight)\
+            .order_by('-weight')\
+            .first()
+
+    @cached_property
+    def next(self):
+        return self.chapter_list\
+            .filter(weight__gt=self.object.weight)\
+            .order_by('weight')\
+            .first()
 
 
 class DocumentDetailView(ChapterDetailView):

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -1,4 +1,3 @@
-from django.utils.functional import cached_property
 from django.views import generic
 
 from adhocracy4.modules import views as module_views
@@ -73,20 +72,6 @@ class ChapterDetailView(rules_mixins.PermissionRequiredMixin,
     @property
     def chapter_list(self):
         return models.Chapter.objects.filter(module=self.module)
-
-    @cached_property
-    def prev(self):
-        return self.chapter_list\
-            .filter(weight__lt=self.object.weight)\
-            .order_by('-weight')\
-            .first()
-
-    @cached_property
-    def next(self):
-        return self.chapter_list\
-            .filter(weight__gt=self.object.weight)\
-            .order_by('weight')\
-            .first()
 
 
 class DocumentDetailView(ProjectMixin, ChapterDetailView):

--- a/apps/ideas/templates/meinberlin_ideas/idea_list.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_list.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block phase_content %}
-    <div class="filter-bar__top-overlap">
+    <div class="control-bar__top-overlap">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}

--- a/apps/ideas/templates/meinberlin_ideas/idea_list.html
+++ b/apps/ideas/templates/meinberlin_ideas/idea_list.html
@@ -18,7 +18,7 @@
             </div>
         </div>
     </div>
-    <div class="list list--highlight">
+    <div class="module-content">
         <div class="l-wrapper">
             <div class="l-center-8">
 

--- a/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
+++ b/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block phase_content %}
-    <div class="filter-bar__top-overlap">
+    <div class="control-bar__top-overlap">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% include "meinberlin_contrib/includes/map_filter_and_sort.html" with filter=view.filter mode=view.mode %}

--- a/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
+++ b/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
@@ -41,7 +41,7 @@
             {% map_display_points object_list view.module.settings_instance.polygon %}
         </div>
     {% else %}
-        <div class="list list--highlight">
+        <div class="module-content">
             <div class="l-wrapper">
                 <div class="l-center-8">
 

--- a/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block phase_content %}
-    <div class="filter-bar__top-overlap">
+    <div class="control-bar__top-overlap">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% include "meinberlin_contrib/includes/map_filter_and_sort.html" with filter=view.filter mode=view.mode %}

--- a/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
+++ b/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
@@ -41,7 +41,7 @@
             {% map_display_points object_list view.module.settings_instance.polygon %}
         </div>
     {% else %}
-        <div class="list list--highlight">
+        <div class="module-content">
             <div class="l-wrapper">
                 <div class="l-center-8">
 

--- a/apps/polls/templates/meinberlin_polls/poll_detail.html
+++ b/apps/polls/templates/meinberlin_polls/poll_detail.html
@@ -3,7 +3,7 @@
 
 
 {% block phase_content %}
-    <div class="list list--highlight">
+    <div class="module-content">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% for question in object.questions.all %}

--- a/apps/topicprio/templates/meinberlin_topicprio/topic_list.html
+++ b/apps/topicprio/templates/meinberlin_topicprio/topic_list.html
@@ -2,7 +2,7 @@
 {% load i18n module_tags rules static maps_tags %}
 
 {% block phase_content %}
-    <div class="filter-bar__top-overlap">
+    <div class="control-bar__top-overlap">
         <div class="l-wrapper">
             <div class="l-center-8">
                 {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}

--- a/apps/topicprio/templates/meinberlin_topicprio/topic_list.html
+++ b/apps/topicprio/templates/meinberlin_topicprio/topic_list.html
@@ -9,7 +9,7 @@
             </div>
         </div>
     </div>
-    <div class="list list--highlight">
+    <div class="module-content">
         <div class="l-wrapper">
             <div class="l-center-8">
 

--- a/apps/topicprio/templates/meinberlin_topicprio/topic_mgmt_list.html
+++ b/apps/topicprio/templates/meinberlin_topicprio/topic_mgmt_list.html
@@ -21,7 +21,7 @@
             </a>
         </div>
     </div>
-    <div class="list list--highlight">
+    <div class="module-content">
         <div class="l-center-8">
             {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
 

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -19,6 +19,7 @@
         color: contrast-color($color-active);
     }
 
+    &.is-disabled,
     &:disabled {
         border-color: mix($color, $color-contrast, 50%);
         background-color: mix($color, $color-contrast, 50%);
@@ -51,7 +52,9 @@
     &,
     &:focus,
     &:hover,
-    &:active {
+    &:active,
+    &:disabled,
+    &.is-disabled {
         border-color: $border-color;
     }
 }
@@ -82,6 +85,7 @@
         background-color: transparent;
     }
 
+    &.is-disabled,
     &:disabled {
         color: $text-color;
         cursor: not-allowed;

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -21,9 +21,13 @@
 
     &.is-disabled,
     &:disabled {
-        border-color: mix($color, $color-contrast, 50%);
-        background-color: mix($color, $color-contrast, 50%);
-        color: mix($color, $color-contrast, 10%);
+        $is-light: luma($color) > luma($color-contrast);
+        $weight-bg: if($is-light, 95%, 50%);
+        $weight-fg: if($is-light, 60%, 10%);
+
+        border-color: mix($color, $color-contrast, $weight-bg);
+        background-color: mix($color, $color-contrast, $weight-bg);
+        color: mix($color, $color-contrast, $weight-fg);
         cursor: not-allowed;
     }
 }

--- a/meinberlin/assets/scss/components/_document.scss
+++ b/meinberlin/assets/scss/components/_document.scss
@@ -1,0 +1,23 @@
+.paragraph {
+    margin-bottom: $spacer / 2;
+}
+
+.chapter-title,
+.paragraph__content,
+.paragraph__actions {
+    background-color: $body-bg;
+    padding: $padding;
+}
+
+.paragraph__content {
+    margin-bottom: 1px;
+}
+
+.chapter-title,
+.paragraph__title {
+    margin-top: 0;
+}
+
+.paragraph__actions {
+    text-align: right;
+}

--- a/meinberlin/assets/scss/components/_document.scss
+++ b/meinberlin/assets/scss/components/_document.scss
@@ -2,6 +2,7 @@
     margin-bottom: $spacer / 2;
 }
 
+.doc-toc,
 .chapter-title,
 .paragraph__content,
 .paragraph__actions {
@@ -20,4 +21,26 @@
 
 .paragraph__actions {
     text-align: right;
+}
+
+.doc-toc {
+    margin-bottom: 2 * $spacer;
+    font-size: $font-size-lg;
+    border: 1px solid $border-color;
+    border-radius: 0.3em;
+
+    ol {
+        margin-bottom: 0;
+    }
+
+    a {
+        color: inherit;
+        text-decoration: none;
+
+        &.active,
+        &:hover,
+        &:focus {
+            color: $link-color;
+        }
+    }
 }

--- a/meinberlin/assets/scss/components/_filter_bar.scss
+++ b/meinberlin/assets/scss/components/_filter_bar.scss
@@ -38,3 +38,9 @@
     z-index: 1;
     bottom: -1.3em;
 }
+
+.filter-bar__bottom-overlap {
+    position: relative;
+    z-index: 1;
+    top: -1em;
+}

--- a/meinberlin/assets/scss/components/_filter_bar.scss
+++ b/meinberlin/assets/scss/components/_filter_bar.scss
@@ -36,7 +36,11 @@
 .filter-bar__top-overlap {
     position: relative;
     z-index: 1;
-    bottom: -1.3em;
+    bottom: -1em;
+
+    .dropdown {
+        margin-bottom: 0;
+    }
 }
 
 .filter-bar__bottom-overlap {

--- a/meinberlin/assets/scss/components/_filter_bar.scss
+++ b/meinberlin/assets/scss/components/_filter_bar.scss
@@ -1,4 +1,4 @@
-.filter-bar {
+.control-bar {
     @include clearfix;
     font-size: $font-size-sm;
 
@@ -21,7 +21,7 @@
         }
     }
 
-    .filter-bar__ordering {
+    .control-bar__right {
         float: right;
 
         @media (max-width: $breakpoint) {
@@ -33,7 +33,7 @@
     }
 }
 
-.filter-bar__top-overlap {
+.control-bar__top-overlap {
     position: relative;
     z-index: 1;
     bottom: -1em;
@@ -43,7 +43,7 @@
     }
 }
 
-.filter-bar__bottom-overlap {
+.control-bar__bottom-overlap {
     position: relative;
     z-index: 1;
     top: -1em;

--- a/meinberlin/assets/scss/components/_module.scss
+++ b/meinberlin/assets/scss/components/_module.scss
@@ -1,4 +1,4 @@
-.list--highlight {
+.module-content {
     padding-top: 2em;
     padding-bottom: 2em;
 

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -25,6 +25,7 @@
 @import 'components/comments';
 @import 'components/dashboard_nav';
 @import 'components/datepicker';
+@import 'components/document';
 @import 'components/dropdown';
 @import "components/embed_layout";
 @import 'components/embed_status';
@@ -48,9 +49,9 @@
 @import 'components/poll';
 @import 'components/popover';
 @import 'components/portal_header';
+@import 'components/project_header';
 @import 'components/radio';
 @import 'components/rating';
-@import 'components/project_header';
 @import 'components/simple_page';
 @import 'components/table';
 @import 'components/tabs';

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -37,12 +37,12 @@
 @import 'components/hero_unit';
 @import 'components/item_detail';
 @import 'components/label';
-@import 'components/list';
 @import 'components/list_item';
 @import 'components/lr_bar';
 @import 'components/map';
 @import 'components/menu_layout';
 @import 'components/moderator_statement';
+@import 'components/module';
 @import 'components/multiform';
 @import 'components/pagination';
 @import 'components/phases';


### PR DESCRIPTION
builds on #522 

This implements both the new document detail styling and styling for chapter navigation. Still to do: The table of content should be in an accordion.

Note that there was some styling-related refactoring, so @vellip should have a look.