### PR TITLE
Fix project dispatcher for bplan projects

### DIFF
--- a/apps/contrib/views.py
+++ b/apps/contrib/views.py
@@ -38,7 +38,8 @@ class ProjectContextDispatcher(generic.base.ContextMixin, generic.View):
         return not object_project or object_project == self.project
 
     def _get_object_project(self):
-        if hasattr(self, 'get_object'):
+        if hasattr(self, 'get_object') \
+                and not isinstance(self, generic.CreateView):
             try:
                 object = self.get_object()
                 if hasattr(object, 'project'):


### PR DESCRIPTION
CreateViews provide the a failing get_object method which should not be called when validating the object project.