### PR TITLE
attempt to fix flex-box issue for IE

### DIFF
--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -117,12 +117,13 @@ select {
 }
 
 .input-addon__input {
-    flex: 1;
+    flex-grow: 1;
 }
 
 .input-addon__before,
 .input-addon__after {
-    flex: 0;
+    flex-grow: 0;
+    width: auto !important;
 }
 
 .input-addon__input,

--- a/meinberlin/templates/a4filters/widgets/free_text_filter.html
+++ b/meinberlin/templates/a4filters/widgets/free_text_filter.html
@@ -7,7 +7,9 @@
             <input type="hidden" name="{{ par_name }}" value="{{ value }}">
         {% endif %}
     {% endfor %}
-    <button class="input-addon__after button button--light" type="submit" title="{% trans 'Search' %}">
-        <i class="fa fa-search" aria-label="{% trans 'Search' %}"></i>
-    </button>
+    <div class="input-addon__after">
+        <button class="button button--light" type="submit" title="{% trans 'Search' %}">
+            <i class="fa fa-search" aria-label="{% trans 'Search' %}"></i>
+        </button>
+    </div>
 </form>


### PR DESCRIPTION
This is more a basis for discussion than a proposal. Flexbox is behaving rather weird on IE, the original problem is, that IE11 translates `flex: 1` differently than other browsers (https://github.com/philipwalton/flexbugs#6-the-default-flex-value-has-changed). However, just using the longer hand syntax doesn't fix the issue because the user agent seems to have a problem with box-sizing and width calculations in general (either both the input and the button are too short or the input is longer than it should be and hides the button behind the next dropdown). We also can't use `flex-basis: auto` because we have set all form elements to 100% width which will also apply to those and create some overlapping of dropdowns (mostly on IE, though, too).