### PR TITLE
add egg for multiform

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ bcrypt==3.1.3
 django-capture-tag==1.0
 # django multiform (released version 0.1 was too old)
 # commit points to PR with 1.9 compatibility
-git+git://github.com/encolpe/django-multiform.git@django-1.9
+git+git://github.com/encolpe/django-multiform.git@django-1.9#egg=django-multiform
 html5lib==0.999999999
 wagtail==1.11.1
 XlsxWriter==0.9.8


### PR DESCRIPTION
Pip apparently needs an egg for vcs. https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support