### PR TITLE
style service konto login

### DIFF
--- a/meinberlin/templates/account/login.html
+++ b/meinberlin/templates/account/login.html
@@ -6,24 +6,8 @@
 {% block content %}
     <h1>{% trans "Login" %}</h1>
 
-    {% get_providers as socialaccount_providers %}
-    {% if socialaccount_providers %}
-        <p>{% blocktrans with site.name as site_name %}Please sign in with one
-        of your existing third party accounts. Or, <a href="{{ signup_url }}">register</a>
-        for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
+    <p>{% blocktrans %}If you have not created an account yet, then please <a href="{{ signup_url }}">register</a> first.{% endblocktrans %}</p>
 
-        <div class="socialaccount_ballot">
-            <ul class="socialaccount_providers">
-                {% include "socialaccount/snippets/provider_list.html" with process="login" %}
-            </ul>
-
-            <div class="login-or">{% trans 'or' %}</div>
-        </div>
-
-        {% include "socialaccount/snippets/login_extra.html" %}
-    {% else %}
-        <p>{% blocktrans %}If you have not created an account yet, then please <a href="{{ signup_url }}">register</a> first.{% endblocktrans %}</p>
-    {% endif %}
     <form method="POST" action="{% url 'account_login' %}">
         {{ form.non_field_errors }}
         {% csrf_token %}
@@ -37,6 +21,7 @@
 
         <div class="u-spacer-bottom">
             <button class="button button--primary" type="submit">{% trans "Login" %}</button>
+            {% include "socialaccount/snippets/provider_list.html" with process="login" %}
             <a class="button button--secondary" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
         </div>
     </form>

--- a/meinberlin/templates/socialaccount/connections.html
+++ b/meinberlin/templates/socialaccount/connections.html
@@ -9,7 +9,7 @@
 
 <div class="general-form">
     {% if form.accounts %}
-        <p>{% blocktrans %}You can sign in to your account using any of the following third party accounts:{% endblocktrans %}</p>
+        <p>{% blocktrans %}Your account is connected to the following services:{% endblocktrans %}</p>
         <form class="multiform" method="post" action="{% url 'socialaccount_connections' %}">
             {% csrf_token %}
             {% if form.non_field_errors %}
@@ -22,25 +22,19 @@
 
             {% for base_account in form.accounts %}
                 {% with base_account.get_provider_account as account %}
-                <div class="form-check">
-                    <label class="form-check__label">
-                        <input type="radio" name="account" value="{{ base_account.id }}">
-                        <strong>{{account.get_brand.name}}</strong>: {{ account }}
-                    </label>
-                </div>
+                <label>
+                    <input type="hidden" name="account" value="{{ base_account.id }}">
+                    <strong>{{account.get_brand.name}}</strong>: {{ account }}
+                </label>
                 {% endwith %}
             {% endfor %}
 
             <button class="button button--secondary" type="submit" name="action_remove" >{% trans 'Remove' %}</button>
         </form>
     {% else %}
-        <p>{% trans 'You currently have no social network accounts connected to this account.' %}</p>
-    {% endif %}
-
-    <h2>{% trans 'Add a 3rd Party Account' %}</h2>
-    <ul class="socialaccount_providers">
+        <p>{% trans 'You can connect your account to the following services:' %}</p>
         {% include "socialaccount/snippets/provider_list.html" with process="connect" %}
-    </ul>
+    {% endif %}
 </div>
 {% include "socialaccount/snippets/login_extra.html" %}
 {% endblock %}

--- a/meinberlin/templates/socialaccount/snippets/provider_list.html
+++ b/meinberlin/templates/socialaccount/snippets/provider_list.html
@@ -1,0 +1,10 @@
+{% load socialaccount %}
+
+{% get_providers as socialaccount_providers %}
+
+{% for provider in socialaccount_providers %}
+    <a
+        class="button button--secondary socialaccount_provider {{provider.id}}"
+        href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}"
+    >{{provider.name}}</a>
+{% endfor %}


### PR DESCRIPTION
This is my porposal for service konto styling. The idea is to make it as simple as possible because service konto is currently our only SSO option. Note that I removed the possibility to add more account connections once the servicekonto is connected.

@damusp what do you think?

![screenshot from 2017-06-14 17-56-17](https://user-images.githubusercontent.com/202576/27142348-0bc07c5c-512b-11e7-875d-51200bd0e224.png)

![screenshot from 2017-06-14 17-56-04](https://user-images.githubusercontent.com/202576/27142346-0a4a2ae4-512b-11e7-9734-ca4b91b3db94.png)

![screenshot from 2017-06-14 17-55-42](https://user-images.githubusercontent.com/202576/27142342-08c36e6a-512b-11e7-8ef0-4868b6ba2f39.png)

