### PR TITLE
Add explicit is_effective check to components

### DIFF
--- a/meinberlin/apps/dashboard2/__init__.py
+++ b/meinberlin/apps/dashboard2/__init__.py
@@ -34,7 +34,7 @@ class ProjectDashboard:
 
     def get_project_components(self):
         return [component for component in components.get_project_components()
-                if component.get_menu_label(self.project)]
+                if component.is_effective(self.project)]
 
     def get_module_components(self):
         return components.get_module_components()
@@ -44,15 +44,17 @@ class ProjectDashboard:
         num_required = 0
 
         for component in self.get_project_components():
-            nums = component.get_progress(self.project)
-            num_valid = num_valid + nums[0]
-            num_required = num_required + nums[1]
+            if component.is_effective(self.project):
+                nums = component.get_progress(self.project)
+                num_valid = num_valid + nums[0]
+                num_required = num_required + nums[1]
 
         for module in self.project.modules:
             for component in self.get_module_components():
-                nums = component.get_progress(module)
-                num_valid = num_valid + nums[0]
-                num_required = num_required + nums[1]
+                if component.is_effective(module):
+                    nums = component.get_progress(module)
+                    num_valid = num_valid + nums[0]
+                    num_required = num_required + nums[1]
 
         return num_valid, num_required
 
@@ -74,8 +76,8 @@ class ProjectDashboard:
     def get_project_menu(self, current_component):
         project_menu = []
         for component in self.get_project_components():
-            menu_item = component.get_menu_label(self.project)
-            if menu_item:
+            if component.is_effective(self.project):
+                menu_item = component.get_menu_label(self.project)
                 is_active = (component == current_component)
                 url = component.get_base_url(self.project)
                 num_valid, num_required = component.get_progress(self.project)
@@ -92,8 +94,8 @@ class ProjectDashboard:
     def get_module_menu(self, module, current_module, current_component):
         module_menu = []
         for component in self.get_module_components():
-            menu_item = component.get_menu_label(module)
-            if menu_item:
+            if component.is_effective(module):
+                menu_item = component.get_menu_label(module)
                 is_active = (component == current_component and
                              module.pk == current_module.pk)
                 url = component.get_base_url(module)
@@ -137,7 +139,7 @@ class TypedProjectDashboard(ProjectDashboard):
             return [components.projects.get('external')]
 
         return [component for component in components.get_project_components()
-                if component.get_menu_label(self.project)]
+                if component.is_effective(self.project)]
 
     def get_module_components(self):
         if self.project_type == 'bplan':

--- a/meinberlin/apps/dashboard2/__init__.py
+++ b/meinberlin/apps/dashboard2/__init__.py
@@ -77,14 +77,13 @@ class ProjectDashboard:
         project_menu = []
         for component in self.get_project_components():
             if component.is_effective(self.project):
-                menu_item = component.get_menu_label(self.project)
                 is_active = (component == current_component)
                 url = component.get_base_url(self.project)
                 num_valid, num_required = component.get_progress(self.project)
                 is_complete = (num_valid == num_required)
 
                 project_menu.append({
-                    'label': menu_item,
+                    'label': component.label,
                     'is_active': is_active,
                     'url': url,
                     'is_complete': is_complete,
@@ -95,7 +94,6 @@ class ProjectDashboard:
         module_menu = []
         for component in self.get_module_components():
             if component.is_effective(module):
-                menu_item = component.get_menu_label(module)
                 is_active = (component == current_component and
                              module.pk == current_module.pk)
                 url = component.get_base_url(module)
@@ -103,7 +101,7 @@ class ProjectDashboard:
                 is_complete = (num_valid == num_required)
 
                 module_menu.append({
-                    'label': menu_item,
+                    'label': component.label,
                     'is_active': is_active,
                     'url': url,
                     'is_complete': is_complete,

--- a/meinberlin/apps/dashboard2/components/__init__.py
+++ b/meinberlin/apps/dashboard2/components/__init__.py
@@ -36,6 +36,27 @@ class DashboardComponent:
     identifier = ''
     weight = 0
 
+    def is_effective(self, project_or_module):
+        """Return if the component is effective for the current context.
+
+        If a component isn't effective it won't be shown in the menu or
+        considered when determining the projects' progress.
+
+        Parameters
+        ----------
+        project_or_module : Project or Module
+            The project or module in whose context the component may
+            be effective.
+
+        Returns
+        -------
+        bool
+            Return True if the component is effective for the passed project
+            or module context.
+
+        """
+        return False
+
     def get_menu_label(self, project_or_module):
         """Return the menu label if the component should be shown.
 

--- a/meinberlin/apps/dashboard2/components/__init__.py
+++ b/meinberlin/apps/dashboard2/components/__init__.py
@@ -31,10 +31,15 @@ class DashboardComponent:
         The component with the lowest weight will be the default entry point
         for editing a project.
 
+    label : str
+        The localized label to be shown in the dashboard menu if the component
+        is effective
+
     """
 
     identifier = ''
     weight = 0
+    label = ''
 
     def is_effective(self, project_or_module):
         """Return if the component is effective for the current context.
@@ -56,25 +61,6 @@ class DashboardComponent:
 
         """
         return False
-
-    def get_menu_label(self, project_or_module):
-        """Return the menu label if the component should be shown.
-
-        Parameters
-        ----------
-        project_or_module : Project or Module
-            The project or module in whose context the component
-            should be shown.
-
-        Returns
-        -------
-        str
-            Return the localized label to be shown in the dashboard menu or
-            '' if the component should not be shown for the passed project or
-            module context.
-
-        """
-        return ''
 
     def get_progress(self, project_or_module):
         """Return the progress of this component.

--- a/meinberlin/apps/dashboard2/components/forms/__init__.py
+++ b/meinberlin/apps/dashboard2/components/forms/__init__.py
@@ -29,8 +29,6 @@ class ProjectFormComponent(DashboardComponent):
 
     Properties
     ----------
-    menu_label : str
-        This label is always returned regardless of project state
     form_title : str
         This title is shown on top of the rendered form
     form_class : ProjectDashboardForm
@@ -38,16 +36,12 @@ class ProjectFormComponent(DashboardComponent):
 
     """
 
-    menu_label = ''
     form_title = ''
     form_class = None
     form_template_name = ''
 
     def is_effective(self, project):
         return True
-
-    def get_menu_label(self, project):
-        return self.menu_label
 
     def get_base_url(self, project_or_module):
         name = 'a4dashboard:dashboard-{identifier}-edit'.format(
@@ -123,8 +117,6 @@ class ModuleFormComponent(ProjectFormComponent):
 
     Properties
     ----------
-    menu_label : str
-        This label is always returned regardless of module state
     form_title : str
         This title is shown on top of the rendered form
     form_class : ModuleDashboardForm
@@ -172,8 +164,6 @@ class ModuleFormSetComponent(ModuleFormComponent):
 
     Properties
     ----------
-    menu_label : str
-        This label is always returned regardless of module state
     form_title : str
         This title is shown on top of the rendered form
     form_class : ModuleDashboardFormSet

--- a/meinberlin/apps/dashboard2/components/forms/__init__.py
+++ b/meinberlin/apps/dashboard2/components/forms/__init__.py
@@ -25,6 +25,7 @@ class ProjectFormComponent(DashboardComponent):
     to be validly entered prior to project publishing. The component provides
     a get_progress implementation based on this list and prevents from removing
     required data if the project is published.
+    Form components are always effective.
 
     Properties
     ----------
@@ -41,6 +42,9 @@ class ProjectFormComponent(DashboardComponent):
     form_title = ''
     form_class = None
     form_template_name = ''
+
+    def is_effective(self, project):
+        return True
 
     def get_menu_label(self, project):
         return self.menu_label
@@ -115,6 +119,7 @@ class ModuleFormComponent(ProjectFormComponent):
     to be validly entered prior to project publishing. The component provides
     a get_progress implementation based on this list and prevents from removing
     required data if the project is published.
+    Form components are always effective.
 
     Properties
     ----------
@@ -163,6 +168,7 @@ class ModuleFormSetComponent(ModuleFormComponent):
     to be validly entered prior to project publishing. The component provides
     a get_progress implementation based on this list and prevents from removing
     required data if the project is published.
+    Form components are always effective.
 
     Properties
     ----------

--- a/meinberlin/apps/dashboard2/dashboard.py
+++ b/meinberlin/apps/dashboard2/dashboard.py
@@ -78,11 +78,12 @@ class ModuleAreaSettingsComponent(ModuleFormComponent):
     form_template_name = 'meinberlin_dashboard2/includes' \
                          '/module_areasettings_form.html'
 
-    def get_menu_label(self, module):
+    def is_effective(self, module):
         module_settings = module.settings_instance
-        if module_settings and hasattr(module_settings, 'polygon'):
-            return self.menu_label
-        return ''
+        return module_settings and hasattr(module_settings, 'polygon')
+
+    def get_menu_label(self, module):
+        return self.menu_label
 
     def get_progress(self, module):
         module_settings = module.settings_instance
@@ -100,24 +101,27 @@ class ModuleCategoriesComponent(ModuleFormSetComponent):
     form_template_name = 'meinberlin_dashboard2/includes' \
                          '/module_categories_form.html'
 
-    def get_menu_label(self, module):
-        # TODO: replace by module feature check
+    def is_effective(self, module):
         for phase in module.phases:
             for models in phase.content().features.values():
                 for model in models:
                     if Categorizable.is_categorizable(model):
-                        return _('Categories')
-        return ''
+                        return True
+        return False
+
+    def get_menu_label(self, module):
+        return _('Categories')
 
 
 class ParticipantsComponent(DashboardComponent):
     identifier = 'participants'
     weight = 30
 
+    def is_effective(self, project):
+        return project.is_private
+
     def get_menu_label(self, project):
-        if project.is_private:
-            return _('Participants')
-        return ''
+        return _('Participants')
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-participants-edit', kwargs={
@@ -135,6 +139,9 @@ class ParticipantsComponent(DashboardComponent):
 class ModeratorsComponent(DashboardComponent):
     identifier = 'moderators'
     weight = 31
+
+    def is_effective(self, project):
+        return True
 
     def get_menu_label(self, project):
         return _('Moderators')
@@ -162,11 +169,12 @@ class ExternalProjectComponent(ProjectFormComponent):
     form_template_name = 'meinberlin_dashboard2/includes' \
                          '/external_project_form.html'
 
-    def get_menu_label(self, project):
+    def is_effective(self, project):
         project_type = get_project_type(project)
-        if project_type == 'external':
-            return self.menu_label
-        return ''
+        return project_type == 'external'
+
+    def get_menu_label(self, project):
+        return self.menu_label
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-external-project-edit', kwargs={
@@ -206,11 +214,12 @@ class BplanProjectComponent(ProjectFormComponent):
     form_template_name = 'meinberlin_dashboard2/includes' \
                          '/bplan_project_form.html'
 
-    def get_menu_label(self, project):
+    def is_effective(self, project):
         project_type = get_project_type(project)
-        if project_type == 'bplan':
-            return self.menu_label
-        return ''
+        return project_type == 'bplan'
+
+    def get_menu_label(self, project):
+        return self.menu_label
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-bplan-project-edit', kwargs={

--- a/meinberlin/apps/dashboard2/dashboard.py
+++ b/meinberlin/apps/dashboard2/dashboard.py
@@ -16,8 +16,8 @@ from . import views
 class ProjectBasicComponent(ProjectFormComponent):
     identifier = 'basic'
     weight = 10
+    label = _('Basic settings')
 
-    menu_label = _('Basic settings')
     form_title = _('Edit basic settings')
     form_class = forms.ProjectBasicForm
     form_template_name = 'meinberlin_dashboard2/includes' \
@@ -27,8 +27,8 @@ class ProjectBasicComponent(ProjectFormComponent):
 class ProjectInformationComponent(ProjectFormComponent):
     identifier = 'information'
     weight = 11
+    label = _('Information')
 
-    menu_label = _('Information')
     form_title = _('Edit project information')
     form_class = forms.ProjectInformationForm
     form_template_name = 'meinberlin_dashboard2' \
@@ -38,8 +38,8 @@ class ProjectInformationComponent(ProjectFormComponent):
 class ProjectResultComponent(ProjectFormComponent):
     identifier = 'result'
     weight = 12
+    label = _('Result')
 
-    menu_label = _('Result')
     form_title = _('Edit project result')
     form_class = forms.ProjectResultForm
     form_template_name = 'meinberlin_dashboard2' \
@@ -49,8 +49,8 @@ class ProjectResultComponent(ProjectFormComponent):
 class ModuleBasicComponent(ModuleFormComponent):
     identifier = 'module_basic'
     weight = 10
+    label = _('Basic information')
 
-    menu_label = _('Basic information')
     form_title = _('Edit basic module information')
     form_class = forms.ModuleBasicForm
     form_template_name = 'meinberlin_dashboard2/includes' \
@@ -60,8 +60,8 @@ class ModuleBasicComponent(ModuleFormComponent):
 class ModulePhasesComponent(ModuleFormSetComponent):
     identifier = 'phases'
     weight = 11
+    label = _('Phases')
 
-    menu_label = _('Phases')
     form_title = _('Edit phases information')
     form_class = forms.PhaseFormSet
     form_template_name = 'meinberlin_dashboard2/includes' \
@@ -72,7 +72,7 @@ class ModuleAreaSettingsComponent(ModuleFormComponent):
     identifier = 'area_settings'
     weight = 12
 
-    menu_label = _('Areasettings')
+    label = _('Areasettings')
     form_title = _('Edit areasettings')
     form_class = forms.AreaSettingsForm
     form_template_name = 'meinberlin_dashboard2/includes' \
@@ -81,9 +81,6 @@ class ModuleAreaSettingsComponent(ModuleFormComponent):
     def is_effective(self, module):
         module_settings = module.settings_instance
         return module_settings and hasattr(module_settings, 'polygon')
-
-    def get_menu_label(self, module):
-        return self.menu_label
 
     def get_progress(self, module):
         module_settings = module.settings_instance
@@ -95,6 +92,7 @@ class ModuleAreaSettingsComponent(ModuleFormComponent):
 class ModuleCategoriesComponent(ModuleFormSetComponent):
     identifier = 'categories'
     weight = 13
+    label = _('Categories')
 
     form_title = _('Edit categories')
     form_class = forms.CategoryFormSet
@@ -109,19 +107,14 @@ class ModuleCategoriesComponent(ModuleFormSetComponent):
                         return True
         return False
 
-    def get_menu_label(self, module):
-        return _('Categories')
-
 
 class ParticipantsComponent(DashboardComponent):
     identifier = 'participants'
     weight = 30
+    label = _('Participants')
 
     def is_effective(self, project):
         return project.is_private
-
-    def get_menu_label(self, project):
-        return _('Participants')
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-participants-edit', kwargs={
@@ -139,12 +132,10 @@ class ParticipantsComponent(DashboardComponent):
 class ModeratorsComponent(DashboardComponent):
     identifier = 'moderators'
     weight = 31
+    label = _('Moderators')
 
     def is_effective(self, project):
         return True
-
-    def get_menu_label(self, project):
-        return _('Moderators')
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-moderators-edit', kwargs={
@@ -162,8 +153,8 @@ class ModeratorsComponent(DashboardComponent):
 class ExternalProjectComponent(ProjectFormComponent):
     identifier = 'external'
     weight = 10
+    label = _('External project settings')
 
-    menu_label = _('External project settings')
     form_title = _('Edit external project settings')
     form_class = forms.ExternalProjectForm
     form_template_name = 'meinberlin_dashboard2/includes' \
@@ -172,9 +163,6 @@ class ExternalProjectComponent(ProjectFormComponent):
     def is_effective(self, project):
         project_type = get_project_type(project)
         return project_type == 'external'
-
-    def get_menu_label(self, project):
-        return self.menu_label
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-external-project-edit', kwargs={
@@ -207,8 +195,8 @@ class ExternalProjectComponent(ProjectFormComponent):
 class BplanProjectComponent(ProjectFormComponent):
     identifier = 'bplan'
     weight = 10
+    label = _('Development plan settings')
 
-    menu_label = _('Development plan settings')
     form_title = _('Edit development plan settings')
     form_class = forms.BplanProjectForm
     form_template_name = 'meinberlin_dashboard2/includes' \
@@ -217,9 +205,6 @@ class BplanProjectComponent(ProjectFormComponent):
     def is_effective(self, project):
         project_type = get_project_type(project)
         return project_type == 'bplan'
-
-    def get_menu_label(self, project):
-        return self.menu_label
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-bplan-project-edit', kwargs={

--- a/meinberlin/apps/documents/dashboard.py
+++ b/meinberlin/apps/documents/dashboard.py
@@ -12,19 +12,17 @@ class DocumentComponent(DashboardComponent):
     identifier = 'document_settings'
     weight = 20
 
-    def get_menu_label(self, module):
+    def is_effective(self, module):
         module_app = module.phases[0].content().app
-        if module_app == 'meinberlin_documents':
-            return _('Document')
-        return ''
+        return module_app == 'meinberlin_documents'
+
+    def get_menu_label(self, module):
+        return _('Document')
 
     def get_progress(self, module):
-        module_app = module.phases[0].content().app
-        if module_app == 'meinberlin_documents':
-            if Chapter.objects.filter(module=module).exists():
-                return 1, 1
-            return 0, 1
-        return 0, 0
+        if Chapter.objects.filter(module=module).exists():
+            return 1, 1
+        return 0, 1
 
     def get_base_url(self, module):
         return reverse('a4dashboard:dashboard-document-settings', kwargs={

--- a/meinberlin/apps/documents/dashboard.py
+++ b/meinberlin/apps/documents/dashboard.py
@@ -11,13 +11,11 @@ from . import views
 class DocumentComponent(DashboardComponent):
     identifier = 'document_settings'
     weight = 20
+    label = _('Document')
 
     def is_effective(self, module):
         module_app = module.phases[0].content().app
         return module_app == 'meinberlin_documents'
-
-    def get_menu_label(self, module):
-        return _('Document')
 
     def get_progress(self, module):
         if Chapter.objects.filter(module=module).exists():

--- a/meinberlin/apps/exports/dashboard.py
+++ b/meinberlin/apps/exports/dashboard.py
@@ -11,12 +11,10 @@ from . import views
 class ExportModuleComponent(DashboardComponent):
     identifier = 'module_export'
     weight = 50
+    label = _('Export')
 
     def is_effective(self, module):
         return not module.project.is_draft and get_exports(module)
-
-    def get_menu_label(self, module):
-        return _('Export')
 
     def get_progress(self, module):
         return 0, 0

--- a/meinberlin/apps/exports/dashboard.py
+++ b/meinberlin/apps/exports/dashboard.py
@@ -12,10 +12,11 @@ class ExportModuleComponent(DashboardComponent):
     identifier = 'module_export'
     weight = 50
 
+    def is_effective(self, module):
+        return not module.project.is_draft and get_exports(module)
+
     def get_menu_label(self, module):
-        if not module.project.is_draft and get_exports(module):
-            return _('Export')
-        return ''
+        return _('Export')
 
     def get_progress(self, module):
         return 0, 0

--- a/meinberlin/apps/offlineevents/dashboard.py
+++ b/meinberlin/apps/offlineevents/dashboard.py
@@ -10,12 +10,10 @@ from . import views
 class OfflineEventsComponent(DashboardComponent):
     identifier = 'offlineevents'
     weight = 20
+    label = _('Offline Events')
 
     def is_effective(self, project):
         return True
-
-    def get_menu_label(self, project):
-        return _('Offline Events')
 
     def get_progress(self, project):
         return 0, 0

--- a/meinberlin/apps/offlineevents/dashboard.py
+++ b/meinberlin/apps/offlineevents/dashboard.py
@@ -11,6 +11,9 @@ class OfflineEventsComponent(DashboardComponent):
     identifier = 'offlineevents'
     weight = 20
 
+    def is_effective(self, project):
+        return True
+
     def get_menu_label(self, project):
         return _('Offline Events')
 

--- a/meinberlin/apps/polls/dashboard.py
+++ b/meinberlin/apps/polls/dashboard.py
@@ -12,19 +12,17 @@ class PollComponent(DashboardComponent):
     identifier = 'polls'
     weight = 20
 
-    def get_menu_label(self, module):
+    def is_effective(self, module):
         module_app = module.phases[0].content().app
-        if module_app == 'meinberlin_polls':
-            return _('Polls')
-        return ''
+        return module_app == 'meinberlin_polls'
+
+    def get_menu_label(self, module):
+        return _('Polls')
 
     def get_progress(self, module):
-        module_app = module.phases[0].content().app
-        if module_app == 'meinberlin_polls':
-            if models.Question.objects.filter(poll__module=module).exists():
-                return 1, 1
-            return 0, 1
-        return 0, 0
+        if models.Question.objects.filter(poll__module=module).exists():
+            return 1, 1
+        return 0, 1
 
     def get_base_url(self, module):
         return reverse('a4dashboard:poll-dashboard', kwargs={

--- a/meinberlin/apps/polls/dashboard.py
+++ b/meinberlin/apps/polls/dashboard.py
@@ -11,13 +11,11 @@ from . import views
 class PollComponent(DashboardComponent):
     identifier = 'polls'
     weight = 20
+    label = _('Polls')
 
     def is_effective(self, module):
         module_app = module.phases[0].content().app
         return module_app == 'meinberlin_polls'
-
-    def get_menu_label(self, module):
-        return _('Polls')
 
     def get_progress(self, module):
         if models.Question.objects.filter(poll__module=module).exists():

--- a/meinberlin/apps/topicprio/dashboard.py
+++ b/meinberlin/apps/topicprio/dashboard.py
@@ -12,19 +12,17 @@ class TopicEditComponent(DashboardComponent):
     identifier = 'topic_edit'
     weight = 20
 
-    def get_menu_label(self, module):
+    def is_effective(self, module):
         module_app = module.phases[0].content().app
-        if module_app == 'meinberlin_topicprio':
-            return _('Topics')
-        return ''
+        return module_app == 'meinberlin_topicprio'
+
+    def get_menu_label(self, module):
+        return _('Topics')
 
     def get_progress(self, module):
-        module_app = module.phases[0].content().app
-        if module_app == 'meinberlin_topicprio':
-            if models.Topic.objects.filter(module=module).exists():
-                return 1, 1
-            return 0, 1
-        return 0, 0
+        if models.Topic.objects.filter(module=module).exists():
+            return 1, 1
+        return 0, 1
 
     def get_base_url(self, module):
         return reverse('a4dashboard:topic-list', kwargs={

--- a/meinberlin/apps/topicprio/dashboard.py
+++ b/meinberlin/apps/topicprio/dashboard.py
@@ -11,13 +11,11 @@ from . import views
 class TopicEditComponent(DashboardComponent):
     identifier = 'topic_edit'
     weight = 20
+    label = _('Topics')
 
     def is_effective(self, module):
         module_app = module.phases[0].content().app
         return module_app == 'meinberlin_topicprio'
-
-    def get_menu_label(self, module):
-        return _('Topics')
 
     def get_progress(self, module):
         if models.Topic.objects.filter(module=module).exists():


### PR DESCRIPTION
Everything on a component (get_menu_label and get_progress ...) may only be called if is_effective is True.
This allows effectively to replace get_menu_label(project_or_module) with a fixed label property.
Furthermore it prevents to have to double check on module types at many places


