### PR TITLE
Allow blank moderator statements

### DIFF
--- a/apps/budgeting/migrations/0011_allow_blank.py
+++ b/apps/budgeting/migrations/0011_allow_blank.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meinberlin_budgeting', '0010_add_default_ordering'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='proposal',
+            name='moderator_statement',
+            field=models.OneToOneField(null=True, related_name='+', to='meinberlin_moderatorfeedback.ModeratorStatement', blank=True),
+        ),
+    ]

--- a/apps/kiezkasse/migrations/0007_allow_blank.py
+++ b/apps/kiezkasse/migrations/0007_allow_blank.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meinberlin_kiezkasse', '0006_add_default_ordering'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='proposal',
+            name='moderator_statement',
+            field=models.OneToOneField(null=True, related_name='+', to='meinberlin_moderatorfeedback.ModeratorStatement', blank=True),
+        ),
+    ]

--- a/apps/moderatorfeedback/models.py
+++ b/apps/moderatorfeedback/models.py
@@ -26,6 +26,7 @@ class Moderateable(models.Model):
         ModeratorStatement,
         related_name='+',
         null=True,
+        blank=True,
     )
 
     class Meta:

--- a/apps/organisations/admin.py
+++ b/apps/organisations/admin.py
@@ -6,4 +6,5 @@ from . import models
 class OrganisationAdmin(admin.ModelAdmin):
     raw_id_fields = ('initiators', )
 
+
 admin.site.register(models.Organisation, OrganisationAdmin)


### PR DESCRIPTION
While moderator statements had been optional (null=True) they had been
marked as required in forms, because the (blank=True) option was not
set.

Fixes #575 