### PR TITLE
Do not show user and date of topics

### DIFF
--- a/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -29,9 +29,7 @@
     </h3>
     {% if object.category %}
         <div class="list-item__labels">
-            <div class="list-item__labels">
-                <span class="label label--big">{{ object.category }}</span>
-            </div>
+            <span class="label label--big">{{ object.category }}</span>
         </div>
     {% endif %}
     <span class="list-item__author">

--- a/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
+++ b/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
@@ -27,9 +27,9 @@
         {{ object.name }}
         </a>
     </h3>
-    <div class="list-item__labels">
-        {% if object.category %}
+    {% if object.category %}
+        <div class="list-item__labels">
             <span class="label label--big">{{ object.category }}</span>
-        {% endif %}
-    </div>
+        </div>
+    {% endif %}
 </li>

--- a/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
+++ b/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
@@ -32,10 +32,4 @@
             <span class="label label--big">{{ object.category }}</span>
         {% endif %}
     </div>
-    <span class="list-item__author">
-        {{ object.creator.username }}
-    </span>
-    <span class="list-item__date">
-        {{ object.created | date }}
-    </span>
 </li>

--- a/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
+++ b/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
@@ -32,11 +32,6 @@
                 {% block additional_content %}{% endblock %}
             </div>
 
-            <div class="item-detail__meta">
-                <strong class="item-detail__creator">{{ object.creator.username }}</strong>
-                {{ object.created|date }}
-            </div>
-
             <div class="item-detail__actions lr-bar">
                 {% if object|has_feature:"rate" %}
                     <div class="lr-bar__left">

--- a/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
+++ b/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
@@ -19,17 +19,14 @@
         <div class="item-detail">
             <h1 class="item-detail__title">{{ object.name }}</h1>
 
-            <div class="item-detail__labels">
-                {% if object.category %}
+            {% if object.category %}
+                <div class="item-detail__labels">
                     <div class="label label--big">{{ object.category }}</div>
-                {% endif %}
-                {% block additional_labels %}{% endblock %}
-            </div>
+                </div>
+            {% endif %}
 
             <div class="item-detail__content">
                 {{ object.description | richtext }}
-
-                {% block additional_content %}{% endblock %}
             </div>
 
             <div class="item-detail__actions lr-bar">

--- a/meinberlin/assets/scss/components/_item_detail.scss
+++ b/meinberlin/assets/scss/components/_item_detail.scss
@@ -9,8 +9,11 @@
 
 .item-detail__meta {
     padding-bottom: 0.6em;
-    border-bottom: 2px solid $border-color;
-    margin-bottom: 0.6em;
+}
+
+.item-detail__actions {
+    padding-top: 0.6em;
+    border-top: 2px solid $border-color;
 }
 
 .item-detail__creator {


### PR DESCRIPTION
As topics are created by the same initiator at one time, having this information shown looks weird and is not interesting for the users.