### PR TITLE
Fix email notifications

### DIFF
--- a/apps/actions/models.py
+++ b/apps/actions/models.py
@@ -39,3 +39,10 @@ class Action(A4Action):
             return 'clock-o'
         else:
             return 'star'
+
+    @staticmethod
+    def from_parent(action):
+        """Cast an A4Action object to the proxied Action."""
+        assert action.__class__ == A4Action
+        action.__class__ = Action
+        return action

--- a/apps/actions/models.py
+++ b/apps/actions/models.py
@@ -41,7 +41,7 @@ class Action(A4Action):
             return 'star'
 
     @staticmethod
-    def from_parent(action):
+    def proxy_of(action):
         """Cast an A4Action object to the proxied Action."""
         assert action.__class__ == A4Action
         action.__class__ = Action

--- a/apps/notifications/emails.py
+++ b/apps/notifications/emails.py
@@ -53,7 +53,8 @@ class NotifyModeratorsEmail(Email):
 
     def get_receivers(self):
         action = self.object
-        receivers = _exclude_actor(super().get_receivers(), action.actor)
+        receivers = action.project.moderators.all()
+        receivers = _exclude_actor(receivers, action.actor)
         receivers = _exclude_notifications_disabled(receivers)
         return receivers
 

--- a/apps/notifications/signals.py
+++ b/apps/notifications/signals.py
@@ -12,7 +12,7 @@ from . import emails
 
 @receiver(signals.post_save, sender=A4Action)
 def send_notifications(instance, created, **kwargs):
-    action = Action.from_parent(instance)
+    action = Action.proxy_of(instance)
     verb = Verbs(action.verb)
 
     if action.type in ('item', 'comment') \


### PR DESCRIPTION
Moderators did not get any emails as there was a regression bug
introduced with the default email language.

This commit also enforces the use of the meinBerlin Action proxy when
using signals.

Note, that signals for Actions are not automatically bubbled down to
proxies, as discussed in https://code.djangoproject.com/ticket/9318