### PR TITLE
Extend package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,16 @@
 {
   "name": "a4-meinberlin",
+  "version": "0.0.1-dev.1",
+  "license": "AGPL-3.0+",
+  "description": "Frontend for meinBerlin",
+  "author": {
+    "name": "Liquid Democracy e.V.",
+    "email": "info@liqd.de",
+    "url": "https://liqd.net"
+  },
+  "files": [
+    "meinberlin"
+  ],
   "repository": "https://github.com/liqd/a4-meinberlin.git",
   "dependencies": {
     "autoprefixer": "7.1.1",


### PR DESCRIPTION
The information is mostly copied from a4-core. It is useful in case we
ever publish this project to npm.