### PR TITLE
fix huge focus box on datepicker in firefox

### DIFF
--- a/meinberlin/assets/scss/components/_datepicker.scss
+++ b/meinberlin/assets/scss/components/_datepicker.scss
@@ -102,3 +102,9 @@
         text-shadow: none;
     }
 }
+
+// The original styling causes a huge focus box in firefox
+.fd-screen-reader {
+    @include sr-only;
+    left: 0;
+}


### PR DESCRIPTION
![screenshot from 2017-09-12 17-19-51](https://user-images.githubusercontent.com/202576/30334050-c3bda236-97de-11e7-88d3-4cbd2b9c2b71.png)
