### PR TITLE
Update to django 1.11 middlewares and disable debug toolbar

### DIFF
--- a/meinberlin/apps/embed/middleware.py
+++ b/meinberlin/apps/embed/middleware.py
@@ -1,7 +1,8 @@
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.http import urlquote
 
 
-class AjaxPathMiddleware(object):
+class AjaxPathMiddleware(MiddlewareMixin):
     """Append request path as a header.
 
     In an ajax request, redirects are handled implicitly, so it it not possible

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -100,7 +100,7 @@ INSTALLED_APPS = (
     'meinberlin.apps.topicprio.apps.Config',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/meinberlin/config/settings/dev.py
+++ b/meinberlin/config/settings/dev.py
@@ -9,16 +9,17 @@ for template_engine in TEMPLATES:
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'qid$h1o8&wh#p(j)lifis*5-rf@lbiy8%^3l4x%@b$z(tli@ab'
 
-
-try:
-    import debug_toolbar
-except ImportError:
-    pass
-else:
-    INSTALLED_APPS += ('debug_toolbar',)
-    MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
-
-    INTERNAL_IPS = ('127.0.0.1', 'localhost')
+# FIXME: reenable after upgrade to wagtail 1.12
+# see: https://github.com/jazzband/django-debug-toolbar/issues/950
+# try:
+#     import debug_toolbar
+# except ImportError:
+#     pass
+# else:
+#     INSTALLED_APPS += ('debug_toolbar',)
+#     MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+#
+#     INTERNAL_IPS = ('127.0.0.1', 'localhost')
 
 try:
     from .local import *

--- a/meinberlin/config/settings/dev.py
+++ b/meinberlin/config/settings/dev.py
@@ -16,7 +16,7 @@ except ImportError:
     pass
 else:
     INSTALLED_APPS += ('debug_toolbar',)
-    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+    MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
     INTERNAL_IPS = ('127.0.0.1', 'localhost')
 


### PR DESCRIPTION
* Update to django 1.11 middlewares (see https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)
* Disable django debug toolbar until wagtail 1.12 is released (see jazzband/django-debug-toolbar#950 for reference)

