### PR TITLE
Add an export framework and item export functionality

### DIFF
--- a/apps/budgeting/views.py
+++ b/apps/budgeting/views.py
@@ -39,7 +39,7 @@ class ProposalExportView(export_views.ItemExportView,
                          export_views.ItemExportWithCommentCountMixin,
                          export_views.ItemExportWithCommentsMixin,
                          export_views.ItemExportWithLocationMixin,
-                         export_views.ItemExportWithModeratorStatement):
+                         export_views.ItemExportWithModeratorFeedback):
     model = models.Proposal
     fields = ['name', 'description', 'creator', 'created', 'budget']
 

--- a/apps/dashboard/templates/meinberlin_dashboard/includes/project_list_item.html
+++ b/apps/dashboard/templates/meinberlin_dashboard/includes/project_list_item.html
@@ -58,5 +58,15 @@
             </a>
         </span>
         {% endif %}
+
+        {% if project|has_exports %}
+        <span class="list-item__action">
+            <a href="{% url 'export-project' project_slug=project.slug %}"
+               class="button button--light button--small">
+                <i class="fa fa-download" aria-hidden="true"></i>
+                {% trans 'Export' %}
+            </a>
+        </span>
+        {% endif %}
     </div>
 </li>

--- a/apps/dashboard/templatetags/dashboard_tags.py
+++ b/apps/dashboard/templatetags/dashboard_tags.py
@@ -1,7 +1,8 @@
 from django import template
 
-from ..blueprints import blueprints
-from ..views import get_management_view
+from apps.dashboard.blueprints import blueprints
+from apps.dashboard.views import get_management_view
+from apps.exports.views import get_exports
 
 register = template.Library()
 
@@ -17,3 +18,8 @@ def get_blueprint_title(key):
         if k == key:
             return blueprint.title
     return key
+
+
+@register.filter
+def has_exports(project):
+    return len(get_exports(project)) > 0

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
@@ -210,6 +212,7 @@ class DashboardProjectManagementView(mixins.DashboardBaseMixin,
             kwargs={'organisation_slug': self.organisation.slug, })
 
 
+@lru_cache()
 def get_management_view(project):
     """
     Test if any phase has a management_view set.

--- a/apps/exports/apps.py
+++ b/apps/exports/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = 'apps.exports'
+    label = 'meinberlin_exports'

--- a/apps/exports/urls.py
+++ b/apps/exports/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^project/(?P<project_slug>[-\w_]+)/$',
+        views.ExportProjectDispatcher.as_view(), name='export-project'),
+    url(r'^module/(?P<module_slug>[-\w_]+)/(?P<export_id>\d+)/$',
+        views.ExportModuleDispatcher.as_view(), name='export-module'),
+]

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -210,10 +210,6 @@ class ItemExportWithRatesMixin(VirtualFieldMixin):
 
         return virtual
 
-    def _count_ratings(self, item, value):
-        ct = ContentType.objects.get_for_model(item)
-        return Rating.objects.filter(content_type=ct, value=value).count()
-
     def get_ratings_positive_data(self, item):
         if hasattr(item, 'positive_rating_count'):
             return item.positive_rating_count
@@ -232,6 +228,10 @@ class ItemExportWithRatesMixin(VirtualFieldMixin):
 
         return 0
 
+    def _count_ratings(self, item, value):
+        ct = ContentType.objects.get_for_model(item)
+        return Rating.objects.filter(content_type=ct, value=value).count()
+
 
 class ItemExportWithCommentCountMixin(VirtualFieldMixin):
     def get_virtual_fields(self):
@@ -245,11 +245,11 @@ class ItemExportWithCommentCountMixin(VirtualFieldMixin):
         # if hasattr(item, 'comment_count'):
         #     return item.comment_count
         if hasattr(item, 'comments'):
-            return self._comment_count(item)
+            return self._count_comments(item)
 
         return 0
 
-    def _comment_count(self, item):
+    def _count_comments(self, item):
         comment_ids = item.comments.values_list('id', flat=True)
         replies = Comment.objects.filter(parent_comment__in=comment_ids)
         return len(comment_ids) + len(replies)

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -42,10 +42,10 @@ class ItemExportView(generic.ListView, VirtualFieldMixin):
         for field in fields:
             if field.concrete \
                     and not (field.one_to_one and field.rel.parent_link) \
-                    and field.attname not in exclude \
-                    and field.attname not in names:
+                    and field.name not in exclude \
+                    and field.name not in names:
 
-                names.append(field.attname)
+                names.append(field.name)
                 header.append(str(field.verbose_name))
 
         virtual = self.get_virtual_fields()

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -268,3 +268,23 @@ class ItemExportWithCommentsMixin(VirtualFieldMixin):
                     username=reply.creator.username,
                     text=strip_tags(reply.comment.strip())
                 )
+
+
+class ItemExportWithLocationMixin(VirtualFieldMixin):
+    def get_virtual_fields(self):
+        virtual = super().get_virtual_fields()
+        if 'location' not in virtual:
+            virtual['location'] = _('Location')
+        if 'location_label' not in virtual:
+            virtual['location_label'] = _('Location label')
+        return virtual
+
+    def get_location_data(self, item):
+        if hasattr(item, 'point'):
+            point = item.point
+            if 'geometry' in point:
+                return ', '.join(map(str, point['geometry']['coordinates']))
+        return ''
+
+    def get_location_label_data(self, item):
+        return getattr(item, 'point_label', '')

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -79,8 +79,11 @@ class ItemExportView(generic.ListView, VirtualFieldMixin):
             return get_field_attr
 
         # If item is a dict, return the fields data by key
-        if name in item:
-            return item['name']
+        try:
+            if name in item:
+                return item['name']
+        except TypeError:
+            pass
 
         # Finally try to get the fields data as a property
         return getattr(item, name, '')

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -1,0 +1,87 @@
+import csv
+
+from django.core.exceptions import FieldError
+from django.http import HttpResponse
+from django.utils.translation import ugettext as _
+
+from adhocracy4.modules import views as module_views
+
+
+class ItemExportView(module_views.ItemListView):
+    paginate_by = 0
+    fields = None
+    exclude = None
+    virtual = None
+    model = None
+
+    def __init__(self):
+        super(ItemExportView, self).__init__()
+        if self.fields and self.exclude:
+            raise FieldError()
+        self._header, self._names = self._setup_fields()
+
+    def _setup_fields(self):
+        meta = self.model._meta
+
+        if self.fields:
+            fields = [meta.get_field(name) for name in self.fields]
+        else:
+            fields = meta.get_fields()
+
+        names = ['link']
+        header = [_('Link')]
+        for field in fields:
+            if field.concrete \
+                    and not (field.one_to_one and field.rel.parent_link) \
+                    and field.attname not in self.exclude \
+                    and field.attname not in names:
+
+                names.append(field.attname)
+                header.append(str(field.verbose_name))
+
+        if self.virtual:
+            for head, name in self.virtual:
+                if name not in names:
+                    names.append(name)
+                    header.append(head)
+
+        return header, names
+
+    def get_queryset(self):
+        return super().get_queryset()
+
+    def get_link_data(self, item):
+        return self.request.build_absolute_uri(item.get_absolute_url())
+
+    def get_field_data(self, item, name):
+        # Use custom getters if they are defined
+        get_field_attr_name = 'get_%s_data' % name
+        if hasattr(self, get_field_attr_name):
+            get_field_attr = getattr(self, get_field_attr_name)
+
+            if hasattr(get_field_attr, '__call__'):
+                return get_field_attr(item)
+            return get_field_attr
+
+        # If item is a dict, return the fields data by key
+        if name in item:
+            return item['name']
+
+        # Finally try to get the fields data as a property
+        return getattr(item, name, '')
+
+    def get(self, request, *args, **kwargs):
+        response = HttpResponse(content_type='text/csv; charset=utf-8')
+        response['Content-Disposition'] = (
+            'attachment; filename="ideas.csv"'
+        )
+
+        writer = csv.writer(response, lineterminator='\n',
+                            quotechar='"', quoting=csv.QUOTE_ALL)
+        writer.writerow(self._header)
+
+        for item in self.get_queryset().all():
+            data = [self.get_field_data(item, name) for name in self._names]
+            writer.writerow(data)
+
+        return response

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
+from django.utils.html import strip_tags
 from django.utils.translation import ugettext as _
 from django.views import generic
 
@@ -173,6 +174,9 @@ class ItemExportView(AbstractCSVExportView,
     def get_link_data(self, item):
         return self.request.build_absolute_uri(item.get_absolute_url())
 
+    def get_description_data(self, item):
+        return strip_tags(item.description.strip())
+
     def get_creator_data(self, item):
         return item.creator.username
 
@@ -255,12 +259,12 @@ class ItemExportWithCommentsMixin(VirtualFieldMixin):
             yield self.COMMENT_FMT.format(
                 date=comment.created.isoformat(),
                 username=comment.creator.username,
-                text=comment.comment.strip()
+                text=strip_tags(comment.comment.strip())
             )
 
             for reply in comment.child_comments.all():
                 yield self.REPLY_FMT.format(
                     date=reply.created.isoformat(),
                     username=reply.creator.username,
-                    text=reply.comment.strip()
+                    text=strip_tags(reply.comment.strip())
                 )

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -288,3 +288,21 @@ class ItemExportWithLocationMixin(VirtualFieldMixin):
 
     def get_location_label_data(self, item):
         return getattr(item, 'point_label', '')
+
+
+class ItemExportWithModeratorStatement(VirtualFieldMixin):
+    def get_virtual_fields(self):
+        virtual = super().get_virtual_fields()
+        if 'moderator_feedback' not in virtual:
+            virtual['moderator_feedback'] = _('Moderator feedback')
+        if 'moderator_statement' not in virtual:
+            virtual['moderator_statement'] = _('Moderator statement')
+        return virtual
+
+    def get_moderator_feedback_data(self, item):
+        return item.get_moderator_feedback_display()
+
+    def get_moderator_statement_data(self, item):
+        if item.moderator_statement:
+            return strip_tags(item.moderator_statement.statement.strip())
+        return ''

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
+from django.utils import timezone
 from django.utils.html import strip_tags
 from django.utils.translation import ugettext as _
 from django.views import generic
@@ -91,11 +92,16 @@ class AbstractCSVExportView(generic.View):
 
         return super().dispatch(request, *args, **kwargs)
 
+    def get_filename(self):
+        project = self.module.project
+        filename = '%s_%s.csv' % (project.slug,
+                                  timezone.now().strftime('%Y%m%dT%H%M%S'))
+        return filename
+
     def get(self, request, *args, **kwargs):
         response = HttpResponse(content_type='text/csv; charset=utf-8')
-        response['Content-Disposition'] = (
-            'attachment; filename="ideas.csv"'
-        )
+        response['Content-Disposition'] = \
+            'attachment; filename="%s"' % self.get_filename()
 
         writer = csv.writer(response, lineterminator='\n',
                             quotechar='"', quoting=csv.QUOTE_ALL)

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -290,7 +290,7 @@ class ItemExportWithLocationMixin(VirtualFieldMixin):
         return getattr(item, 'point_label', '')
 
 
-class ItemExportWithModeratorStatement(VirtualFieldMixin):
+class ItemExportWithModeratorFeedback(VirtualFieldMixin):
     def get_virtual_fields(self):
         virtual = super().get_virtual_fields()
         if 'moderator_feedback' not in virtual:

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -88,6 +88,13 @@ class ItemExportView(generic.ListView, VirtualFieldMixin):
         # Finally try to get the fields data as a property
         return getattr(item, name, '')
 
+    def get_header(self):
+        return self._header
+
+    def export_rows(self):
+        for item in self.get_queryset().all():
+            yield [self.get_field_data(item, name) for name in self._names]
+
     def get(self, request, *args, **kwargs):
         response = HttpResponse(content_type='text/csv; charset=utf-8')
         response['Content-Disposition'] = (
@@ -96,11 +103,8 @@ class ItemExportView(generic.ListView, VirtualFieldMixin):
 
         writer = csv.writer(response, lineterminator='\n',
                             quotechar='"', quoting=csv.QUOTE_ALL)
-        writer.writerow(self._header)
-
-        for item in self.get_queryset().all():
-            data = [self.get_field_data(item, name) for name in self._names]
-            writer.writerow(data)
+        writer.writerow(self.get_header())
+        writer.writerows(self.export_rows())
 
         return response
 

--- a/apps/exports/views.py
+++ b/apps/exports/views.py
@@ -1,4 +1,5 @@
 import csv
+from collections import OrderedDict
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldError
@@ -10,8 +11,12 @@ from adhocracy4.projects import mixins as project_mixins
 from adhocracy4.ratings.models import Rating
 
 
-class ItemExportView(project_mixins.ProjectMixin,
-                     generic.ListView):
+class VirtualFieldMixin:
+    def get_virtual_fields(self):
+        return OrderedDict()
+
+
+class ItemExportView(generic.ListView, VirtualFieldMixin):
     fields = None
     exclude = None
     virtual = None
@@ -43,7 +48,7 @@ class ItemExportView(project_mixins.ProjectMixin,
                 names.append(field.attname)
                 header.append(str(field.verbose_name))
 
-        virtual = self.get_virtual_fields({})
+        virtual = self.get_virtual_fields()
         for name, head in virtual.items():
             if name not in names:
                 names.append(name)
@@ -54,8 +59,8 @@ class ItemExportView(project_mixins.ProjectMixin,
     def get_queryset(self):
         return super().get_queryset()
 
-    def get_virtual_fields(self, virtual):
-        virtual = super().get_virtual_fields(virtual)
+    def get_virtual_fields(self):
+        virtual = super().get_virtual_fields()
         if 'link' not in virtual:
             virtual['link'] = _('Link')
         return virtual
@@ -97,9 +102,9 @@ class ItemExportView(project_mixins.ProjectMixin,
         return response
 
 
-class ItemExportWithRatesMixin:
-    def get_virtual_fields(self, virtual):
-        virtual = super().get_virtual_fields(virtual)
+class ItemExportWithRatesMixin(VirtualFieldMixin):
+    def get_virtual_fields(self):
+        virtual = super().get_virtual_fields()
         if 'ratings_positive' not in virtual:
             virtual['ratings_positive'] = _('Positive ratings')
         if 'ratings_negative' not in virtual:
@@ -130,9 +135,9 @@ class ItemExportWithRatesMixin:
         return 0
 
 
-class ItemExportWithCommentCountMixin:
-    def get_virtual_fields(self, virtual):
-        virtual = super().get_virtual_fields(virtual)
+class ItemExportWithCommentCountMixin(VirtualFieldMixin):
+    def get_virtual_fields(self):
+        virtual = super().get_virtual_fields()
         if 'comment_count' not in virtual:
             virtual['comment_count'] = _('Comment count')
         return virtual
@@ -147,11 +152,12 @@ class ItemExportWithCommentCountMixin:
         return 0
 
 
-class ItemExportWithCommentsMixin:
+
+class ItemExportWithCommentsMixin(VirtualFieldMixin):
     COMMENT_FMT = '{date} - {username}\n{text}'
 
-    def get_virtual_fields(self, virtual):
-        virtual = super().get_virtual_fields(virtual)
+    def get_virtual_fields(self):
+        virtual = super().get_virtual_fields()
         if 'comments' not in virtual:
             virtual['comments'] = _('Comments')
         return virtual

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -40,7 +40,7 @@ class IdeaExportView(export_views.ItemExportView,
     fields = ['name', 'description', 'creator', 'created']
 
     def get_queryset(self):
-        return models.Idea.objects \
+        return super().get_queryset() \
             .filter(module=self.module)\
             .annotate_comment_count()\
             .annotate_positive_rating_count()\

--- a/apps/ideas/views.py
+++ b/apps/ideas/views.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.modules import views as module_views
 from apps.contrib import filters
+from apps.exports import views as export_views
 
 from . import forms
 from . import models
@@ -31,9 +32,25 @@ class IdeaFilterSet(a4_filters.DefaultsFilterSet):
         fields = ['category']
 
 
+class IdeaExportView(export_views.ItemExportView,
+                     export_views.ItemExportWithRatesMixin,
+                     export_views.ItemExportWithCommentCountMixin,
+                     export_views.ItemExportWithCommentsMixin):
+    model = models.Idea
+    fields = ['name', 'description', 'creator', 'created']
+
+    def get_queryset(self):
+        return models.Idea.objects \
+            .filter(module=self.module)\
+            .annotate_comment_count()\
+            .annotate_positive_rating_count()\
+            .annotate_negative_rating_count()
+
+
 class IdeaListView(module_views.ItemListView):
     model = models.Idea
     filter_set = IdeaFilterSet
+    exports = [(_('Ideas with comments'), IdeaExportView)]
 
     def get_queryset(self):
         return super().get_queryset().filter(module=self.module) \

--- a/apps/kiezkasse/views.py
+++ b/apps/kiezkasse/views.py
@@ -6,6 +6,7 @@ from adhocracy4.filters import filters as a4_filters
 from adhocracy4.modules import views as module_views
 from adhocracy4.rules import mixins as rules_mixins
 from apps.contrib import filters
+from apps.exports import views as export_views
 
 from . import forms
 from . import models
@@ -33,9 +34,27 @@ class ProposalFilterSet(a4_filters.DefaultsFilterSet):
         fields = ['category']
 
 
+class ProposalExportView(export_views.ItemExportView,
+                         export_views.ItemExportWithRatesMixin,
+                         export_views.ItemExportWithCommentCountMixin,
+                         export_views.ItemExportWithCommentsMixin,
+                         export_views.ItemExportWithLocationMixin):
+    model = models.Proposal
+    fields = ['name', 'description', 'creator', 'created', 'budget',
+              'creator_contribution']
+
+    def get_queryset(self):
+        return super().get_queryset() \
+            .filter(module=self.module)\
+            .annotate_comment_count()\
+            .annotate_positive_rating_count()\
+            .annotate_negative_rating_count()
+
+
 class ProposalListView(module_views.ItemListView):
     model = models.Proposal
     filter_set = ProposalFilterSet
+    exports = [(_('Proposals with comments'), ProposalExportView)]
 
     def dispatch(self, request, **kwargs):
         self.mode = request.GET.get('mode', 'map')

--- a/apps/mapideas/views.py
+++ b/apps/mapideas/views.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.modules import views as module_views
 from apps.contrib import filters
+from apps.exports import views as export_views
 
 from . import forms
 from . import models
@@ -31,9 +32,27 @@ class MapIdeaFilterSet(a4_filters.DefaultsFilterSet):
         fields = ['category']
 
 
+class MapIdeaExportView(export_views.ItemExportView,
+                        export_views.ItemExportWithRatesMixin,
+                        export_views.ItemExportWithCommentCountMixin,
+                        export_views.ItemExportWithCommentsMixin,
+                        export_views.ItemExportWithLocationMixin,
+                        export_views.ItemExportWithModeratorFeedback):
+    model = models.MapIdea
+    fields = ['name', 'description', 'creator', 'created']
+
+    def get_queryset(self):
+        return super().get_queryset() \
+            .filter(module=self.module)\
+            .annotate_comment_count()\
+            .annotate_positive_rating_count()\
+            .annotate_negative_rating_count()
+
+
 class MapIdeaListView(module_views.ItemListView):
     model = models.MapIdea
     filter_set = MapIdeaFilterSet
+    exports = [(_('Ideas with location and comments'), MapIdeaExportView)]
 
     def dispatch(self, request, **kwargs):
         self.mode = request.GET.get('mode', 'map')

--- a/apps/topicprio/views.py
+++ b/apps/topicprio/views.py
@@ -8,6 +8,7 @@ from adhocracy4.modules import views as module_views
 from adhocracy4.rules import mixins as rules_mixins
 from apps.contrib import filters
 from apps.dashboard.mixins import DashboardBaseMixin
+from apps.exports import views as export_views
 
 from . import forms
 from . import models
@@ -31,9 +32,25 @@ class TopicFilterSet(a4_filters.DefaultsFilterSet):
         fields = ['category']
 
 
+class TopicExportView(export_views.ItemExportView,
+                      export_views.ItemExportWithRatesMixin,
+                      export_views.ItemExportWithCommentCountMixin,
+                      export_views.ItemExportWithCommentsMixin):
+    model = models.Topic
+    fields = ['name', 'description', 'creator', 'created']
+
+    def get_queryset(self):
+        return super().get_queryset() \
+            .filter(module=self.module)\
+            .annotate_comment_count()\
+            .annotate_positive_rating_count()\
+            .annotate_negative_rating_count()
+
+
 class TopicListView(module_views.ItemListView):
     model = models.Topic
     filter_set = TopicFilterSet
+    exports = [(_('Topics with comments'), TopicExportView)]
 
     def get_queryset(self):
         return super().get_queryset().filter(module=self.module) \

--- a/meinberlin/settings/base.py
+++ b/meinberlin/settings/base.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = (
     'apps.moderatorfeedback.apps.Config',
     'apps.maps.apps.Config',
     'apps.notifications.apps.Config',
+    'apps.exports.apps.Config',
 
     'apps.account.apps.Config',
     'apps.dashboard.apps.Config',

--- a/meinberlin/urls.py
+++ b/meinberlin/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     url(r'^accounts/social/', include('allauth.socialaccount.urls')),
     url(r'^documents/', include('wagtail.wagtaildocs.urls')),
     url(r'^projects/', include('apps.projects.urls')),
+    url(r'^exports/', include('apps.exports.urls')),
 
     url(r'^ideas/', include('apps.ideas.urls',
                             namespace='meinberlin_ideas')),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,8 @@ register(factories.OrganisationFactory)
 register(factories.PhaseFactory)
 register(factories.ContentTypeFactory)
 register(factories.CommentFactory)
+register(factories.RatingFactory)
+register(factories.ModeratorStatementFactory)
 
 register(a4_factories.ProjectFactory)
 register(a4_factories.ModuleFactory)

--- a/tests/exports/conftest.py
+++ b/tests/exports/conftest.py
@@ -4,6 +4,4 @@ from tests.exports import factories
 from tests.ideas import factories as ideas_factories
 
 register(ideas_factories.IdeaFactory)
-register(factories.RatingFactory)
-register(factories.ModeratorStatementFactory)
 register(factories.ProposalFactory)

--- a/tests/exports/conftest.py
+++ b/tests/exports/conftest.py
@@ -1,0 +1,9 @@
+from pytest_factoryboy import register
+
+from tests.exports import factories
+from tests.ideas import factories as ideas_factories
+
+register(ideas_factories.IdeaFactory)
+register(factories.RatingFactory)
+register(factories.ModeratorStatementFactory)
+register(factories.ProposalFactory)

--- a/tests/exports/factories.py
+++ b/tests/exports/factories.py
@@ -4,25 +4,6 @@ from adhocracy4.test import factories as a4_factories
 from apps.budgeting import models as budgeting_models
 from apps.moderatorfeedback import models as moderatorfeedback_models
 from tests import factories
-from tests.ideas import factories as idea_factories
-
-
-class RatingFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = 'a4ratings.Rating'
-
-    value = 1
-    creator = factory.SubFactory(a4_factories.USER_FACTORY)
-    content_object = factory.SubFactory(idea_factories.IdeaFactory)
-
-
-class ModeratorStatementFactory(factory.django.DjangoModelFactory):
-
-    class Meta:
-        model = moderatorfeedback_models.ModeratorStatement
-
-    statement = factory.Faker('text')
-    creator = factory.SubFactory(factories.UserFactory)
 
 
 class ProposalFactory(factory.django.DjangoModelFactory):
@@ -35,7 +16,8 @@ class ProposalFactory(factory.django.DjangoModelFactory):
     creator = factory.SubFactory(factories.UserFactory)
     module = factory.SubFactory(a4_factories.ModuleFactory)
 
-    moderator_statement = factory.SubFactory(ModeratorStatementFactory)
+    moderator_statement = factory.SubFactory(
+        factories.ModeratorStatementFactory)
     moderator_feedback = moderatorfeedback_models.DEFAULT_CHOICES[0][0]
 
     point_label = factory.Faker('address')

--- a/tests/exports/factories.py
+++ b/tests/exports/factories.py
@@ -1,0 +1,47 @@
+import factory
+
+from adhocracy4.test import factories as a4_factories
+from apps.budgeting import models as budgeting_models
+from apps.moderatorfeedback import models as moderatorfeedback_models
+from tests import factories
+from tests.ideas import factories as idea_factories
+
+
+class RatingFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = 'a4ratings.Rating'
+
+    value = 1
+    creator = factory.SubFactory(a4_factories.USER_FACTORY)
+    content_object = factory.SubFactory(idea_factories.IdeaFactory)
+
+
+class ModeratorStatementFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = moderatorfeedback_models.ModeratorStatement
+
+    statement = factory.Faker('text')
+    creator = factory.SubFactory(factories.UserFactory)
+
+
+class ProposalFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = budgeting_models.Proposal
+
+    name = factory.Faker('name')
+    description = 'Description'
+    creator = factory.SubFactory(factories.UserFactory)
+    module = factory.SubFactory(a4_factories.ModuleFactory)
+
+    moderator_statement = factory.SubFactory(ModeratorStatementFactory)
+    moderator_feedback = moderatorfeedback_models.DEFAULT_CHOICES[0][0]
+
+    point_label = factory.Faker('address')
+    point = {
+        'type': 'Feature',
+        'properties': {},
+        'geometry': {'type': 'Point',
+                     'coordinates': [13.447437286376953, 52.51518602243137]}
+    }

--- a/tests/exports/test_csv_export.py
+++ b/tests/exports/test_csv_export.py
@@ -1,0 +1,33 @@
+import csv
+
+import pytest
+
+from apps.exports import views
+
+
+@pytest.mark.django_db
+def test_csv_export(rf, module):
+    class CSVExport(views.AbstractCSVExportView):
+        def get_filename(self):
+            return 'testexport.csv'
+
+        def get_header(self):
+            return ['head1', 'head2']
+
+        def export_rows(self):
+            return [['regular', 'delimiter,;\t '],
+                    ['escaping"\'', 'newlines\r\n']]
+
+    request = rf.get('/')
+    response = CSVExport.as_view()(request, module=module)
+
+    assert response['Content-Disposition'] == 'attachment; ' \
+                                              'filename="testexport.csv"'
+
+    reader = csv.reader(response.content.decode('utf-8').splitlines(True),
+                        lineterminator='\n', quotechar='"',
+                        quoting=csv.QUOTE_ALL)
+    lines = list(reader)
+    assert lines[0] == ['head1', 'head2']
+    assert lines[1] == ['regular', 'delimiter,;\t ']
+    assert lines[2] == ['escaping"\'', 'newlines\r\n']

--- a/tests/exports/test_item_exports.py
+++ b/tests/exports/test_item_exports.py
@@ -1,0 +1,167 @@
+import pytest
+from django.utils.translation import ugettext as _
+
+from adhocracy4.ratings.models import Rating
+from apps.exports import views
+from apps.ideas import models
+
+
+@pytest.mark.django_db
+def test_item_export(idea_factory, module, rf):
+    request_ = rf.get('/')
+    module_ = module
+
+    class IdeaExportView(views.ItemExportView):
+        model = models.Idea
+        fields = ['name', 'description', 'creator', 'created']
+
+        def get_queryset(self):
+            return models.Idea.objects.order_by('id')
+
+        request = request_
+        module = module_
+
+    idea0 = idea_factory(module=module)
+    idea1 = idea_factory(module=module)
+
+    view = IdeaExportView()
+
+    header = [_('Link')] + [models.Idea._meta.get_field(name).verbose_name
+                            for name in IdeaExportView.fields]
+    assert view.get_header() == header
+
+    rows = list(view.export_rows())
+    assert len(rows) == 2
+
+    assert rows[0][0].endswith(idea0.get_absolute_url())
+    assert rows[0][1] == idea0.name
+    assert rows[0][2] == idea0.description
+    assert rows[0][3] == idea0.creator.username
+    assert rows[0][4] == idea0.created.isoformat()
+
+    assert rows[1][0].endswith(idea1.get_absolute_url())
+    assert rows[1][1] == idea1.name
+    assert rows[1][2] == idea1.description
+    assert rows[1][3] == idea1.creator.username
+    assert rows[1][4] == idea1.created.isoformat()
+
+
+@pytest.mark.django_db
+def test_item_text_cleanup(idea_factory, module, rf):
+    request_ = rf.get('/')
+    module_ = module
+
+    class IdeaExportView(views.ItemExportView):
+        model = models.Idea
+        fields = ['description']
+
+        def get_queryset(self):
+            return models.Idea.objects.order_by('id')
+
+        request = request_
+        module = module_
+
+    idea_factory(module=module, description='  <i>desc</i>ription ')
+
+    view = IdeaExportView()
+    rows = list(view.export_rows())
+    assert rows[0][1] == 'description'
+
+
+@pytest.mark.django_db
+def test_item_rates_mixin(idea, rating_factory):
+    rating_factory(content_object=idea, value=Rating.POSITIVE)
+    rating_factory(content_object=idea, value=Rating.NEGATIVE)
+
+    mixin = views.ItemExportWithRatesMixin()
+
+    virtual = mixin.get_virtual_fields({})
+    assert 'ratings_positive' in virtual
+    assert 'ratings_negative' in virtual
+
+    # Test explicit count
+    assert mixin.get_ratings_positive_data({}) == 0
+    assert mixin.get_ratings_positive_data(idea) == 1
+    assert mixin.get_ratings_negative_data({}) == 0
+    assert mixin.get_ratings_negative_data(idea) == 1
+
+    # Test annotated counting
+    idea = models.Idea.objects \
+        .annotate_positive_rating_count() \
+        .annotate_negative_rating_count() \
+        .first()
+    assert mixin.get_ratings_positive_data(idea) == 1
+    assert mixin.get_ratings_negative_data(idea) == 1
+
+
+@pytest.mark.django_db
+def test_item_comment_count_mixin(idea, comment_factory):
+    comment_factory(content_object=idea)
+    comment = comment_factory(content_object=idea)
+    comment_factory(content_object=comment)
+
+    mixin = views.ItemExportWithCommentCountMixin()
+
+    virtual = mixin.get_virtual_fields({})
+    assert 'comment_count' in virtual
+
+    # Test explicit count
+    assert mixin.get_comment_count_data({}) == 0
+    assert mixin.get_comment_count_data(idea) == 3
+
+    # Test annotated counting
+    idea = models.Idea.objects \
+        .annotate_comment_count() \
+        .first()
+    assert mixin.get_comment_count_data(idea) == 3
+
+
+@pytest.mark.django_db
+def test_item_comments_mixin(idea, comment_factory):
+    comment = comment_factory(comment='comment', content_object=idea)
+    comment_factory(comment='reply to comment', content_object=comment)
+    comment_factory(comment='<i>comment</i>2   ', content_object=idea)
+
+    mixin = views.ItemExportWithCommentsMixin()
+
+    virtual = mixin.get_virtual_fields({})
+    assert 'comments' in virtual
+
+    assert mixin.get_comments_data({}) == ''
+    data = mixin.get_comments_data(idea)
+    assert 'comment' in data
+    assert 'reply to comment' in data
+    assert 'comment2' in data
+    assert '<i>comment</i>' not in data
+    assert '2   ' not in data
+
+
+@pytest.mark.django_db
+def test_item_location_mixin(proposal):
+    mixin = views.ItemExportWithLocationMixin()
+
+    virtual = mixin.get_virtual_fields({})
+    assert 'location' in virtual
+    assert 'location_label' in virtual
+
+    assert mixin.get_location_data({}) == ''
+    assert mixin.get_location_label_data({}) == ''
+
+    lon, lat = proposal.point['geometry']['coordinates']
+    assert mixin.get_location_data(proposal) == '%s, %s' % (lon, lat)
+    assert mixin.get_location_label_data(proposal) == proposal.point_label
+
+
+@pytest.mark.django_db
+def test_moderator_feedback_mixin(proposal):
+    mixin = views.ItemExportWithModeratorFeedback()
+
+    virtual = mixin.get_virtual_fields({})
+    assert 'moderator_feedback' in virtual
+    assert 'moderator_statement' in virtual
+
+    assert mixin.get_moderator_feedback_data(proposal)\
+        == proposal.get_moderator_feedback_display()
+
+    assert mixin.get_moderator_statement_data(proposal)\
+        == proposal.moderator_statement.statement

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -117,3 +117,20 @@ class CommentFactory(factory.django.DjangoModelFactory):
 
     comment = factory.Faker('text')
     creator = factory.SubFactory(UserFactory)
+
+
+class RatingFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = 'a4ratings.Rating'
+
+    value = 1
+    creator = factory.SubFactory(UserFactory)
+
+
+class ModeratorStatementFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = 'meinberlin_moderatorfeedback.ModeratorStatement'
+
+    statement = factory.Faker('text')
+    creator = factory.SubFactory(UserFactory)


### PR DESCRIPTION
The export framework is designed with extensibility in mind, while the current implementation only allows for exporting "anything which looks like a item list"

Furthermore until now it is only allowed to have on export view per project. In the future it may be possible to select different exports for a project. For example for different modules.