### PR TITLE
Connect all signals from a Proxy model to its parent

### DIFF
--- a/apps/actions/apps.py
+++ b/apps/actions/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = 'apps.actions'
     label = 'meinberlin_actions'
+
+    def ready(self):
+        import apps.actions.signals  # noqa:F401

--- a/apps/actions/signals.py
+++ b/apps/actions/signals.py
@@ -1,0 +1,6 @@
+from apps.contrib.signals import connect_proxy_signals
+
+from .models import A4Action
+from .models import Action
+
+connect_proxy_signals(Action, A4Action)

--- a/apps/contrib/signals.py
+++ b/apps/contrib/signals.py
@@ -1,0 +1,37 @@
+from django.db.models.signals import m2m_changed
+from django.db.models.signals import post_delete
+from django.db.models.signals import post_save
+from django.db.models.signals import pre_delete
+from django.db.models.signals import pre_save
+
+signals = [
+    pre_save,
+    post_save,
+    pre_delete,
+    post_delete,
+    m2m_changed,
+]
+
+
+def _make_sender_fn(model, signal):
+    """Make a sender function used to connect signals."""
+    def sender_fn(sender, **kwargs):
+        # signal send method passes itself as a signal kwarg to its receivers
+        kwargs.pop('signal')
+        signal.send(sender=model, **kwargs)
+
+    return sender_fn
+
+
+def connect_proxy_signals(from_model, to_model):
+    """Connect all signals from a Proxy model to its parent.
+
+    There is 9 year old bug report where the problem is discussed:
+    https://code.djangoproject.com/ticket/9318
+    """
+    for signal in signals:
+        signal.connect(
+            _make_sender_fn(to_model, signal),
+            sender=from_model,
+            weak=False,
+        )


### PR DESCRIPTION
There is 9 year old bug report where the problem is discussed:
https://code.djangoproject.com/ticket/9318