### PR TITLE
Add dashboard signals

### DIFF
--- a/meinberlin/apps/dashboard2/apps.py
+++ b/meinberlin/apps/dashboard2/apps.py
@@ -8,3 +8,6 @@ class Config(AppConfig):
     def ready(self):
         from django.utils.module_loading import autodiscover_modules
         autodiscover_modules('dashboard', register_to=self.module.components)
+
+        from . import signals
+        signals.connect_model_signal_handlers()

--- a/meinberlin/apps/dashboard2/mixins.py
+++ b/meinberlin/apps/dashboard2/mixins.py
@@ -16,6 +16,7 @@ from meinberlin.apps.contrib.views import ProjectContextDispatcher
 from meinberlin.apps.organisations import models as org_models
 
 from . import get_project_dashboard
+from . import signals
 
 
 class DashboardBaseMixin(rules_mixins.PermissionRequiredMixin):
@@ -123,12 +124,14 @@ class DashboardProjectDuplicateMixin:
             project_clone.created = datetime.now()
             project_clone.is_draft = True
             project_clone.save()
+            signals.project_created.send(sender=None, project=project_clone)
 
             for module in project.module_set.all():
                 module_clone = deepcopy(module)
                 module_clone.project = project_clone
                 module_clone.pk = None
                 module_clone.save()
+                signals.module_created.send(sender=None, module=module_clone)
 
                 for phase in module.phase_set.all():
                     phase_clone = deepcopy(phase)

--- a/meinberlin/apps/dashboard2/mixins.py
+++ b/meinberlin/apps/dashboard2/mixins.py
@@ -16,7 +16,6 @@ from meinberlin.apps.contrib.views import ProjectContextDispatcher
 from meinberlin.apps.organisations import models as org_models
 
 from . import get_project_dashboard
-from . import signals
 
 
 class DashboardBaseMixin(rules_mixins.PermissionRequiredMixin):
@@ -124,14 +123,12 @@ class DashboardProjectDuplicateMixin:
             project_clone.created = datetime.now()
             project_clone.is_draft = True
             project_clone.save()
-            signals.project_created.send(sender=None, project=project_clone)
 
             for module in project.module_set.all():
                 module_clone = deepcopy(module)
                 module_clone.project = project_clone
                 module_clone.pk = None
                 module_clone.save()
-                signals.module_created.send(sender=None, module=module_clone)
 
                 for phase in module.phase_set.all():
                     phase_clone = deepcopy(phase)

--- a/meinberlin/apps/dashboard2/signals.py
+++ b/meinberlin/apps/dashboard2/signals.py
@@ -1,0 +1,9 @@
+from django import dispatch
+
+project_created = dispatch.Signal(providing_args=['project'])
+module_created = dispatch.Signal(providing_args=['module'])
+# Handlers may return an error message to prevent a project from publishing
+project_pre_publish = dispatch.Signal(providing_args=['project'])
+project_published = dispatch.Signal(providing_args=['project'])
+project_unpublished = dispatch.Signal(providing_args=['project'])
+project_archived = dispatch.Signal(providing_args=['project'])

--- a/meinberlin/apps/dashboard2/signals.py
+++ b/meinberlin/apps/dashboard2/signals.py
@@ -1,4 +1,9 @@
 from django import dispatch
+from django.apps import apps
+from django.db.models import signals as db_signals
+
+from adhocracy4.modules.models import Module
+from adhocracy4.projects.models import Project
 
 project_created = dispatch.Signal(providing_args=['project'])
 module_created = dispatch.Signal(providing_args=['module'])
@@ -7,3 +12,23 @@ project_pre_publish = dispatch.Signal(providing_args=['project'])
 project_published = dispatch.Signal(providing_args=['project'])
 project_unpublished = dispatch.Signal(providing_args=['project'])
 project_archived = dispatch.Signal(providing_args=['project'])
+
+
+def _handle_project_signal(sender, instance, created, *args, **kwargs):
+    if created:
+        project_created.send(sender=None, project=instance)
+
+
+def _handle_module_signal(sender, instance, created, *args, **kwargs):
+    if created:
+        module_created.send(sender=None, module=instance)
+
+
+def connect_model_signal_handlers():
+    # Setup signals for all Models inheriting from Project
+    for model in apps.get_models():
+        if issubclass(model, Project):
+            db_signals.post_save.connect(_handle_project_signal, sender=model)
+
+    # Setup signals for Modules
+    db_signals.post_save.connect(_handle_module_signal, sender=Module)

--- a/meinberlin/apps/dashboard2/views.py
+++ b/meinberlin/apps/dashboard2/views.py
@@ -84,10 +84,6 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
 
     def form_valid(self, form):
         response = super().form_valid(form)
-
-        signals.project_created.send(sender=None, project=self.object)
-
-        # FIXME: maybe replace by dashboard signals
         self._create_modules_and_phases(self.object)
 
         return response
@@ -100,7 +96,6 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
             project=project,
         )
         module.save()
-        signals.module_created.send(sender=None, module=module)
 
         self._create_module_settings(module)
         self._create_phases(module, self.blueprint.content)

--- a/meinberlin/apps/dashboard2/views.py
+++ b/meinberlin/apps/dashboard2/views.py
@@ -23,6 +23,7 @@ from . import blueprints
 from . import forms
 from . import get_project_dashboard
 from . import mixins
+from . import signals
 from .components.forms.views import ProjectComponentFormView
 
 User = get_user_model()
@@ -84,6 +85,8 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
     def form_valid(self, form):
         response = super().form_valid(form)
 
+        signals.project_created.send(sender=None, project=self.object)
+
         # FIXME: maybe replace by dashboard signals
         self._create_modules_and_phases(self.object)
 
@@ -97,6 +100,8 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
             project=project,
         )
         module.save()
+        signals.module_created.send(sender=None, module=module)
+
         self._create_module_settings(module)
         self._create_phases(module, self.blueprint.content)
 
@@ -173,8 +178,18 @@ class ProjectPublishView(mixins.DashboardBaseMixin,
                              'Required fields are missing.'))
             return
 
+        responses = signals.project_pre_publish.send(sender=None,
+                                                     project=self.project)
+        errors = [str(msg) for func, msg in responses if msg]
+        if errors:
+            msg = _('Project cannot be published.') + ' \n' + '\n'.join(errors)
+            messages.error(self.request, msg)
+            return
+
         self.project.is_draft = False
         self.project.save()
+        signals.project_published.send(sender=None, project=self.project)
+
         messages.success(self.request,
                          _('Project successfully published.'))
 
@@ -185,6 +200,7 @@ class ProjectPublishView(mixins.DashboardBaseMixin,
 
         self.project.is_draft = True
         self.project.save()
+        signals.project_unpublished.send(sender=None, project=self.project)
         messages.success(self.request,
                          _('Project successfully unpublished.'))
 


### PR DESCRIPTION
Note that the project_pre_publish signal may be used to prevent from publishing if
any connected handler returns an error message.
The create signals are derived directly from the db signals. Unfortunately this is not easily possible for the other cases as they require a before/after knowledge.