### PR TITLE
restore default browser focus style

### DIFF
--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -33,7 +33,6 @@ select {
 
     &:focus {
         border-color: $brand-secondary;
-        outline: none;
     }
 }
 


### PR DESCRIPTION
The default focus style in chromium (a light blue outline) was removed in #732. I believe that consistency across pages is more important than consistency across browsers (because users rarely change their browser but spend a lot of time with the same browser on other people's pages).

So I propose to restore the outline.