### PR TITLE
Allow to (un)publish projects

### DIFF
--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/base_dashboard_project.html
@@ -50,7 +50,7 @@
         </div>
 
         <div class="menu-layout__aside">
-            {% include "meinberlin_dashboard2/includes/progress.html" with value=project_progress.valid max=project_progress.required %}
+            {% include "meinberlin_dashboard2/includes/progress.html" with value=project_progress.valid max=project_progress.required project=project %}
         </div>
     </div>
 {% endblock %}

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/progress.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/progress.html
@@ -26,7 +26,7 @@
             {% trans 'Publish' %}
         </button>
     {% else %}
-        <button name="action" value="unpublish" class="btn btn--primary btn--full btn--attached-top">
+        <button name="action" value="unpublish" class="btn btn--light btn--full btn--attached-top">
             {% trans 'Unpublish' %}
         </button>
     {% endif %}

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/progress.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/progress.html
@@ -16,4 +16,19 @@
         {% blocktrans %}required fields for publication{% endblocktrans %}
     </div>
 </div>
-<button type="button" {% if value != max %}disabled{% endif %} class="btn btn--primary btn--full btn--attached-top">{% trans 'Publish' %}</button>
+
+<form action="{% url 'a4dashboard:project-publish' project_slug=project.slug %}" method="post">
+    {% csrf_token %}
+    <input type="hidden" name="referrer" value="{{ request.path }}" />
+
+    {% if project.is_draft %}
+        <button name="action" value="publish" {% if value != max %}disabled{% endif %} class="btn btn--primary btn--full btn--attached-top">
+            {% trans 'Publish' %}
+        </button>
+    {% else %}
+        <button name="action" value="unpublish" class="btn btn--primary btn--full btn--attached-top">
+            {% trans 'Unpublish' %}
+        </button>
+    {% endif %}
+</form>
+

--- a/meinberlin/apps/dashboard2/urls.py
+++ b/meinberlin/apps/dashboard2/urls.py
@@ -25,4 +25,7 @@ urlpatterns = [
         r'(?P<component_identifier>[-_:\w]+)/$',
         views.ModuleComponentDispatcher.as_view(),
         name='module-edit-component'),
+    url(r'^publish/project/(?P<project_slug>[-\w_]+)/$',
+        views.ProjectPublishView.as_view(),
+        name='project-publish'),
 ]


### PR DESCRIPTION
This PR adds a separate view that acts as the target of the form containing the (un) publish button inat the progress indicator.
It ensures each required field of a project and its modules is present. 
*Note: Currently this is done by checking the progress explicitly. But this could be replaces by some kind of signal/callback functionality that would be called prior to publishing. This callback could also check more complicated conditions like: allow publishing only if phases are non overlapping*

The view redirect to the previous page. Or the default project-update page if the previous page can not be detected. 
