### PR TITLE
 Add Area Settings component 

### DIFF
--- a/meinberlin/apps/dashboard2/dashboard.py
+++ b/meinberlin/apps/dashboard2/dashboard.py
@@ -107,9 +107,31 @@ class ModeratorsComponent(DashboardComponent):
         )]
 
 
+class ModuleAreaSettingsComponent(ModuleFormComponent):
+    identifier = 'area_settings'
+    weight = 12
+
+    menu_label = _('Areasettings')
+    form_title = _('Edit areasettings')
+    form_class = forms.AreaSettingsForm
+    form_template_name = 'meinberlin_dashboard2/includes' \
+                         '/module_areasettings_form.html'
+
+    def get_menu_label(self, module):
+        module_settings = module.settings_instance
+        if module_settings and hasattr(module_settings, 'polygon'):
+            return self.menu_label
+        return ''
+
+    def get_progress(self, module):
+        module_settings = module.settings_instance
+        return super().get_progress(module_settings)
+
+
 content.register_project(ProjectBasicComponent())
 content.register_project(ProjectInformationComponent())
 content.register_project(ModeratorsComponent())
 content.register_project(ParticipantsComponent())
 content.register_module(ModuleBasicComponent())
 content.register_module(ModulePhasesComponent())
+content.register_module(ModuleAreaSettingsComponent())

--- a/meinberlin/apps/dashboard2/dashboard.py
+++ b/meinberlin/apps/dashboard2/dashboard.py
@@ -125,7 +125,9 @@ class ModuleAreaSettingsComponent(ModuleFormComponent):
 
     def get_progress(self, module):
         module_settings = module.settings_instance
-        return super().get_progress(module_settings)
+        if module_settings:
+            return super().get_progress(module_settings)
+        return 0, 0
 
 
 content.register_project(ProjectBasicComponent())

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -9,6 +9,7 @@ from adhocracy4.modules import models as module_models
 from adhocracy4.phases import models as phase_models
 from adhocracy4.projects import models as project_models
 from meinberlin.apps.contrib import widgets
+from meinberlin.apps.maps.widgets import MapChoosePolygonWithPresetWidget
 from meinberlin.apps.users.fields import CommaSeparatedEmailField
 
 User = get_user_model()
@@ -248,4 +249,5 @@ class AreaSettingsForm(ModuleDashboardForm):
         model = map_models.AreaSettings
         fields = ['polygon']
         required_for_project_publish = ['polygon']
-        widgets = map_models.AreaSettings.widgets()
+        # widgets = map_models.AreaSettings.widgets()
+        widgets = {'polygon': MapChoosePolygonWithPresetWidget}

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.forms import inlineformset_factory
 from django.utils.translation import ugettext_lazy as _
 
+from adhocracy4.maps import models as map_models
 from adhocracy4.modules import models as module_models
 from adhocracy4.phases import models as phase_models
 from adhocracy4.projects import models as project_models
@@ -227,3 +228,24 @@ class AddUsersFromEmailForm(forms.Form):
 
         self.missing = missing
         return users
+
+
+class AreaSettingsForm(ModuleDashboardForm):
+
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs['instance']
+        kwargs['instance'] = self.module.settings_instance
+        super().__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        super().save(commit)
+        return self.module
+
+    def get_project(self):
+        return self.module.project
+
+    class Meta:
+        model = map_models.AreaSettings
+        fields = ['polygon']
+        required_for_project_publish = ['polygon']
+        widgets = map_models.AreaSettings.widgets()

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -68,12 +68,15 @@ class ProjectDashboardForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not self.instance.is_draft:
+        if not self.get_project().is_draft:
             _make_fields_required(self.fields.items(),
                                   self.get_required_fields())
 
         _make_fields_required_for_publish(self.fields.items(),
                                           self.get_required_fields())
+
+    def get_project(self):
+        return self.instance
 
     @classmethod
     def get_required_fields(cls):
@@ -92,12 +95,15 @@ class ModuleDashboardForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if not self.instance.project.is_draft:
+        if not self.get_project().is_draft:
             _make_fields_required(self.fields.items(),
                                   self.get_required_fields())
 
         _make_fields_required_for_publish(self.fields.items(),
                                           self.get_required_fields())
+
+    def get_project(self):
+        return self.instance.project
 
     @classmethod
     def get_required_fields(cls):

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/module_areasettings_form.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/module_areasettings_form.html
@@ -1,0 +1,1 @@
+{% include 'meinberlin_dashboard2/includes/form_field.html' with field=form.polygon %}

--- a/meinberlin/apps/dashboard2/views.py
+++ b/meinberlin/apps/dashboard2/views.py
@@ -205,8 +205,8 @@ class ProjectComponentFormView(mixins.DashboardBaseMixin,
         return self.project
 
 
-class ModuleComponentFormView(mixins.DashboardComponentMixin,
-                              mixins.DashboardBaseMixin,
+class ModuleComponentFormView(mixins.DashboardBaseMixin,
+                              mixins.DashboardComponentMixin,
                               mixins.DashboardContextMixin,
                               SuccessMessageMixin,
                               generic.UpdateView):


### PR DESCRIPTION
As FormSets won't work with OneToOne relations AreaSettings now have a custom form which is replacing the forms instance with the modules settings_instance. 

Note: The settings concept is still broken as OneToOne makes no sense at all. But this brings back the current functionality. Settings should be discussed at SoS



