### PR TITLE
Export module component 

### DIFF
--- a/meinberlin/apps/dashboard/templatetags/dashboard_tags.py
+++ b/meinberlin/apps/dashboard/templatetags/dashboard_tags.py
@@ -2,7 +2,7 @@ from django import template
 
 from meinberlin.apps.dashboard.blueprints import blueprints
 from meinberlin.apps.dashboard.views import get_management_view
-from meinberlin.apps.exports.views import get_exports
+from meinberlin.apps.exports import get_exports
 
 register = template.Library()
 

--- a/meinberlin/apps/exports/__init__.py
+++ b/meinberlin/apps/exports/__init__.py
@@ -1,0 +1,15 @@
+from functools import lru_cache
+
+
+@lru_cache()
+def get_exports(project_or_module):
+    exports = []
+    existing_views = set()
+    for phase in project_or_module.phases:
+        phase_view = phase.content().view
+        if hasattr(phase_view, 'exports'):
+            for name, view in phase_view.exports:
+                if view not in existing_views:
+                    existing_views.add(view)
+                    exports.append((name, view))
+    return exports

--- a/meinberlin/apps/exports/dashboard.py
+++ b/meinberlin/apps/exports/dashboard.py
@@ -1,0 +1,37 @@
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
+
+from meinberlin.apps.dashboard2 import DashboardComponent
+from meinberlin.apps.dashboard2 import components
+
+from . import get_exports
+from . import views
+
+
+class ExportModuleComponent(DashboardComponent):
+    identifier = 'module_export'
+    weight = 50
+
+    def get_menu_label(self, module):
+        if get_exports(module):
+            return _('Export')
+        return ''
+
+    def get_progress(self, module):
+        return 0, 0
+
+    def get_base_url(self, module):
+        return reverse('a4dashboard:export-module', kwargs={
+            'module_slug': module.slug,
+            'export_id': 0,
+        })
+
+    def get_urls(self):
+        return [
+            (r'^modules/(?P<module_slug>[-\w_]+)/export/(?P<export_id>\d+)/$',
+             views.ExportModuleDispatcher.as_view(),
+             'export-module'),
+        ]
+
+
+components.register_module(ExportModuleComponent())

--- a/meinberlin/apps/exports/dashboard.py
+++ b/meinberlin/apps/exports/dashboard.py
@@ -13,7 +13,7 @@ class ExportModuleComponent(DashboardComponent):
     weight = 50
 
     def get_menu_label(self, module):
-        if get_exports(module):
+        if not module.project.is_draft and get_exports(module):
             return _('Export')
         return ''
 

--- a/meinberlin/apps/exports/views.py
+++ b/meinberlin/apps/exports/views.py
@@ -1,6 +1,5 @@
 import csv
 from collections import OrderedDict
-from functools import lru_cache
 
 import xlsxwriter
 from django.contrib.contenttypes.models import ContentType
@@ -19,19 +18,7 @@ from adhocracy4.projects.models import Project
 from adhocracy4.ratings.models import Rating
 from adhocracy4.rules import mixins as rules_mixins
 
-
-@lru_cache()
-def get_exports(project):
-    exports = []
-    existing_views = set()
-    for phase in project.phases:
-        phase_view = phase.content().view
-        if hasattr(phase_view, 'exports'):
-            for name, view in phase_view.exports:
-                if view not in existing_views:
-                    existing_views.add(view)
-                    exports.append((name, view))
-    return exports
+from . import get_exports
 
 
 class ExportProjectDispatcher(rules_mixins.PermissionRequiredMixin,
@@ -82,7 +69,7 @@ class ExportModuleDispatcher(rules_mixins.PermissionRequiredMixin,
         if not self.has_permission():
             return self.handle_no_permission()
 
-        exports = get_exports(project)
+        exports = get_exports(module)
         assert len(exports) > export_id
 
         # Dispatch the request to the export view


### PR DESCRIPTION
Currently the component always returns the first export found. In the
future different exports for a single module may be possible, but this
would require a intermediate page to select the desired export.

The  export component is only shown for published projects


