### PR TITLE
clearify connection between "notification" and "follow"

### DIFF
--- a/meinberlin/apps/users/models.py
+++ b/meinberlin/apps/users/models.py
@@ -55,7 +55,8 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
         verbose_name=_('Send me email notifications'),
         default=True,
         help_text=_(
-            'Designates whether you want to receive notifications. '
+            'Designates whether you want to receive notifications about '
+            'content you follow. '
             'Unselect if you do not want to receive notifications.')
     )
 


### PR DESCRIPTION
we got the feedback that the connection between "email", "notification", and "follow" is not completely clear.

@janaba what do you think of this change?