### PR TITLE
Remove potential circular import

### DIFF
--- a/meinberlin/apps/dashboard/templatetags/dashboard_tags.py
+++ b/meinberlin/apps/dashboard/templatetags/dashboard_tags.py
@@ -1,13 +1,13 @@
 from django import template
 
-from meinberlin.apps.dashboard2.blueprints import blueprints
+from meinberlin.apps.dashboard2.blueprints import get_blueprints
 
 register = template.Library()
 
 
 @register.filter
 def get_blueprint_title(key):
-    for k, blueprint in blueprints:
+    for k, blueprint in get_blueprints():
         if k == key:
             return blueprint.title
     return key

--- a/meinberlin/apps/dashboard2/blueprints.py
+++ b/meinberlin/apps/dashboard2/blueprints.py
@@ -10,10 +10,7 @@ ProjectBlueprint = namedtuple(
 )
 
 
-def _get_blueprints():
+def get_blueprints():
     key = 'BLUEPRINTS'
     dashboard_settings = settings.A4_DASHBOARD
     return import_string(dashboard_settings[key])
-
-
-blueprints = _get_blueprints()

--- a/meinberlin/apps/dashboard2/mixins.py
+++ b/meinberlin/apps/dashboard2/mixins.py
@@ -56,8 +56,8 @@ class DashboardBaseMixin(rules_mixins.PermissionRequiredMixin):
 class BlueprintMixin:
     @property
     def blueprint(self):
-        from .blueprints import blueprints
-        return dict(blueprints)[self.blueprint_key]
+        from .blueprints import get_blueprints
+        return dict(get_blueprints())[self.blueprint_key]
 
     @property
     def blueprint_key(self):

--- a/meinberlin/apps/dashboard2/views.py
+++ b/meinberlin/apps/dashboard2/views.py
@@ -18,12 +18,12 @@ from adhocracy4.phases import models as phase_models
 from adhocracy4.projects import models as project_models
 from meinberlin.apps.projects.emails import InviteParticipantEmail
 
-from . import blueprints
 from . import filter
 from . import forms
 from . import get_project_dashboard
 from . import mixins
 from . import signals
+from .blueprints import get_blueprints
 
 User = get_user_model()
 
@@ -53,10 +53,13 @@ class ProjectListView(mixins.DashboardBaseMixin,
 
 class BlueprintListView(mixins.DashboardBaseMixin,
                         generic.TemplateView):
-    blueprints = blueprints.blueprints
     template_name = 'meinberlin_dashboard2/blueprint_list.html'
     permission_required = 'a4projects.add_project'
     menu_item = 'project'
+
+    @property
+    def blueprints(self):
+        return get_blueprints()
 
 
 class ProjectCreateView(mixins.DashboardBaseMixin,

--- a/meinberlin/apps/projects/views.py
+++ b/meinberlin/apps/projects/views.py
@@ -12,7 +12,7 @@ from adhocracy4.filters.filters import DefaultsFilterSet
 from adhocracy4.filters.filters import FreeTextFilter
 from adhocracy4.filters.widgets import DropdownLinkWidget
 from adhocracy4.projects import models as project_models
-from meinberlin.apps.dashboard2 import blueprints
+from meinberlin.apps.dashboard2.blueprints import get_blueprints
 
 
 class OrderingWidget(DropdownLinkWidget):
@@ -61,7 +61,8 @@ class TypeWidget(DropdownLinkWidget):
 
     def __init__(self, attrs=None):
         choices = (('', _('Any')),)
-        sorted_blueprints = sorted(blueprints.blueprints, key=lambda a: a[1])
+        blueprints = get_blueprints()
+        sorted_blueprints = sorted(blueprints, key=lambda a: a[1])
         for blueprint_key, blueprint in sorted_blueprints:
             choices += (blueprint_key, blueprint.title),
         super().__init__(attrs, choices)


### PR DESCRIPTION
`get_blueprints()` dashboard2/blueprints.py is importing the module from the settings (in our case dashboard/blueprints.py) which is importing `ProjectBlueprint` from dashboard2/blueprints.py

```
dashboard2/blueprints.py 
[ blueprints = _get_blueprints()  ->  importlib.import_module ]
dashboard/blueprints.py 
[ from meinberlin.apps.dashboard2.blueprints import ProjectBlueprint ]
dasboard2/blueprints.py
```

I am not sure why this has not been a problem yet. Maybe because only some metehods/classes are imported?  @2e2a  @xi  do you have any idea how python resolves this?