### PR TITLE
reduce number of extra category fields to 1

### DIFF
--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -197,5 +197,5 @@ CategoryFormSet = inlineformset_factory(module_models.Module,
                                         category_models.Category,
                                         form=CategoryForm,
                                         formset=ModuleDashboardFormSet,
-                                        extra=1,
+                                        extra=0,
                                         )

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -197,4 +197,5 @@ CategoryFormSet = inlineformset_factory(module_models.Module,
                                         category_models.Category,
                                         form=CategoryForm,
                                         formset=ModuleDashboardFormSet,
+                                        extra=1,
                                         )


### PR DESCRIPTION
The category form always displays 3 empty fields. This is confusing, especially when I remove them and submit, just to find that they are back.

I talked to @damusp and we thought that it would be nice to show the 3 empty fields only when there are no categories.

When trying to implement this, I only found the `min_num` parameter which would lead to strange results when trying to create less then 3 categories (if I manually remove the fields it works fine, but not if I leave them empty).

In the end I simply reduced the number of extra fields to 1. @damusp what do you think?