### PR TITLE
Fix missing initiator request emails for the supervisor

### DIFF
--- a/meinberlin/apps/initiators/emails.py
+++ b/meinberlin/apps/initiators/emails.py
@@ -10,7 +10,7 @@ class InitiatorRequest(Email):
     template_name = 'meinberlin_initiators/emails/initiator_request'
 
     def get_receivers(self):
-        return [settings.CONTACT_EMAIL]
+        return [settings.SUPERVISOR_EMAIL]
 
     def get_context(self):
         context = super().get_context()

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -368,5 +368,6 @@ A4_MAP_BASEURL = 'https://maps.berlinonline.de/tile/bright/'
 A4_MAP_ATTRIBUTION = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 A4_MAP_BOUNDING_BOX = ([[52.3517, 13.8229], [52.6839, 12.9543]])
 
-CONTACT_EMAIL = 'support-berlin@liqd.de'
+CONTACT_EMAIL = 'support-berlin@liqd.net'
+SUPERVISOR_EMAIL = 'supervisor-berlin@liqd.net'
 EMAIL_DEFAULT_LANGUAGE = 'de'


### PR DESCRIPTION
Add SUPERVISOR_EMAIL setting
Supervisors should e.g. receive notifications about initiator requests.

Note that supervisor-berlin@liqd.net is not set yet. Before deployment it should be set up and redirected to the correct supervisor addresses.

Note also, that this is an ugly hack, as we should define the role supervisor on the User model if we'd really need them and then adapt get_receivers to return the users with the supervisor role.