### PR TITLE
Add dashboard error count and set form fields to required for published projects

### DIFF
--- a/meinberlin/apps/dashboard2/__init__.py
+++ b/meinberlin/apps/dashboard2/__init__.py
@@ -1,4 +1,7 @@
 from .contents import content
 from .components import DashboardComponent
+from .components import ModuleFormComponent
+from .components import ProjectFormComponent
 
-__all__ = ['content', 'DashboardComponent']
+__all__ = ['content', 'DashboardComponent', 'ModuleFormComponent',
+           'ProjectFormComponent']

--- a/meinberlin/apps/dashboard2/__init__.py
+++ b/meinberlin/apps/dashboard2/__init__.py
@@ -1,7 +1,9 @@
 from .contents import content
 from .components import DashboardComponent
 from .components import ModuleFormComponent
+from .components import ModuleFormSetComponent
 from .components import ProjectFormComponent
 
-__all__ = ['content', 'DashboardComponent', 'ModuleFormComponent',
+__all__ = ['content', 'DashboardComponent',
+           'ModuleFormComponent', 'ModuleFormSetComponent',
            'ProjectFormComponent']

--- a/meinberlin/apps/dashboard2/components.py
+++ b/meinberlin/apps/dashboard2/components.py
@@ -68,7 +68,10 @@ class ProjectFormComponent(DashboardComponent):
         )
 
     def get_progress(self, object):
-        required_fields = self._get_required_fields(self.form_class, object)
+        required_fields = self.form_class.get_required_fields()
+        if required_fields == '__all__':
+            required_fields = self._get_all_required_fields(self.form_class,
+                                                            object)
 
         if not required_fields:
             return 0, 0
@@ -76,20 +79,15 @@ class ProjectFormComponent(DashboardComponent):
         return self._get_progress_for_object(object, required_fields)
 
     @staticmethod
-    def _get_required_fields(form_class, model):
-        meta = getattr(form_class, 'Meta', None)
-        required_fields = getattr(meta, 'required', [])
-
-        if required_fields == '__all__':
-            required_fields = []
-            for field_name in form_class.base_fields.keys():
-                try:
-                    field = model._meta.get_field(field_name)
-                    if field.concrete:
-                        required_fields.append(field_name)
-                except FieldDoesNotExist:
-                    pass
-
+    def _get_all_required_fields(form_class, model):
+        required_fields = []
+        for field_name in form_class.base_fields.keys():
+            try:
+                field = model._meta.get_field(field_name)
+                if field.concrete:
+                    required_fields.append(field_name)
+            except FieldDoesNotExist:
+                pass
         return required_fields
 
     @staticmethod
@@ -122,8 +120,10 @@ class ModuleFormSetComponent(ModuleFormComponent):
         child_form_class = self.form_class.form
         child_model = child_form_class._meta.model
 
-        required_fields = self._get_required_fields(child_form_class,
-                                                    child_model)
+        required_fields = self.form_class.get_required_fields()
+        if required_fields == '__all__':
+            required_fields = self._get_all_required_fields(child_form_class,
+                                                            child_model)
 
         if not required_fields:
             return 0, 0

--- a/meinberlin/apps/dashboard2/components.py
+++ b/meinberlin/apps/dashboard2/components.py
@@ -80,6 +80,7 @@ class ProjectFormComponent(DashboardComponent):
     def get_view(self):
         from .views import ProjectComponentFormView
         return ProjectComponentFormView.as_view(
+            component=self,
             title=self.form_title,
             form_class=self.form_class,
             form_template_name=self.form_template_name
@@ -140,6 +141,7 @@ class ModuleFormComponent(ProjectFormComponent):
     def get_view(self):
         from .views import ModuleComponentFormView
         return ModuleComponentFormView.as_view(
+            component=self,
             title=self.form_title,
             form_class=self.form_class,
             form_template_name=self.form_template_name

--- a/meinberlin/apps/dashboard2/components.py
+++ b/meinberlin/apps/dashboard2/components.py
@@ -68,25 +68,39 @@ class ProjectFormComponent(DashboardComponent):
         )
 
     def get_progress(self, object):
-        meta = getattr(self.form_class, 'Meta', None)
-        required_fields = getattr(meta, 'required', None)
+        required_fields = self._get_required_fields(self.form_class, object)
 
         if not required_fields:
             return 0, 0
 
-        if required_fields == '__all__':
-            required_fields = list(self.form_class.base_fields)
+        return self._get_progress_for_object(object, required_fields)
 
+    @staticmethod
+    def _get_required_fields(form_class, model):
+        meta = getattr(form_class, 'Meta', None)
+        required_fields = getattr(meta, 'required', [])
+
+        if required_fields == '__all__':
+            required_fields = []
+            for field_name in form_class.base_fields.keys():
+                try:
+                    field = model._meta.get_field(field_name)
+                    if field.concrete:
+                        required_fields.append(field_name)
+                except FieldDoesNotExist:
+                    pass
+
+        return required_fields
+
+    @staticmethod
+    def _get_progress_for_object(object, required_fields):
         num_valid = num_required = len(required_fields)
         for field_name in required_fields:
-            try:
-                field = object._meta.get_field(field_name)
-                value = getattr(object, field_name, None)
+            field = object._meta.get_field(field_name)
+            value = getattr(object, field_name, None)
 
-                if value is None or value in field.empty_values:
-                    num_valid = num_valid - 1
-            except FieldDoesNotExist:
-                pass
+            if value is None or value in field.empty_values:
+                num_valid = num_valid - 1
 
         return num_valid, num_required
 
@@ -100,3 +114,30 @@ class ModuleFormComponent(ProjectFormComponent):
             form_class=self.form_class,
             form_template_name=self.form_template_name
         )
+
+
+class ModuleFormSetComponent(ModuleFormComponent):
+
+    def get_progress(self, parent):
+        child_form_class = self.form_class.form
+        child_model = child_form_class._meta.model
+
+        required_fields = self._get_required_fields(child_form_class,
+                                                    child_model)
+
+        if not required_fields:
+            return 0, 0
+
+        # Attention: this could break if additional args
+        # would be expected by the formset.
+        formset = self.form_class(instance=parent)
+
+        num_valid = 0
+        num_required = 0
+        for child in formset.queryset:
+            num_valid_obj, num_required_obj = \
+                self._get_progress_for_object(child, required_fields)
+            num_valid = num_valid + num_valid_obj
+            num_required = num_required + num_required_obj
+
+        return num_valid, num_required

--- a/meinberlin/apps/dashboard2/components.py
+++ b/meinberlin/apps/dashboard2/components.py
@@ -24,6 +24,10 @@ class DashboardComponent:
 
     - get_view(): view function
       Return a view function which takes menu and project/module as kwargs
+
+    - get_progress(): (int, int)
+      Return a tuple containing the number of valid "input fields" as first
+      element and the total number of "input fields" as the second.
     """
 
     app_label = None
@@ -50,6 +54,20 @@ class DashboardComponent:
 
 
 class ProjectFormComponent(DashboardComponent):
+    """Abstract interface for project dashboard components based on forms.
+
+    This component is intended to be used with ProjectDashboardForm's.
+    It will always return a ProjectComponentFormView
+    and provides a default implementation for get_progress.
+
+    Required properties:
+    - menu_label: str
+      This label is always returned regardless of project state
+    - form_title: str
+      This title is shown on top of the rendered form
+    - form_class: ProjectDashboardForm
+      This is the form class used to render from the ProjectComponentFormView
+    """
 
     menu_label = ''
     form_title = ''
@@ -104,6 +122,20 @@ class ProjectFormComponent(DashboardComponent):
 
 
 class ModuleFormComponent(ProjectFormComponent):
+    """Abstract interface for module dashboard components based on forms.
+
+    This component is intended to be used with ModuleDashboardForm's.
+    It will always return a ModuleComponentFormView
+    and provides a default implementation for get_progress.
+
+    Required properties:
+    - menu_label: str
+      This label is always returned regardless of project state
+    - form_title: str
+      This title is shown on top of the rendered form
+    - form_class: ModuleDashboardForm
+      This is the form class used to render from the ModuleComponentFormView
+    """
 
     def get_view(self):
         from .views import ModuleComponentFormView
@@ -115,6 +147,20 @@ class ModuleFormComponent(ProjectFormComponent):
 
 
 class ModuleFormSetComponent(ModuleFormComponent):
+    """Abstract interface for module dashboard components based on formsets.
+
+    This component is intended to be used with ModuleDashboardFormSet's.
+    It will always return a ModuleComponentFormView
+    and provides a default implementation for get_progress.
+
+    Required properties:
+    - menu_label: str
+      This label is always returned regardless of project state
+    - form_title: str
+      This title is shown on top of the rendered form
+    - form_class: ModuleDashboardFormSet
+      This is the formset class used to render from the ModuleComponentFormView
+    """
 
     def get_progress(self, parent):
         child_form_class = self.form_class.form

--- a/meinberlin/apps/dashboard2/components.py
+++ b/meinberlin/apps/dashboard2/components.py
@@ -56,7 +56,7 @@ class DashboardComponent:
 class ProjectFormComponent(DashboardComponent):
     """Abstract interface for project dashboard components based on forms.
 
-    This component is intended to be used with ProjectDashboardForm's.
+    This component is intended to be used with ProjectDashboardForm.
     It will always return a ProjectComponentFormView
     and provides a default implementation for get_progress.
 
@@ -71,7 +71,7 @@ class ProjectFormComponent(DashboardComponent):
 
     menu_label = ''
     form_title = ''
-    form_class = ''
+    form_class = None
     form_template_name = ''
 
     def get_menu_label(self, project):
@@ -125,7 +125,7 @@ class ProjectFormComponent(DashboardComponent):
 class ModuleFormComponent(ProjectFormComponent):
     """Abstract interface for module dashboard components based on forms.
 
-    This component is intended to be used with ModuleDashboardForm's.
+    This component is intended to be used with ModuleDashboardForm.
     It will always return a ModuleComponentFormView
     and provides a default implementation for get_progress.
 
@@ -151,7 +151,7 @@ class ModuleFormComponent(ProjectFormComponent):
 class ModuleFormSetComponent(ModuleFormComponent):
     """Abstract interface for module dashboard components based on formsets.
 
-    This component is intended to be used with ModuleDashboardFormSet's.
+    This component is intended to be used with ModuleDashboardFormSet.
     It will always return a ModuleComponentFormView
     and provides a default implementation for get_progress.
 

--- a/meinberlin/apps/dashboard2/dashboard.py
+++ b/meinberlin/apps/dashboard2/dashboard.py
@@ -1,6 +1,7 @@
 from django.utils.translation import ugettext_lazy as _
 
 from . import ModuleFormComponent
+from . import ModuleFormSetComponent
 from . import ProjectFormComponent
 from . import content
 from . import forms
@@ -43,7 +44,7 @@ class ModuleBasicComponent(ModuleFormComponent):
                          '/module_basic_form.html'
 
 
-class ModulePhasesComponent(ModuleFormComponent):
+class ModulePhasesComponent(ModuleFormSetComponent):
     app_label = Config.label
     label = 'phases'
     identifier = 'phases'

--- a/meinberlin/apps/dashboard2/dashboard.py
+++ b/meinberlin/apps/dashboard2/dashboard.py
@@ -1,78 +1,58 @@
 from django.utils.translation import ugettext_lazy as _
 
-from . import DashboardComponent
+from . import ModuleFormComponent
+from . import ProjectFormComponent
 from . import content
 from . import forms
-from . import views
 from .apps import Config
 
 
-class ProjectBasicComponent(DashboardComponent):
+class ProjectBasicComponent(ProjectFormComponent):
     app_label = Config.label
     label = 'basic'
     identifier = 'basic'
 
-    def get_menu_label(self, project):
-        return _('Basic settings')
-
-    def get_view(self):
-        return views.ProjectComponentFormView.as_view(
-            title=_('Edit basic settings'),
-            form_class=forms.ProjectBasicForm,
-            form_template_name='meinberlin_dashboard2'
-                               '/includes/project_basic_form.html'
-        )
+    menu_label = _('Basic settings')
+    form_title = _('Edit basic settings')
+    form_class = forms.ProjectBasicForm
+    form_template_name = 'meinberlin_dashboard2/includes' \
+                         '/project_basic_form.html'
 
 
-class ProjectInformationComponent(DashboardComponent):
+class ProjectInformationComponent(ProjectFormComponent):
     app_label = Config.label
     label = 'information'
     identifier = 'information'
 
-    def get_menu_label(self, project):
-        return _('Information')
-
-    def get_view(self):
-        return views.ProjectComponentFormView.as_view(
-            title=_('Edit project information'),
-            form_class=forms.ProjectInformationForm,
-            form_template_name='meinberlin_dashboard2'
-                               '/includes/project_information_form.html',
-        )
+    menu_label = _('Information')
+    form_title = _('Edit project information')
+    form_class = forms.ProjectInformationForm
+    form_template_name = 'meinberlin_dashboard2' \
+                         '/includes/project_information_form.html'
 
 
-class ModuleBasicComponent(DashboardComponent):
+class ModuleBasicComponent(ModuleFormComponent):
     app_label = Config.label
     label = 'phases'
     identifier = 'module_basic'
 
-    def get_menu_label(self, module):
-        return _('Basic information')
-
-    def get_view(self):
-        return views.ModuleComponentFormView.as_view(
-            title=_('Edit basic module information'),
-            form_class=forms.ModuleBasicForm,
-            form_template_name='meinberlin_dashboard2/includes'
-                               '/module_basic_form.html'
-        )
+    menu_label = _('Basic information')
+    form_title = _('Edit basic module information')
+    form_class = forms.ModuleBasicForm
+    form_template_name = 'meinberlin_dashboard2/includes' \
+                         '/module_basic_form.html'
 
 
-class ModulePhasesComponent(DashboardComponent):
+class ModulePhasesComponent(ModuleFormComponent):
     app_label = Config.label
     label = 'phases'
     identifier = 'phases'
 
-    def get_menu_label(self, module):
-        return _('Phases')
-
-    def get_view(self):
-        return views.ModuleComponentFormView.as_view(
-            title=_('Edit phases information'),
-            form_class=forms.PhaseFormSet,
-            form_template_name='meinberlin_dashboard2/includes'
-                               '/module_phases_form.html'
-        )
+    menu_label = _('Phases')
+    form_title = _('Edit phases information')
+    form_class = forms.PhaseFormSet
+    form_template_name = 'meinberlin_dashboard2/includes' \
+                         '/module_phases_form.html'
 
 
 content.register_project(ProjectBasicComponent())

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -84,6 +84,7 @@ class PhaseForm(forms.ModelForm):
             'type': forms.HiddenInput(),
             'weight': forms.HiddenInput()
         }
+        required = '__all__'
 
 
 PhaseFormSet = inlineformset_factory(module_models.Module,

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -50,6 +50,7 @@ class ProjectUpdateForm(forms.ModelForm):
 
 
 def _make_fields_required(fields, required):
+    """Set the required attributes on all fields who's key is in required."""
     if required:
         for name, field in fields:
             if required == '__all__' or name in required:
@@ -57,6 +58,12 @@ def _make_fields_required(fields, required):
 
 
 class ProjectDashboardForm(forms.ModelForm):
+    """
+    Base form for project related dashboard forms.
+
+    Sets fields to required if the project is published.
+    Intended to be used with ProjectFormComponent's.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -72,6 +79,12 @@ class ProjectDashboardForm(forms.ModelForm):
 
 
 class ModuleDashboardForm(forms.ModelForm):
+    """
+    Base form for module related dashboard forms.
+
+    Sets fields to required if the project is published.
+    Intended to be used with ModuleFormComponent's.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -87,6 +100,12 @@ class ModuleDashboardForm(forms.ModelForm):
 
 
 class ModuleDashboardFormSet(forms.BaseInlineFormSet):
+    """
+    Base form for module related dashboard formsets.
+
+    Sets fields to required if the project is published.
+    Intended to be used with ModuleFormSetComponent's.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -3,66 +3,11 @@ from django.contrib.auth import get_user_model
 from django.forms import inlineformset_factory
 from django.utils.translation import ugettext_lazy as _
 
-from adhocracy4.categories import models as category_models
 from adhocracy4.modules import models as module_models
 from adhocracy4.phases import models as phase_models
 from adhocracy4.projects import models as project_models
-from meinberlin.apps.contrib import multiform
 
 User = get_user_model()
-
-
-class ProjectEditFormBase(multiform.MultiModelForm):
-
-    def _project_form(self):
-        return self.get_formset('project')
-
-    def _phases_form(self):
-        return self.get_formset('phases')
-
-    def _categories_form(self):
-        return self.get_formset('categories')
-
-    def _module_settings_form(self):
-        return self.get_formset('module_settings')
-
-    def info_error_count(self):
-        project_form_errors = self._project_form().errors.keys()
-        info_error_count = len(project_form_errors)
-        if 'result' in project_form_errors:
-            info_error_count = info_error_count - 1
-
-        return info_error_count
-
-    def participate_error_count(self):
-        error_count = 0
-
-        module_settings = self._module_settings_form()
-        if module_settings is not None:
-            error_count += len(module_settings.errors)
-
-        categories = self._categories_form()
-        if categories is not None:
-            error_count += categories.total_error_count()
-
-        error_count += self._phases_form().total_error_count()
-
-        return error_count
-
-    def result_error_count(self):
-        project_form_errors = self._project_form().errors.keys()
-        return 1 if 'result' in project_form_errors else 0
-
-    def _show_categories_form(self, phases):
-        """Check if any of the phases has a categorizable item.
-
-        TODO: Move this functionality to a4phases.
-        """
-        for phase in phases:
-            for models in phase.features.values():
-                for model in models:
-                    if category_models.Categorizable.is_categorizable(model):
-                        return True
 
 
 class ProjectCreateForm(forms.ModelForm):
@@ -110,6 +55,7 @@ class ProjectBasicForm(forms.ModelForm):
         model = project_models.Project
         fields = ['name', 'description', 'image', 'tile_image', 'is_archived',
                   'is_public']
+        required = '__all__'
 
 
 class ProjectInformationForm(forms.ModelForm):
@@ -117,6 +63,7 @@ class ProjectInformationForm(forms.ModelForm):
     class Meta:
         model = project_models.Project
         fields = ['information']
+        required = '__all__'
 
 
 class ModuleBasicForm(forms.ModelForm):
@@ -124,6 +71,7 @@ class ModuleBasicForm(forms.ModelForm):
     class Meta:
         model = module_models.Module
         fields = ['name', 'description']
+        required = '__all__'
 
 
 class PhaseForm(forms.ModelForm):

--- a/meinberlin/apps/dashboard2/mixins.py
+++ b/meinberlin/apps/dashboard2/mixins.py
@@ -71,8 +71,8 @@ class DashboardMenuMixin:
 
         return {'project': project_menu, 'modules': menu_modules}
 
-    @classmethod
-    def get_project_menu(cls, project, current_component):
+    @staticmethod
+    def get_project_menu(project, current_component):
         project_menu = []
         for component in content.get_project_components():
             menu_item = component.get_menu_label(project)
@@ -93,8 +93,8 @@ class DashboardMenuMixin:
                 })
         return project_menu or None
 
-    @classmethod
-    def get_module_menu(cls, module, current_component, current_module):
+    @staticmethod
+    def get_module_menu(module, current_component, current_module):
         module_menu = []
         for component in content.get_module_components():
             menu_item = component.get_menu_label(module)

--- a/meinberlin/apps/dashboard2/mixins.py
+++ b/meinberlin/apps/dashboard2/mixins.py
@@ -105,10 +105,13 @@ class DashboardMenuMixin:
                     'module_slug': module.slug,
                     'component_identifier': component.identifier
                 })
+                num_valid, num_required = component.get_progress(module)
+                is_complete = (num_valid == num_required)
 
                 module_menu.append({
                     'label': menu_item,
                     'is_active': is_active,
                     'url': url,
+                    'is_complete': is_complete,
                 })
         return module_menu or None

--- a/meinberlin/apps/dashboard2/mixins.py
+++ b/meinberlin/apps/dashboard2/mixins.py
@@ -82,11 +82,14 @@ class DashboardMenuMixin:
                     'project_slug': project.slug,
                     'component_identifier': component.identifier
                 })
+                num_valid, num_required = component.get_progress(project)
+                is_complete = (num_valid == num_required)
 
                 project_menu.append({
                     'label': menu_item,
                     'is_active': is_active,
                     'url': url,
+                    'is_complete': is_complete,
                 })
         return project_menu or None
 

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
@@ -50,7 +50,7 @@
         </div>
 
         <div class="menu-layout__aside">
-            {% include "meinberlin_dashboard2/includes/progress.html" with value=3 max=23 %}
+            {% include "meinberlin_dashboard2/includes/progress.html" with value=project_progress.valid max=project_progress.required %}
         </div>
     </div>
 {% endblock %}

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
@@ -15,7 +15,7 @@
                                class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">
                                 {{ item.label }}
                                 {% if not item.is_complete %}
-                                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                                    <i class="fa fa-exclamation-circle" title="{% trans 'Missing fields for publication' %}" aria-label="{% trans 'Missing fields for publication' %}"></i>
                                 {% endif %}
                             </a>
                         </li>
@@ -35,7 +35,7 @@
                                    class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">
                                     {{ item.label }}
                                     {% if not item.is_complete %}
-                                        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                                        <i class="fa fa-exclamation-circle" title="{% trans 'Missing fields for publication' %}" aria-label="{% trans 'Missing fields for publication' %}"></i>
                                     {% endif %}
                                 </a>
                             </li>

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
@@ -11,7 +11,13 @@
                 <ul class="dashboard-nav__pages">
                     {% for item in dashboard_menu.project %}
                         <li class="dashboard-nav__page">
-                            <a href="{{ item.url }}" class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">{{ item.label }}</a>
+                            <a href="{{ item.url }}"
+                               class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">
+                                {{ item.label }}
+                                {% if not item.is_complete %}
+                                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                                {% endif %}
+                            </a>
                         </li>
                     {% endfor %}
                 </ul>

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
@@ -31,7 +31,13 @@
                     <ul class="dashboard-nav__pages">
                         {% for item in module_menu.menu %}
                             <li class="dashboard-nav__page">
-                                <a href="{{ item.url }}" class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">{{ item.label }}</a>
+                                <a href="{{ item.url }}"
+                                   class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">
+                                    {{ item.label }}
+                                    {% if not item.is_complete %}
+                                        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                                    {% endif %}
+                                </a>
                             </li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
This PR introduces a `get_progress(project_or_module)` method on the DashboardComponent Interface. 
This get_progress is used to show error notes in the menu and display the progress bar. 
During the development specialized abstract Components for forms were introduces.

The progress / error counting has to be done on the models as it is not possible to reliably convert a model object to a POST data dict.
For example: phase.start_date may be split into two fields by the datetimepicker widget. Thus two separate values are expected in the POST data dict, which will be merged after the initial validation. But fields/widgets are not holding any information about the expected POST data fields. 