### PR TITLE
Temporary set single module name and description

### DIFF
--- a/meinberlin/apps/dashboard/forms.py
+++ b/meinberlin/apps/dashboard/forms.py
@@ -205,7 +205,8 @@ class ProjectCreateForm(ProjectEditFormBase):
             project.moderators.add(self.creator)
 
         module = module_models.Module(
-            name=project.slug + '_module',
+            name='Onlinebeteiligung',
+            description=project.description,
             weight=1,
             project=project
         )

--- a/meinberlin/apps/dashboard2/views.py
+++ b/meinberlin/apps/dashboard2/views.py
@@ -80,7 +80,8 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
 
     def _create_modules_and_phases(self, project):
         module = module_models.Module(
-            name=project.slug + '_module',
+            name='Onlinebeteiligung',
+            description=project.description,
             weight=1,
             project=project,
         )


### PR DESCRIPTION
Set valid module name and description from project.
Will be replaced by module type and user input in the new dashboard.
