### PR TITLE
Filter public actions

### DIFF
--- a/apps/actions/blocks.py
+++ b/apps/actions/blocks.py
@@ -11,7 +11,7 @@ class PlatformActivityBlock(blocks.StructBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
         block = context['self']
-        context['actions'] = Action.objects.all()[:block['count']]
+        context['actions'] = Action.objects.public()[:block['count']]
         return context
 
     class Meta:

--- a/apps/actions/models.py
+++ b/apps/actions/models.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db import models
 from django.utils.functional import cached_property
 
 from adhocracy4.actions.models import Action as A4Action
@@ -14,10 +15,20 @@ def get_action_type(content_type):
     return _ACTION_TYPES.get(content_type, 'unknown')
 
 
+class ActionQuerySet(models.QuerySet):
+    def public(self):
+        return self.filter(
+            (models.Q(project__is_draft=False) &
+             models.Q(project__is_public=True)) |
+            models.Q(project__isnull=True))
+
+
 class Action(A4Action):
     class Meta:
         proxy = True
         ordering = ('-timestamp',)
+
+    objects = ActionQuerySet.as_manager()
 
     @cached_property
     def type(self):


### PR DESCRIPTION
Add a custom QuerySet that allows to filter public actions.
An action is public if it is either not connected to a project or the
project is published and public.