### PR TITLE
initiator request

### DIFF
--- a/meinberlin/apps/initiators/apps.py
+++ b/meinberlin/apps/initiators/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = 'meinberlin.apps.initiators'
+    label = 'meinberlin_initiators'

--- a/meinberlin/apps/initiators/emails.py
+++ b/meinberlin/apps/initiators/emails.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+
+from meinberlin.apps.contrib.emails import Email
+
+
+class InitiatorRequest(Email):
+    template_name = 'meinberlin_initiators/emails/initiator_request'
+
+    def get_receivers(self):
+        return [settings.CONTACT_EMAIL]
+
+    def get_context(self):
+        context = super().get_context()
+        context['organitaion_name'] = self.kwargs.get('organisation_name')
+        context['phone'] = self.kwargs.get('phone')
+        return context

--- a/meinberlin/apps/initiators/forms.py
+++ b/meinberlin/apps/initiators/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+
+class InitiatorRequestForm(forms.Form):
+    organisation_name = forms.CharField(label=_('Name of the organisation'))
+    phone = forms.CharField(label=_('Phone number'))

--- a/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.de.email
+++ b/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.de.email
@@ -26,4 +26,4 @@ Datum der Nutzerregistrierung auf meinBerlin
 {% endblock %}
 
 {% block cta_label %}Zur Administration{% endblock %}
-{% block cta_url %}https://mein.berlin.de/django-admin{% endblock %}
+{% block cta_url %}{{ email.get_host }}{% url 'admin:index' %}{% endblock %}

--- a/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.de.email
+++ b/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.de.email
@@ -1,0 +1,29 @@
+{% extends 'email_base.'|add:part_type %}
+{% load wagtailcore_tags %}
+
+{% block subject %}Neue Initiatorenanfrage von {{ user.username }}{% endblock %}
+
+{% block headline %}Neue Initiatorenanfrage von {{ user.username }}{% endblock %}
+
+{% block content %}
+{{ user.username }} möchte zur Initator*in gemacht werden.
+
+Name
+{{ user.username }}
+
+Name der Behörde
+{{ organisation_name }}
+
+Dienstliche E-Mail-Adresse
+{{ user.email }}
+
+Telefonnummer
+{{ phone }}
+
+Datum der Nutzerregistrierung auf meinBerlin
+{{ user.date_joined }}
+
+{% endblock %}
+
+{% block cta_label %}Zur Administration{% endblock %}
+{% block cta_url %}https://mein.berlin.de/django-admin{% endblock %}

--- a/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.en.email
+++ b/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.en.email
@@ -1,0 +1,29 @@
+{% extends 'email_base.'|add:part_type %}
+{% load wagtailcore_tags %}
+
+{% block subject %}New initiator request by {{ user.username }}{% endblock %}
+
+{% block headline %}New initiator request by {{ user.username }}{% endblock %}
+
+{% block content %}
+{{ user.username }} wants to become an initiator.
+
+Name
+{{ user.username }}
+
+Name of the Organisation
+{{ organisation_name }}
+
+Email address
+{{ user.email }}
+
+Phone number
+{{ phone }}
+
+Date of registration on meinBerlin
+{{ user.date_joined }}
+
+{% endblock %}
+
+{% block cta_label %}Go to Administration{% endblock %}
+{% block cta_url %}https://mein.berlin.de/django-admin{% endblock %}

--- a/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.en.email
+++ b/meinberlin/apps/initiators/templates/meinberlin_initiators/emails/initiator_request.en.email
@@ -26,4 +26,4 @@ Date of registration on meinBerlin
 {% endblock %}
 
 {% block cta_label %}Go to Administration{% endblock %}
-{% block cta_url %}https://mein.berlin.de/django-admin{% endblock %}
+{% block cta_url %}{{ email.get_host }}{% url 'admin:index' %}{% endblock %}

--- a/meinberlin/apps/initiators/templates/meinberlin_initiators/request.html
+++ b/meinberlin/apps/initiators/templates/meinberlin_initiators/request.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block title %}{% trans 'Registration for Initiators' %} &mdash; {{ block.super }}{% endblock %}
+
 {% block content %}
     <div class="l-wrapper">
         <div class="l-center-6">

--- a/meinberlin/apps/initiators/templates/meinberlin_initiators/request.html
+++ b/meinberlin/apps/initiators/templates/meinberlin_initiators/request.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+    <div class="l-wrapper">
+        <div class="l-center-6">
+            <h1>{% trans 'Registration for Initiators' %}</h1>
+
+            <p>{% trans 'If you want to initiate new participation projects on meinBerlin, please use this form to request the required access permissions.' %}</p>
+
+            <form action="" method="post">
+                {% csrf_token %}
+                {{ form }}
+                <input type="submit" value="{% trans 'Send request' %}" class="button button--primary" />
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/meinberlin/apps/initiators/templates/meinberlin_initiators/request.html
+++ b/meinberlin/apps/initiators/templates/meinberlin_initiators/request.html
@@ -10,11 +10,17 @@
 
             <p>{% trans 'If you want to initiate new participation projects on meinBerlin, please use this form to request the required access permissions.' %}</p>
 
-            <form action="" method="post">
+            <form enctype="multipart/form-data" action="{{ request.path }}" method="post" >
                 {% csrf_token %}
-                {{ form }}
-                <input type="submit" value="{% trans 'Send request' %}" class="button button--primary" />
+                {% include 'meinberlin_contrib/includes/form_field.html' with field=form.organisation_name %}
+
+                {% include 'meinberlin_contrib/includes/form_field.html' with field=form.phone %}
+
+                <div class="u-spacer-bottom">
+                    <button type="submit" class="button button--primary">{% trans 'Send request' %}</button>
+                </div>
             </form>
+            {{ form.media }}
         </div>
     </div>
 {% endblock %}

--- a/meinberlin/apps/initiators/urls.py
+++ b/meinberlin/apps/initiators/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^request/$',
+        views.InitiatorRequestView.as_view(),
+        name='initiator_request'),
+]

--- a/meinberlin/apps/initiators/views.py
+++ b/meinberlin/apps/initiators/views.py
@@ -1,0 +1,25 @@
+from django.contrib import messages
+from django.utils.translation import ugettext_lazy as _
+from django.views.generic.edit import FormView
+
+from adhocracy4.rules import mixins as rules_mixins
+
+from . import emails
+from . import forms
+
+
+class InitiatorRequestView(rules_mixins.PermissionRequiredMixin,
+                           FormView):
+
+    template_name = 'meinberlin_initiators/request.html'
+    permission_required = 'is_authenticated'
+    form_class = forms.InitiatorRequestForm
+    success_url = '/'
+
+    def form_valid(self, form):
+        emails.InitiatorRequest.send(self.request.user, **form.cleaned_data)
+        messages.add_message(
+            self.request,
+            messages.SUCCESS,
+            _('Request was send.'))
+        return super().form_valid(form)

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -83,6 +83,7 @@ INSTALLED_APPS = (
 
     'meinberlin.apps.account.apps.Config',
     'meinberlin.apps.dashboard.apps.Config',
+    'meinberlin.apps.initiators.apps.Config',
 
     'meinberlin.apps.actions.apps.Config',
     'meinberlin.apps.bplan.apps.Config',

--- a/meinberlin/config/urls.py
+++ b/meinberlin/config/urls.py
@@ -47,6 +47,8 @@ urlpatterns = [
     url(r'^account/', include('meinberlin.apps.account.urls')),
     url(r'^embed/', include('meinberlin.apps.embed.urls')),
     url(r'^profile/', include('meinberlin.apps.users.urls')),
+    url(r'^initiators/', include('meinberlin.apps.initiators.urls',
+                                 namespace='meinberlin_initiators')),
 
     url(r'^admin/', include('wagtail.wagtailadmin.urls')),
     url(r'^accounts/', include('allauth.urls')),


### PR DESCRIPTION
This adds a simple form at http://localhost:8000/initiators/request/ which can be used by regular users to request initiator permissions. An email will be send to `settings.CONTACT_EMAIL`.

Note that currently there is only an informal `organisation_name` field. We could change this to a select box of all existing organisations. This would provide us with enough information to allow admins to accept the request with a single click of a button. I am not sure though whether that is desirable/required.