### PR TITLE
Sort components by weight

### DIFF
--- a/meinberlin/apps/dashboard2/components.py
+++ b/meinberlin/apps/dashboard2/components.py
@@ -26,9 +26,16 @@ class DashboardComponent:
         The identifier is used to register and retrieve components from the
         registry. It may be used to define unique url names.
 
+    weight : int
+        Weight of the component.
+        Used to sort components within the dashboard menu.
+        The component with the lowest weight will be the default entry point
+        for editing a project.
+
     """
 
     identifier = ''
+    weight = 0
 
     def get_menu_label(self, project_or_module):
         """Return the menu label if the component should be shown.

--- a/meinberlin/apps/dashboard2/contents.py
+++ b/meinberlin/apps/dashboard2/contents.py
@@ -17,14 +17,6 @@ class DashboardContents:
                              .format(component.identifier))
         self._registry[section][component.identifier] = component
 
-    def unregister_project(self, component):
-        identifier = getattr(component, 'identifier', component)
-        self._registry['projects'].pop(identifier, None)
-
-    def unregister_module(self, component):
-        identifier = getattr(component, 'identifier', component)
-        self._registry['modules'].pop(identifier, None)
-
     def get_project_components(self):
         return sorted(self._registry['projects'].values(),
                       key=_component_sort_key)

--- a/meinberlin/apps/dashboard2/contents.py
+++ b/meinberlin/apps/dashboard2/contents.py
@@ -1,25 +1,37 @@
+def _component_sort_key(component):
+    return component.weight, component.identifier
+
+
 class DashboardContents:
     _registry = {'projects': {}, 'modules': {}}
 
-    @property
-    def projects(self):
-        return self._registry['projects']
-
-    @property
-    def modules(self):
-        return self._registry['modules']
-
     def register_project(self, component):
-        self._registry['projects'][component.identifier] = component
+        self._register('projects', component)
 
     def register_module(self, component):
-        self._registry['modules'][component.identifier] = component
+        self._register('modules', component)
+
+    def _register(self, section, component):
+        if component.identifier in self._registry[section]:
+            raise ValueError('Identifier ({}) is already registered'
+                             .format(component.identifier))
+        self._registry[section][component.identifier] = component
+
+    def unregister_project(self, component):
+        identifier = getattr(component, 'identifier', component)
+        self._registry['projects'].pop(identifier, None)
+
+    def unregister_module(self, component):
+        identifier = getattr(component, 'identifier', component)
+        self._registry['modules'].pop(identifier, None)
 
     def get_project_components(self):
-        return list(self._registry['projects'].values())
+        return sorted(self._registry['projects'].values(),
+                      key=_component_sort_key)
 
     def get_module_components(self):
-        return list(self._registry['modules'].values())
+        return sorted(self._registry['modules'].values(),
+                      key=_component_sort_key)
 
     def get_urls(self):
         # FIXME: where to move this method

--- a/meinberlin/apps/dashboard2/dashboard.py
+++ b/meinberlin/apps/dashboard2/dashboard.py
@@ -9,6 +9,7 @@ from . import forms
 
 class ProjectBasicComponent(ProjectFormComponent):
     identifier = 'basic'
+    weight = 10
 
     menu_label = _('Basic settings')
     form_title = _('Edit basic settings')
@@ -19,6 +20,7 @@ class ProjectBasicComponent(ProjectFormComponent):
 
 class ProjectInformationComponent(ProjectFormComponent):
     identifier = 'information'
+    weight = 11
 
     menu_label = _('Information')
     form_title = _('Edit project information')
@@ -29,6 +31,7 @@ class ProjectInformationComponent(ProjectFormComponent):
 
 class ModuleBasicComponent(ModuleFormComponent):
     identifier = 'module_basic'
+    weight = 10
 
     menu_label = _('Basic information')
     form_title = _('Edit basic module information')
@@ -39,6 +42,7 @@ class ModuleBasicComponent(ModuleFormComponent):
 
 class ModulePhasesComponent(ModuleFormSetComponent):
     identifier = 'phases'
+    weight = 11
 
     menu_label = _('Phases')
     form_title = _('Edit phases information')

--- a/meinberlin/apps/offlineevents/dashboard.py
+++ b/meinberlin/apps/offlineevents/dashboard.py
@@ -9,6 +9,7 @@ from . import views
 
 class OfflineEventsComponent(DashboardComponent):
     identifier = 'offlineevents'
+    weight = 20
 
     def get_menu_label(self, project):
         return _('Offline Events')


### PR DESCRIPTION
If the weight is the same, the identifier is used to get a constant order.

If this will be required some day it would be possible to use a weight @property which determines the weight from a setting.