### PR TITLE
collapse chapter TOC

### DIFF
--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -21,6 +21,7 @@
                             aria-expanded="{{ object.prev|yesno:'false,true' }}"
                             aria-controls="doc-toc__content">
                             <h2 class="doc-toc__title">{% trans 'Table of Contents' %}</h2>
+                            <i class="fa fa-chevron-up" aria-hidden="true"></i>
                         </button>
                         <div class="doc-toc__content collapse {% if not object.prev %}show{% endif %}" id="doc-toc__content">
                             <ol>

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -15,14 +15,14 @@
                 {% if chapter_list|length > 1 %}
                     <nav class="doc-toc" aria-label="{% trans 'Table of Contents' %}">
                         <button
-                            class="doc-toc__toggle"
+                            class="doc-toc__toggle {% if object.prev %}collapsed{% endif %}"
                             data-toggle="collapse"
                             data-target="#doc-toc__content"
-                            aria-expanded="falce"
+                            aria-expanded="{{ object.prev|yesno:'false,true' }}"
                             aria-controls="doc-toc__content">
                             <h2 class="doc-toc__title">{% trans 'Table of Contents' %}</h2>
                         </button>
-                        <div class="doc-toc__content collapse" id="doc-toc__content">
+                        <div class="doc-toc__content collapse {% if not object.prev %}show{% endif %}" id="doc-toc__content">
                             <ol>
                                 {% for chapter in chapter_list %}
                                     <li>

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -17,7 +17,7 @@
                         <ol>
                             {% for chapter in chapter_list %}
                                 <li>
-                                    <a href="{{ chapter.get_absolute_url }}" {% if chapter.pk == object.pk %}class="active"{% endif %}>
+                                    <a href="{{ chapter.get_absolute_url }}" class="doc-toc__link {% if chapter.pk == object.pk %}active{% endif %}">
                                         {{ chapter.name }}
                                     </a>
                                 </li>

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -14,15 +14,18 @@
             <div class="l-center-8">
                 {% if chapter_list|length > 1 %}
                     <nav class="doc-toc" aria-label="{% trans 'Table of Contents' %}">
-                        <ol>
-                            {% for chapter in chapter_list %}
-                                <li>
-                                    <a href="{{ chapter.get_absolute_url }}" class="doc-toc__link {% if chapter.pk == object.pk %}active{% endif %}">
-                                        {{ chapter.name }}
-                                    </a>
-                                </li>
-                            {% endfor %}
-                        </ol>
+                        <h2 class="doc-toc__title">{% trans 'Table of Contents' %}</h2>
+                        <div class="doc-toc__content">
+                            <ol>
+                                {% for chapter in chapter_list %}
+                                    <li>
+                                        <a href="{{ chapter.get_absolute_url }}" class="doc-toc__link {% if chapter.pk == object.pk %}active{% endif %}">
+                                            {{ chapter.name }}
+                                        </a>
+                                    </li>
+                                {% endfor %}
+                            </ol>
+                        </div>
                     </nav>
                 {% endif %}
 

--- a/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -14,8 +14,15 @@
             <div class="l-center-8">
                 {% if chapter_list|length > 1 %}
                     <nav class="doc-toc" aria-label="{% trans 'Table of Contents' %}">
-                        <h2 class="doc-toc__title">{% trans 'Table of Contents' %}</h2>
-                        <div class="doc-toc__content">
+                        <button
+                            class="doc-toc__toggle"
+                            data-toggle="collapse"
+                            data-target="#doc-toc__content"
+                            aria-expanded="falce"
+                            aria-controls="doc-toc__content">
+                            <h2 class="doc-toc__title">{% trans 'Table of Contents' %}</h2>
+                        </button>
+                        <div class="doc-toc__content collapse" id="doc-toc__content">
                             <ol>
                                 {% for chapter in chapter_list %}
                                     <li>

--- a/meinberlin/assets/scss/components/_document.scss
+++ b/meinberlin/assets/scss/components/_document.scss
@@ -32,15 +32,15 @@
     ol {
         margin-bottom: 0;
     }
+}
 
-    a {
-        color: inherit;
-        text-decoration: none;
+.doc-toc__link {
+    color: inherit;
+    text-decoration: none;
 
-        &.active,
-        &:hover,
-        &:focus {
-            color: $link-color;
-        }
+    &.active,
+    &:hover,
+    &:focus {
+        color: $link-color;
     }
 }

--- a/meinberlin/assets/scss/components/_document.scss
+++ b/meinberlin/assets/scss/components/_document.scss
@@ -33,7 +33,20 @@
 
 .doc-toc__toggle {
     display: block;
+    position: relative;
     width: 100%;
+    padding-right: 2em;
+
+    i {
+        transition: transform 0.3s;
+        position: absolute;
+        top: 0.7em;
+        right: $padding;
+    }
+
+    &.collapsed i {
+        transform: rotate(-180deg);
+    }
 }
 
 .doc-toc__title {

--- a/meinberlin/assets/scss/components/_document.scss
+++ b/meinberlin/assets/scss/components/_document.scss
@@ -31,6 +31,11 @@
     border-radius: 0.3em;
 }
 
+.doc-toc__toggle {
+    display: block;
+    width: 100%;
+}
+
 .doc-toc__title {
     margin: 0;
     padding: ($padding / 2) $padding;

--- a/meinberlin/assets/scss/components/_document.scss
+++ b/meinberlin/assets/scss/components/_document.scss
@@ -25,9 +25,20 @@
 
 .doc-toc {
     margin-bottom: 2 * $spacer;
+    padding: 0;
     font-size: $font-size-lg;
     border: 1px solid $border-color;
     border-radius: 0.3em;
+}
+
+.doc-toc__title {
+    margin: 0;
+    padding: ($padding / 2) $padding;
+}
+
+.doc-toc__content {
+    padding: $padding;
+    border-top: 1px solid $border-color;
 
     ol {
         margin-bottom: 0;


### PR DESCRIPTION
This makes the chapter TOC collapsible and collapses it on all chapter detail
pages, except for the first one.

It uses bootstrap's [collapse component](https://v4-alpha.getbootstrap.com/components/collapse/).