### PR TITLE
only show feedback button on large screens

### DIFF
--- a/meinberlin/assets/scss/_layout.scss
+++ b/meinberlin/assets/scss/_layout.scss
@@ -23,7 +23,7 @@
     @include clearfix;
     position: relative;
     width: 100%;  // required when used in a flex container
-    max-width: 81rem;
+    max-width: $wrapper-width;
     margin: 0 auto;
     padding: 0 $padding;
 }

--- a/meinberlin/assets/scss/_variables.scss
+++ b/meinberlin/assets/scss/_variables.scss
@@ -41,6 +41,7 @@ $font-size-xs: 0.64rem;
 
 $breakpoint: 50em;
 $breakpoint-md: 64em;
+$wrapper-width: 81rem;
 
 $hero-height: 41em;
 $hero-height-secondary: 30em;

--- a/meinberlin/assets/scss/components/_fixed_side.scss
+++ b/meinberlin/assets/scss/components/_fixed_side.scss
@@ -7,7 +7,7 @@
     top: 45%;
     z-index: 1;
 
-    @media (min-width: $breakpoint) {
+    @media (min-width: ($wrapper-width + 4rem)) {
         display: block;
     }
 }


### PR DESCRIPTION
fixes #518

We already did hide the feedback button on small screens. But there was a rather large area in which we could not be reasonably sure that nothing is covered. This is fixed now.

Note that the feedback form is already linked in the footer, so the information is still available.