### PR TITLE
remove unnecessary @extend from follow styling

### DIFF
--- a/meinberlin/assets/scss/_shame.scss
+++ b/meinberlin/assets/scss/_shame.scss
@@ -36,7 +36,6 @@ input[type="search"] {
 // used by adhocracy4 for the follow button, long-term we'd like
 // our own classes.
 .btngroup .btn {
-    @extend %button-base;
     @extend .btn--light;
     @extend .btn--small;
 


### PR DESCRIPTION
our buttons were renamed to `.btn` in #699, so the styling already applies.