### PR TITLE
refactor input-group

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field_with_addon.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field_with_addon.html
@@ -9,13 +9,13 @@
         {{ field.help_text }}
     </div>
     {% endif %}
-    <div class="widget widget--{{ field|widget_type }} input-addon">
+    <div class="widget widget--{{ field|widget_type }} input-group">
         {% if before %}
-            <span class="input-addon__before addon">{{ before }}</span>
+            <span class="input-group__before addon">{{ before }}</span>
         {% endif %}
-        {{ field|add_class:'input-addon__input' }}
+        {{ field|add_class:'input-group__input' }}
         {% if after %}
-            <span class="input-addon__after addon">{{ after }}</span>
+            <span class="input-group__after addon">{{ after }}</span>
         {% endif %}
     </div>
     {{ field.errors }}

--- a/meinberlin/apps/dashboard/templates/meinberlin_dashboard/includes/users_from_email_form.html
+++ b/meinberlin/apps/dashboard/templates/meinberlin_dashboard/includes/users_from_email_form.html
@@ -11,7 +11,7 @@
             {{ form.add_users.help_text }}
         </div>
         {% endif %}
-        <div class="btn-group input-addon">
+        <div class="input-addon">
             <div class="input-addon__input widget widget--{{ form.add_users|widget_type }}">
                 {{ form.add_users }}
             </div>

--- a/meinberlin/apps/dashboard/templates/meinberlin_dashboard/includes/users_from_email_form.html
+++ b/meinberlin/apps/dashboard/templates/meinberlin_dashboard/includes/users_from_email_form.html
@@ -11,11 +11,11 @@
             {{ form.add_users.help_text }}
         </div>
         {% endif %}
-        <div class="input-addon">
-            <div class="input-addon__input widget widget--{{ form.add_users|widget_type }}">
+        <div class="input-group">
+            <div class="input-group__input widget widget--{{ form.add_users|widget_type }}">
                 {{ form.add_users }}
             </div>
-            <input type="submit" class="btn btn--primary input-addon__after" value="{% trans 'Add' %}"/>
+            <input type="submit" class="btn btn--primary input-group__after" value="{% trans 'Add' %}"/>
         </div>
         {{ form.add_users.errors }}
     </div>

--- a/meinberlin/apps/polls/assets/ChoiceForm.jsx
+++ b/meinberlin/apps/polls/assets/ChoiceForm.jsx
@@ -21,7 +21,7 @@ class ChoiceForm extends React.Component {
           htmlFor={'id_choices-' + this.props.index + '-name'}>
           {django.gettext('Choice') + ` #${this.props.index}`}
         </label>
-        <div className="btn-group input-addon">
+        <div className="input-addon">
           <input
             id={'id_choices-' + this.props.index + '-name'}
             name={'choices-' + this.props.index + '-name'}

--- a/meinberlin/apps/polls/assets/ChoiceForm.jsx
+++ b/meinberlin/apps/polls/assets/ChoiceForm.jsx
@@ -21,16 +21,16 @@ class ChoiceForm extends React.Component {
           htmlFor={'id_choices-' + this.props.index + '-name'}>
           {django.gettext('Choice') + ` #${this.props.index}`}
         </label>
-        <div className="input-addon">
+        <div className="input-group">
           <input
             id={'id_choices-' + this.props.index + '-name'}
             name={'choices-' + this.props.index + '-name'}
             type="text"
-            className="input-addon__input"
+            className="input-group__input"
             value={this.props.choice.label}
             onChange={this.handleLabelChange.bind(this)} />
           <button
-            className="input-addon__after btn btn--light"
+            className="input-group__after btn btn--light"
             onClick={this.handleDelete.bind(this)}
             title={django.gettext('remove')}
             type="button">

--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -104,14 +104,6 @@ select {
     }
 }
 
-.widget--datetimeinput {
-    @include clearfix;
-}
-
-.widget--datetimeinput__date {
-    display: flex;
-}
-
 .errorcount {
     color: $brand-danger;
 }

--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -112,10 +112,6 @@ select {
     display: flex;
 }
 
-.input-round {
-    border-radius: 0.3em;
-}
-
 .errorcount {
     color: $brand-danger;
 }

--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -112,56 +112,6 @@ select {
     display: flex;
 }
 
-.input-addon {
-    display: flex;
-}
-
-.input-addon__input {
-    flex: 1 1 auto;
-}
-
-.input-addon__before,
-.input-addon__after {
-    flex: 0 1 0%;
-}
-
-.input-addon__input,
-.input-addon__before,
-.input-addon__after {
-    border-radius: 0;
-
-    &:focus {
-        // highlighted border should be on top
-        z-index: 1;
-    }
-}
-
-.input-addon__before {
-    margin-right: -1px;
-
-    &:first-child {
-        border-top-left-radius: 0.3em;
-        border-bottom-left-radius: 0.3em;
-    }
-}
-
-.input-addon__after {
-    margin-left: -1px;
-
-    &:last-child {
-        border-top-right-radius: 0.3em;
-        border-bottom-right-radius: 0.3em;
-    }
-}
-
-.addon {
-    @extend %input-base;
-    background-color: $body-bg;
-    color: contrast-color($body-bg);
-    min-width: 2.4em;
-    text-align: center;
-}
-
 .input-round {
     border-radius: 0.3em;
 }

--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -128,6 +128,8 @@ select {
 .input-addon__input,
 .input-addon__before,
 .input-addon__after {
+    border-radius: 0;
+
     &:focus {
         // highlighted border should be on top
         z-index: 1;
@@ -136,26 +138,28 @@ select {
 
 .input-addon__before {
     margin-right: -1px;
+
+    &:first-child {
+        border-top-left-radius: 0.3em;
+        border-bottom-left-radius: 0.3em;
+    }
 }
 
 .input-addon__after {
     margin-left: -1px;
+
+    &:last-child {
+        border-top-right-radius: 0.3em;
+        border-bottom-right-radius: 0.3em;
+    }
 }
 
 .addon {
     @extend %input-base;
     background-color: $body-bg;
     color: contrast-color($body-bg);
-
-    &:first-child {
-        border-top-left-radius: 0.3em;
-        border-bottom-left-radius: 0.3em;
-    }
-
-    &:last-child {
-        border-top-right-radius: 0.3em;
-        border-bottom-right-radius: 0.3em;
-    }
+    min-width: 2.4em;
+    text-align: center;
 }
 
 .input-round {

--- a/meinberlin/assets/scss/_mixins.scss
+++ b/meinberlin/assets/scss/_mixins.scss
@@ -3,6 +3,7 @@
 @mixin fake-focus {
     // stylelint-disable scale-unlimited/declaration-strict-value
     outline: 2px solid Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
     // stylelint-enable
 }
 

--- a/meinberlin/assets/scss/components/_addon.scss
+++ b/meinberlin/assets/scss/components/_addon.scss
@@ -1,3 +1,5 @@
+// FIXME: this only works with buttons if it is included *afterwards*
+
 .input-addon {
     display: flex;
 }

--- a/meinberlin/assets/scss/components/_addon.scss
+++ b/meinberlin/assets/scss/components/_addon.scss
@@ -1,0 +1,49 @@
+.input-addon {
+    display: flex;
+}
+
+.input-addon__input {
+    flex: 1 1 auto;
+}
+
+.input-addon__before,
+.input-addon__after {
+    flex: 0 1 0%;
+}
+
+.input-addon__input,
+.input-addon__before,
+.input-addon__after {
+    border-radius: 0;
+
+    &:focus {
+        // highlighted border should be on top
+        z-index: 1;
+    }
+}
+
+.input-addon__before {
+    margin-right: -1px;
+
+    &:first-child {
+        border-top-left-radius: 0.3em;
+        border-bottom-left-radius: 0.3em;
+    }
+}
+
+.input-addon__after {
+    margin-left: -1px;
+
+    &:last-child {
+        border-top-right-radius: 0.3em;
+        border-bottom-right-radius: 0.3em;
+    }
+}
+
+.addon {
+    @extend %input-base;
+    background-color: $body-bg;
+    color: contrast-color($body-bg);
+    min-width: 2.4em;
+    text-align: center;
+}

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -136,14 +136,18 @@
 }
 
 .btn-group {
-    > :not(:first-child) {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+    > * {
+        border-radius: 0;
     }
 
-    > :not(:last-child) {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+    > :first-child {
+        border-top-left-radius: 0.3em;
+        border-bottom-left-radius: 0.3em;
+    }
+
+    > :last-child {
+        border-top-right-radius: 0.3em;
+        border-bottom-right-radius: 0.3em;
     }
 }
 

--- a/meinberlin/assets/scss/components/_datepicker.scss
+++ b/meinberlin/assets/scss/components/_datepicker.scss
@@ -6,37 +6,46 @@
     @extend .input-group;
 }
 
-.date-picker-control:link,
-.date-picker-control:visited {
-    padding: 0.5em 0.4em;
-    border: 1px solid $border-color;
-    min-width: inherit;
-
-    background: $bg-secondary;
+.datepicker {
+    @extend .input-group__input;
 }
+
 // stylelint-disable selector-max-specificity
 // need to override the default styling
-.date-picker-control {
+.date-picker-control:link {
+    background-image: none !important;
+    min-width: 3em;
+    z-index: 0;
+
+    @extend .input-group__after;
+    @extend .btn;
+    @extend .btn--light;
+
+    &:focus {
+        outline: 2px solid Highlight !important;
+        outline: 5px auto -webkit-focus-ring-color !important;
+    }
+
     &:focus,
     &:hover {
         span:first-child:before {
             content: '\f073';
+        }
+
+        span {
+            box-shadow: none !important;
+            animation: none !important;
         }
     }
 }
 // stylelint-enable
 
 .date-picker-control span:first-child {
-    width: auto;
-    height: auto;
-
-    // HACK to remove &nbsp;
-    font-size: 0;
+    display: inline;
 
     &:before {
         content: '\f133';
         font-family: 'FontAwesome';
-        font-size: $font-size-lg;
     }
 }
 

--- a/meinberlin/assets/scss/components/_datepicker.scss
+++ b/meinberlin/assets/scss/components/_datepicker.scss
@@ -1,3 +1,11 @@
+.widget--datetimeinput {
+    @include clearfix;
+}
+
+.widget--datetimeinput__date {
+    @extend .input-group;
+}
+
 .date-picker-control:link,
 .date-picker-control:visited {
     padding: 0.5em 0.4em;

--- a/meinberlin/assets/scss/components/_input_group.scss
+++ b/meinberlin/assets/scss/components/_input_group.scss
@@ -1,21 +1,21 @@
 // FIXME: this only works with buttons if it is included *afterwards*
 
-.input-addon {
+.input-group {
     display: flex;
 }
 
-.input-addon__input {
+.input-group__input {
     flex: 1 1 auto;
 }
 
-.input-addon__before,
-.input-addon__after {
+.input-group__before,
+.input-group__after {
     flex: 0 1 0%;
 }
 
-.input-addon__input,
-.input-addon__before,
-.input-addon__after {
+.input-group__input,
+.input-group__before,
+.input-group__after {
     border-radius: 0;
 
     &:focus {
@@ -24,7 +24,7 @@
     }
 }
 
-.input-addon__before {
+.input-group__before {
     margin-right: -1px;
 
     &:first-child {
@@ -33,7 +33,7 @@
     }
 }
 
-.input-addon__after {
+.input-group__after {
     margin-left: -1px;
 
     &:last-child {

--- a/meinberlin/assets/scss/components/_upload.scss
+++ b/meinberlin/assets/scss/components/_upload.scss
@@ -24,9 +24,6 @@
 // inputs are in the accessibility tree, but the visual representation is very
 // different from the underlying semantics.
 .upload-wrapper__action {
-    position: absolute;
-    top: 0;
-    right: 0;
     z-index: 1;
 }
 

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -21,7 +21,6 @@
 @import 'components/blocks';
 @import 'components/breadcrumbs';
 @import 'components/button';
-@import 'components/addon';
 @import 'components/commenting';
 @import 'components/comments';
 @import 'components/dashboard_nav';
@@ -36,6 +35,7 @@
 @import 'components/formset';
 @import 'components/header';
 @import 'components/hero_unit';
+@import 'components/input_group';
 @import 'components/item_detail';
 @import 'components/label';
 @import 'components/list_item';

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -17,6 +17,7 @@
 @import 'form';
 
 @import 'components/action';
+@import 'components/addon';
 @import 'components/alert';
 @import 'components/blocks';
 @import 'components/breadcrumbs';

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -17,11 +17,11 @@
 @import 'form';
 
 @import 'components/action';
-@import 'components/addon';
 @import 'components/alert';
 @import 'components/blocks';
 @import 'components/breadcrumbs';
 @import 'components/button';
+@import 'components/addon';
 @import 'components/commenting';
 @import 'components/comments';
 @import 'components/dashboard_nav';

--- a/meinberlin/templates/a4filters/widgets/free_text_filter.html
+++ b/meinberlin/templates/a4filters/widgets/free_text_filter.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 
-<form class="input-addon form-group u-inline-flex" action="" method="get" role="presentation">
-    <input class="input-addon__input" type="search" name="{{ name }}" placeholder="{% trans 'Search' %}" value="{{ value }}">
+<form class="input-group form-group u-inline-flex" action="" method="get" role="presentation">
+    <input class="input-group__input" type="search" name="{{ name }}" placeholder="{% trans 'Search' %}" value="{{ value }}">
     {% for par_name, value in url_par.items %}
         {% if par_name != name %}
             <input type="hidden" name="{{ par_name }}" value="{{ value }}">
         {% endif %}
     {% endfor %}
-    <button class="input-addon__after btn btn--light" type="submit" title="{% trans 'Search' %}">
+    <button class="input-group__after btn btn--light" type="submit" title="{% trans 'Search' %}">
         <i class="fa fa-search" aria-label="{% trans 'Search' %}"></i>
     </button>
 </form>

--- a/meinberlin/templates/a4filters/widgets/free_text_filter.html
+++ b/meinberlin/templates/a4filters/widgets/free_text_filter.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<form class="input-addon form-group btn-group u-inline-flex" action="" method="get" role="presentation">
+<form class="input-addon form-group u-inline-flex" action="" method="get" role="presentation">
     <input class="input-addon__input input-round" type="search" name="{{ name }}" placeholder="{% trans 'Search' %}" value="{{ value }}">
     {% for par_name, value in url_par.items %}
         {% if par_name != name %}

--- a/meinberlin/templates/a4filters/widgets/free_text_filter.html
+++ b/meinberlin/templates/a4filters/widgets/free_text_filter.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <form class="input-addon form-group u-inline-flex" action="" method="get" role="presentation">
-    <input class="input-addon__input input-round" type="search" name="{{ name }}" placeholder="{% trans 'Search' %}" value="{{ value }}">
+    <input class="input-addon__input" type="search" name="{{ name }}" placeholder="{% trans 'Search' %}" value="{{ value }}">
     {% for par_name, value in url_par.items %}
         {% if par_name != name %}
             <input type="hidden" name="{{ par_name }}" value="{{ value }}">

--- a/meinberlin/templates/a4images/image_upload_widget.html
+++ b/meinberlin/templates/a4images/image_upload_widget.html
@@ -1,23 +1,21 @@
 {% load i18n %}
 <div class="upload-wrapper form-control-upload">
-    <div class="upload-wrapper__fields">
+    <div class="upload-wrapper__fields input-group">
         {{ text_input }}
         {{ file_input }}
-        <span class="upload-wrapper__action">
-            {% if has_image_set and not is_required %}
-                <label for="{{ checkbox_id }}"
-                    class="btn btn--danger"
-                    title="{% trans 'Remove the picture' %}">
-                    <i class="fa fa-trash" aria-label="{% trans 'Remove the picture' %}"></i>
-                </label>
-            {% else %}
-                <label for="{{ name }}"
-                    class="btn"
-                    title="{% trans 'Upload a picture' %}">
-                    <i class="fa fa-cloud-upload" aria-label="{% trans 'Upload a picture' %}"></i>
-                </label>
-            {% endif %}
-        </span>
+        {% if has_image_set and not is_required %}
+            <label for="{{ checkbox_id }}"
+                class="upload-wrapper__action input-group__after btn btn--danger"
+                title="{% trans 'Remove the picture' %}">
+                <i class="fa fa-trash" aria-label="{% trans 'Remove the picture' %}"></i>
+            </label>
+        {% else %}
+            <label for="{{ name }}"
+                class="upload-wrapper__action input-group__after btn"
+                title="{% trans 'Upload a picture' %}">
+                <i class="fa fa-cloud-upload" aria-label="{% trans 'Upload a picture' %}"></i>
+            </label>
+        {% endif %}
     </div>
     <div class="form-{{ name }} upload-wrapper__preview">
         {{ checkbox_input }}


### PR DESCRIPTION
fixes #469

-   `input-addon` is renamed to `input-group`
-   `btn-group` and `input-group` are still separate
-   `input-group` does no longer require `btn-group` if buttons are involved
-   image upload uses `input-group`
-   datepicker uses `input-group`

Note that `input-group` is the same name that is also used in bootstrap, but the element classes (e.g. `input-group__input`) is not compatible.