### PR TITLE
Show other_organisations_of_user in dashboard top menu

### DIFF
--- a/meinberlin/apps/dashboard2/mixins.py
+++ b/meinberlin/apps/dashboard2/mixins.py
@@ -34,6 +34,14 @@ class DashboardBaseMixin(rules_mixins.PermissionRequiredMixin):
 
         raise ObjectDoesNotExist()
 
+    @property
+    def other_organisations_of_user(self):
+        user = self.request.user
+        if self.organisation:
+            return user.organisation_set.exclude(pk=self.organisation.pk)
+        else:
+            return None
+
     def get_permission_object(self):
         return self.organisation
 

--- a/meinberlin/templates/meinberlin_dashboard2/base_dashboard.html
+++ b/meinberlin/templates/meinberlin_dashboard2/base_dashboard.html
@@ -5,7 +5,7 @@
 
 <div class="tablist tablist--right tablist--background u-after-dialogue-box">
     <div class="l-wrapper">
-        <div class="tablist__left">
+        <div class="tablist__left dropdown">
             {% if view.other_organisations_of_user %}
                 <button
                         title="{% trans 'Organisations' %}"


### PR DESCRIPTION
ToDo:
- [x] Make the organisation dropdown on the left in the top menu work

@xi, @vellip could you please take a look at the issue with the dropdown?