### PR TITLE
user activity stream

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -18,6 +18,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html.py:15
+msgid "Search"
+msgstr "Suchen"
+
 #: adhocracy4/images/templates/a4images/image_upload_widget.html.py:8
 #: adhocracy4/images/templates/a4images/image_upload_widget.html.py:8
 #: meinberlin/templates/a4images/image_upload_widget.html.py:10
@@ -279,6 +283,12 @@ msgid "Profile"
 msgstr "Profil"
 
 #: meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html.py:30
+#: meinberlin/apps/account/templates/meinberlin_account/actions.html.py:5
+#: meinberlin/apps/account/templates/meinberlin_account/actions.html.py:8
+msgid "Activities"
+msgstr "Aktivitäten"
+
+#: meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html.py:37
 #: meinberlin/templates/account/password_change.html.py:5
 #: meinberlin/templates/account/password_change.html.py:42
 #: meinberlin/templates/account/password_reset_from_key.html.py:20

--- a/meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html
@@ -24,6 +24,13 @@
                         </a>
                     </li>
                     <li class="dashboard-nav__page">
+                        <a href="{% url 'account_actions' %}"
+                           class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == "account_actions" %}is-active{% endif %}">
+                            <i class="fa fa-star" aria-hidden="true"></i>
+                            {% trans 'Activities' %}
+                        </a>
+                    </li>
+                    <li class="dashboard-nav__page">
                         <a href="{% url 'account_change_password' %}"
                            class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == "account_change_password" %}is-active{% endif %}">
                             <i class="fa fa-lock" aria-hidden="true"></i>

--- a/meinberlin/apps/account/templates/meinberlin_account/actions.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/actions.html
@@ -1,0 +1,17 @@
+{% extends "meinberlin_account/account_dashboard.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans 'Activities' %} &mdash; {{ block.super }}{% endblock %}
+
+{% block dashboard_content %}
+    <h1>{% trans 'Activities' %}</h1>
+
+    <div>
+        {% for action in action_list %}
+            {% include 'meinberlin_actions/includes/action.html' with action=action %}
+        {% endfor %}
+    </div>
+
+    {% include "meinberlin_contrib/includes/pagination.html" %}
+{% endblock %}

--- a/meinberlin/apps/account/templates/meinberlin_account/actions.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/actions.html
@@ -6,6 +6,7 @@
 
 {% block dashboard_content %}
     <h1>{% trans 'Activities' %}</h1>
+    <p>{% trans 'Here you can find any actions that have happened in projects you are following.' %}</p>
 
     <div>
         {% for action in action_list %}

--- a/meinberlin/apps/account/templates/meinberlin_account/profile.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/profile.html
@@ -4,7 +4,7 @@
 
 {% block title %}{% trans 'Your user profile' %} &mdash; {{ block.super }}{% endblock %}
 {% block dashboard_content %}
-<h1 class="gray-divider dashboard-title">{% trans 'Your profile' %}</h1>
+<h1>{% trans 'Your profile' %}</h1>
 
 <div class="general-form">
     <form enctype="multipart/form-data" action="{{ request.path }}" method="post" class="l-col-2">

--- a/meinberlin/apps/account/urls.py
+++ b/meinberlin/apps/account/urls.py
@@ -9,4 +9,7 @@ urlpatterns = [
     url(r'^profile/$',
         views.ProfileUpdateView.as_view(),
         name='account_profile'),
+    url(r'^actions/$',
+        views.ProfileActionsView.as_view(),
+        name='account_actions'),
 ]

--- a/meinberlin/apps/account/views.py
+++ b/meinberlin/apps/account/views.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from django.views.generic.base import RedirectView
 
+from adhocracy4.actions.models import Action
 from meinberlin.apps.users.models import User
 
 from . import forms
@@ -29,3 +30,13 @@ class ProfileUpdateView(SuccessMessageMixin,
 
     def get_success_url(self):
         return self.request.path
+
+
+class ProfileActionsView(generic.ListView):
+
+    model = Action
+    paginate_by = 10
+    template_name = 'meinberlin_account/actions.html'
+
+    def get_queryset(self):
+        return super().get_queryset().exclude_updates()

--- a/meinberlin/apps/account/views.py
+++ b/meinberlin/apps/account/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from django.views.generic.base import RedirectView
+from rules.contrib.views import LoginRequiredMixin
 
 from adhocracy4.actions.models import Action
 from adhocracy4.follows.models import Follow
@@ -19,6 +20,7 @@ class AccountView(RedirectView):
 
 
 class ProfileUpdateView(SuccessMessageMixin,
+                        LoginRequiredMixin,
                         generic.UpdateView):
 
     model = User
@@ -33,7 +35,8 @@ class ProfileUpdateView(SuccessMessageMixin,
         return self.request.path
 
 
-class ProfileActionsView(generic.ListView):
+class ProfileActionsView(LoginRequiredMixin,
+                         generic.ListView):
 
     model = Action
     paginate_by = 10

--- a/meinberlin/apps/account/views.py
+++ b/meinberlin/apps/account/views.py
@@ -6,7 +6,6 @@ from django.views.generic.base import RedirectView
 from rules.contrib.views import LoginRequiredMixin
 
 from adhocracy4.actions.models import Action
-from adhocracy4.follows.models import Follow
 from meinberlin.apps.users.models import User
 
 from . import forms
@@ -44,7 +43,7 @@ class ProfileActionsView(LoginRequiredMixin,
 
     def get_queryset(self):
         user = get_object_or_404(User, pk=self.request.user.id)
-        follows = Follow.objects.filter(creator=user, enabled=True)
-        projects = [follow.project for follow in follows]
-        return super().get_queryset().exclude_updates()\
-            .filter(project__in=projects)
+        qs = super().get_queryset()
+        qs = qs.filter(project__follow__creator=user,
+                       project__follow__enabled=True)
+        return qs.exclude_updates()

--- a/meinberlin/apps/account/views.py
+++ b/meinberlin/apps/account/views.py
@@ -5,6 +5,7 @@ from django.views import generic
 from django.views.generic.base import RedirectView
 
 from adhocracy4.actions.models import Action
+from adhocracy4.follows.models import Follow
 from meinberlin.apps.users.models import User
 
 from . import forms
@@ -39,4 +40,8 @@ class ProfileActionsView(generic.ListView):
     template_name = 'meinberlin_account/actions.html'
 
     def get_queryset(self):
-        return super().get_queryset().exclude_updates()
+        user = get_object_or_404(User, pk=self.request.user.id)
+        follows = Follow.objects.filter(creator=user, enabled=True)
+        projects = [follow.project for follow in follows]
+        return super().get_queryset().exclude_updates()\
+            .filter(project__in=projects)

--- a/meinberlin/apps/actions/templates/meinberlin_actions/blocks/platform_activity_block.html
+++ b/meinberlin/apps/actions/templates/meinberlin_actions/blocks/platform_activity_block.html
@@ -1,41 +1,7 @@
-{% load i18n %}
-
 <div class="block block--bordered l-center-6">
     <h2>{{ self.heading }}</h2>
 
     {% for action in actions %}
-        <div class="action">
-            <i class="fa fa-{{ action.icon }} action__icon" aria-hidden="true"></i>
-            <div class="action__main">
-                <div class="action__line">
-                    {% if action.type == 'comment' and action.verb == 'add' %}
-                        {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username comment_url=action.obj.get_absolute_url %}{{ name }} added a new <a href="{{ comment_url }}">comment</a>{% endblocktrans%}
-                    {% elif action.type == 'comment' and action.verb == 'update' %}
-                        {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username comment_url=action.obj.get_absolute_url %}{{ name }} updated a <a href="{{ comment_url }}">comment</a>{% endblocktrans%}
-                    {% elif action.type == 'item' and action.verb == 'add' %}
-                        {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username item_url=action.obj.get_absolute_url %}{{ name }} added a new <a href="{{ item_url }}">item</a>{% endblocktrans%}
-                    {% elif action.type == 'item' and action.verb == 'update' %}
-                        {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username item_url=action.obj.get_absolute_url %}{{ name }} updated an <a href="{{ item_url }}">item</a>{% endblocktrans%}
-                    {% elif action.type == 'project' and action.verb == 'start' %}
-                        {% trans "New participation started" %}
-                    {% elif action.type == 'phase' and action.verb == 'schedule' %}
-                        {% trans "Participation phase will end soon:" %}
-                        {{ action.obj.name }}
-                    {% else %}
-                        {{ action }}
-                    {% endif %}
-                </div>
-                <div class="action__line">
-                    {% blocktrans with url=action.project.get_absolute_url name=action.project.name %}on <a href="{{ url }}">{{ name }}</a>{% endblocktrans %}
-                </div>
-                <div class="action__date">
-                    <time datetime="{{ action.timestamp|date:'Y-m-d h:i' }}"
-                          title="{{ action.timestamp|date:'DATETIME_FORMAT' }}"
-                          class="relative">
-                        {{ action.timestamp|date:'d.m.Y' }}
-                    </time>
-                </div>
-            </div>
-        </div>
+        {% include 'meinberlin_actions/includes/action.html' with action=action %}
     {% endfor %}
 </div>

--- a/meinberlin/apps/actions/templates/meinberlin_actions/includes/action.html
+++ b/meinberlin/apps/actions/templates/meinberlin_actions/includes/action.html
@@ -1,0 +1,35 @@
+{% load i18n %}
+
+<div class="action">
+    <i class="fa fa-{{ action.icon }} action__icon" aria-hidden="true"></i>
+    <div class="action__main">
+        <div class="action__line">
+            {% if action.type == 'comment' and action.verb == 'add' %}
+                {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username comment_url=action.obj.get_absolute_url %}{{ name }} added a new <a href="{{ comment_url }}">comment</a>{% endblocktrans %}
+            {% elif action.type == 'comment' and action.verb == 'update' %}
+                {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username comment_url=action.obj.get_absolute_url %}{{ name }} updated a <a href="{{ comment_url }}">comment</a>{% endblocktrans %}
+            {% elif action.type == 'item' and action.verb == 'add' %}
+                {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username item_url=action.obj.get_absolute_url %}{{ name }} added a new <a href="{{ item_url }}">item</a>{% endblocktrans %}
+            {% elif action.type == 'item' and action.verb == 'update' %}
+                {% blocktrans with url=action.actor.get_absolute_url name=action.actor.username item_url=action.obj.get_absolute_url %}{{ name }} updated an <a href="{{ item_url }}">item</a>{% endblocktrans %}
+            {% elif action.type == 'project' and action.verb == 'start' %}
+                {% trans "New participation started" %}
+            {% elif action.type == 'phase' and action.verb == 'schedule' %}
+                {% trans "Participation phase will end soon:" %}
+                {{ action.obj.name }}
+            {% else %}
+                {{ action }}
+            {% endif %}
+        </div>
+        <div class="action__line">
+            {% blocktrans with url=action.project.get_absolute_url name=action.project.name %}on <a href="{{ url }}">{{ name }}</a>{% endblocktrans %}
+        </div>
+        <div class="action__date">
+            <time datetime="{{ action.timestamp|date:'Y-m-d h:i' }}"
+                  title="{{ action.timestamp|date:'DATETIME_FORMAT' }}"
+                  class="relative">
+                {{ action.timestamp|date:'d.m.Y' }}
+            </time>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This adds an activity stream to the user dashboard. The purpose is *not* to be a public record of a user's activities, but to allow users to see what happened in the projects (or other resources) they follow.

Note:

-   Someone should double check that no private information is leaking via actions (e.g. private projects).
-   If I am not logged in the page currently throws an error. I did not find out why.
-   The UI still needs some work.
-   Filtering actions by follows could be moved to core. But it will also get more complicated once it is possible to follow resources other than projects.