### PR TITLE
Accessibility fixes

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-18 16:33+0200\n"
+"POT-Creation-Date: 2017-09-19 15:28+0200\n"
 "PO-Revision-Date: 2017-09-18 15:04+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -977,7 +977,6 @@ msgstr ""
 "Legen Sie Orte auf einer Karte an, welche dann von den Nutzerinnen und "
 "Nutzern bewertet und kommentiert werden können."
 
-
 #: meinberlin/apps/dashboard/blueprints.py:146
 msgid "Development Plan"
 msgstr "Bebauungsplan"
@@ -1903,21 +1902,23 @@ msgstr "Projekt auf meinBerlin"
 #, python-format
 msgid ""
 "\n"
-"                    Participation possible until %(date)s\n"
+"                    Participation possible until <time datetime=\"%(isodate)s"
+"\">%(date)s</time>\n"
 "                "
 msgstr ""
 "\n"
-"Beteiligung möglich bis zum %(date)s"
+"Beteiligung möglich bis zum <time datetime=\"%(isodate)s\">%(date)s</time>"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:52
 #, python-format
 msgid ""
 "\n"
-"                    Participation starting from %(date)s\n"
+"                    Participation starting from <time datetime=\"%(isodate)s"
+"\">%(date)s</time>\n"
 "                "
 msgstr ""
 "\n"
-"Beteiligung fängt ab dem %(date)s an"
+"Beteiligung fängt ab dem <time datetime=\"%(isodate)s\">%(date)s</time> an"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:7
 msgid "Timeline"
@@ -1942,18 +1943,18 @@ msgstr "Die Beteiligung ist aktuell nicht möglich."
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:51
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:96
 #, python-format
-msgid "It starts on %(date)s."
-msgstr "Sie startet am %(date)s."
+msgid "It starts on <time datetime=\"%(isodate)s\">%(date)s</time>."
+msgstr "Sie startet am <time datetime=\"%(isodate)s\">%(date)s</time>."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:53
 #, python-format
-msgid "It continues on %(date)s."
-msgstr "Es geht weiter am %(date)s."
+msgid "It continues on <time datetime=\"%(isodate)s\">%(date)s</time>."
+msgstr "Es geht weiter am <time datetime=\"%(isodate)s\">%(date)s</time>."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:55
 #, python-format
-msgid "It ended on %(date)s."
-msgstr "Sie hat am %(date)s geendet."
+msgid "It ended on <time datetime=\"%(isodate)s\">%(date)s</time>."
+msgstr "Sie hat am <time datetime=\"%(isodate)s\">%(date)s</time> geendet."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:89
 msgid "Show phase overview"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-18 16:33+0200\n"
+"POT-Creation-Date: 2017-09-19 15:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1818,22 +1818,26 @@ msgstr "Project on meinBerlin"
 #, python-format
 msgid ""
 "\n"
-"                    Participation possible until %(date)s\n"
+"                    Participation possible until <time datetime=\"%(isodate)s"
+"\">%(date)s</time>\n"
 "                "
 msgstr ""
 "\n"
-"                    Participation possible until %(date)s\n"
+"                    Participation possible until <time datetime=\"%(isodate)s"
+"\">%(date)s</time>\n"
 "                "
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:52
 #, python-format
 msgid ""
 "\n"
-"                    Participation starting from %(date)s\n"
+"                    Participation starting from <time datetime=\"%(isodate)s"
+"\">%(date)s</time>\n"
 "                "
 msgstr ""
 "\n"
-"                    Participation starting from %(date)s\n"
+"                    Participation starting from <time datetime=\"%(isodate)s"
+"\">%(date)s</time>\n"
 "                "
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:7
@@ -1859,18 +1863,18 @@ msgstr "Participation is not possible at the moment."
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:51
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:96
 #, python-format
-msgid "It starts on %(date)s."
-msgstr "It starts on %(date)s."
+msgid "It starts on <time datetime=\"%(isodate)s\">%(date)s</time>."
+msgstr "It starts on <time datetime=\"%(isodate)s\">%(date)s</time>."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:53
 #, python-format
-msgid "It continues on %(date)s."
-msgstr "It continues on %(date)s."
+msgid "It continues on <time datetime=\"%(isodate)s\">%(date)s</time>."
+msgstr "It continues on <time datetime=\"%(isodate)s\">%(date)s</time>."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:55
 #, python-format
-msgid "It ended on %(date)s."
-msgstr "It ended on %(date)s."
+msgid "It ended on <time datetime=\"%(isodate)s\">%(date)s</time>."
+msgstr "It ended on <time datetime=\"%(isodate)s\">%(date)s</time>."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html:89
 msgid "Show phase overview"

--- a/meinberlin/apps/actions/templates/meinberlin_actions/includes/action.html
+++ b/meinberlin/apps/actions/templates/meinberlin_actions/includes/action.html
@@ -25,7 +25,7 @@
             {% blocktrans with url=action.project.get_absolute_url name=action.project.name %}on <a href="{{ url }}">{{ name }}</a>{% endblocktrans %}
         </div>
         <div class="action__date">
-            <time datetime="{{ action.timestamp|date:'Y-m-d H:i' }}"
+            <time datetime="{{ action.timestamp|date:'c' }}"
                   title="{{ action.timestamp|date:'DATETIME_FORMAT' }}"
                   class="relative">
                 {{ action.timestamp|date:'d.m.Y' }}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
@@ -44,7 +44,7 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    <span class="list-item__date">
-        {{ object.created | date }}
-    </span>
+    <time class="list-item__date" datetime="{{ object.created|date:'c' }}">
+        {{ object.created|date }}
+    </time>
 </li>

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_list_item.html
@@ -1,30 +1,32 @@
 {% load i18n item_tags moderatorfeedback_tags humanize %}
 
 <li class="list-item list-item--squashed">
-    <div class="list-item__stats">
-        {% spaceless %}
-        <span class="rating">
-            <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
-                <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
-                {{ object.positive_rating_count }}
+    <div class="list-item__header">
+        <h3 class="list-item__title">
+            {% get_item_detail_url object as detail_url %}
+            <a href="{{ detail_url }}">
+            {{ object.name }}
+            </a>
+        </h3>
+        <div class="list-item__stats">
+            {% spaceless %}
+            <span class="rating">
+                <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
+                    <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+                    {{ object.positive_rating_count }}
+                </span>
+                <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
+                    <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
+                    {{ object.negative_rating_count }}
+                </span>
             </span>
-            <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
-                <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
-                {{ object.negative_rating_count }}
+            <span title="{% trans 'Comments' %}" class="list-item__comments">
+                <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
+                {{ object.comment_count }}
             </span>
-        </span>
-        <span title="{% trans 'Comments' %}" class="list-item__comments">
-            <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
-            {{ object.comment_count }}
-        </span>
-        {% endspaceless %}
+            {% endspaceless %}
+        </div>
     </div>
-    <h3 class="list-item__title">
-        {% get_item_detail_url object as detail_url %}
-        <a href="{{ detail_url }}">
-        {{ object.name }}
-        </a>
-    </h3>
     <div class="list-item__labels">
         {% if object.category %}
             <span class="label label--big">{{ object.category }}</span>

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
@@ -22,9 +22,9 @@
                         <strong class="moderator-statement__organisation">
                             {{ proposal.module.project.organisation.name }}
                         </strong>
-                        <span class="moderator-statement__date">
-                            {{ proposal.moderator_statement.created | date }}
-                        </span>
+                        <time class="moderator-statement__date" datetime="{{ proposal.moderator_statement.created|date:'c' }}">
+                            {{ proposal.moderator_statement.created|date }}
+                        </time>
                     </div>
                     <div class="moderator-statement__body">
                         {{ proposal.moderator_statement.statement | safe }}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -34,7 +34,7 @@
 
             <div class="item-detail__meta">
                 <strong class="item-detail__creator">{{ object.creator.username }}</strong>
-                {{ object.created|date }}
+                <time datetime="{{ object.created|date:"c" }}">{{ object.created|date }}</time>
             </div>
 
             <div class="item-detail__actions lr-bar">

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -1,32 +1,34 @@
 {% load i18n module_tags item_tags %}
 
 <li class="list-item list-item--squashed">
-    <div class="list-item__stats">
-        {% spaceless %}
-        {% if object|has_feature:"rate" %}
-            <span class="rating">
-                <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
-                    <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
-                    {{ object.positive_rating_count }}
+    <div class="list-item__header">
+        <h3 class="list-item__title">
+            {% get_item_detail_url object as detail_url %}
+            <a href="{{ detail_url }}">
+            {{ object.name }}
+            </a>
+        </h3>
+        <div class="list-item__stats">
+            {% spaceless %}
+            {% if object|has_feature:"rate" %}
+                <span class="rating">
+                    <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
+                        <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+                        {{ object.positive_rating_count }}
+                    </span>
+                    <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
+                        <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
+                        {{ object.negative_rating_count }}
+                    </span>
                 </span>
-                <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
-                    <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
-                    {{ object.negative_rating_count }}
-                </span>
+            {% endif %}
+            <span title="{% trans 'Comments' %}" class="list-item__comments">
+                <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
+                {{ object.comment_count }}
             </span>
-        {% endif %}
-        <span title="{% trans 'Comments' %}" class="list-item__comments">
-            <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
-            {{ object.comment_count }}
-        </span>
-        {% endspaceless %}
+            {% endspaceless %}
+        </div>
     </div>
-    <h3 class="list-item__title">
-        {% get_item_detail_url object as detail_url %}
-        <a href="{{ detail_url }}">
-        {{ object.name }}
-        </a>
-    </h3>
     {% if object.category %}
         <div class="list-item__labels">
             <span class="label label--big">{{ object.category }}</span>

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -35,7 +35,7 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    <span class="list-item__date">
-        {{ object.created | date }}
-    </span>
+    <time class="list-item__date" datetime="{{ object.created|date:'c' }}">
+        {{ object.created|date }}
+    </time>
 </li>

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/includes/proposal_list_item.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/includes/proposal_list_item.html
@@ -44,7 +44,7 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    <span class="list-item__date">
-        {{ object.created | date }}
-    </span>
+    <time class="list-item__date" datetime="{{ object.created|date:'c' }}">
+        {{ object.created|date }}
+    </time>
 </li>

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/includes/proposal_list_item.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/includes/proposal_list_item.html
@@ -1,30 +1,32 @@
 {% load i18n item_tags moderatorfeedback_tags humanize %}
 
 <li class="list-item list-item--squashed">
-    <div class="list-item__stats">
-        {% spaceless %}
-        <span class="rating">
-            <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
-                <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
-                {{ object.positive_rating_count }}
+    <div class="list-item__header">
+        <h3 class="list-item__title">
+            {% get_item_detail_url object as detail_url %}
+            <a href="{{ detail_url }}">
+            {{ object.name }}
+            </a>
+        </h3>
+        <div class="list-item__stats">
+            {% spaceless %}
+            <span class="rating">
+                <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
+                    <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+                    {{ object.positive_rating_count }}
+                </span>
+                <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
+                    <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
+                    {{ object.negative_rating_count }}
+                </span>
             </span>
-            <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
-                <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
-                {{ object.negative_rating_count }}
+            <span title="{% trans 'Comments' %}" class="list-item__comments">
+                <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
+                {{ object.comment_count }}
             </span>
-        </span>
-        <span title="{% trans 'Comments' %}" class="list-item__comments">
-            <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
-            {{ object.comment_count }}
-        </span>
-        {% endspaceless %}
+            {% endspaceless %}
+        </div>
     </div>
-    <h3 class="list-item__title">
-        {% get_item_detail_url object as detail_url %}
-        <a href="{{ detail_url }}">
-        {{ object.name }}
-        </a>
-    </h3>
     <div class="list-item__labels">
         {% if object.category %}
             <span class="label label--big">{{ object.category }}</span>

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_detail.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_detail.html
@@ -22,9 +22,9 @@
                         <strong class="moderator-statement__organisation">
                             {{ proposal.module.project.organisation.name }}
                         </strong>
-                        <span class="moderator-statement__date">
-                            {{ proposal.moderator_statement.created | date }}
-                        </span>
+                        <time class="moderator-statement__date" datetime="{{ proposal.moderator_statement.created|date }}">
+                            {{ proposal.moderator_statement.created|date }}
+                        </time>
                     </div>
                     <div class="moderator-statement__body">
                         {{ proposal.moderator_statement.statement | safe }}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
@@ -1,32 +1,34 @@
 {% load i18n module_tags item_tags %}
 
 <li class="list-item list-item--squashed">
-    <div class="list-item__stats">
-        {% spaceless %}
-        {% if object|has_feature:"rate" %}
-            <span class="rating">
-                <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
-                    {{ object.positive_rating_count }}
-                    <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+    <div class="list-item__header">
+        <h3 class="list-item__title">
+            {% get_item_detail_url object as detail_url %}
+            <a href="{{ detail_url }}">
+            {{ object.name }}
+            </a>
+        </h3>
+        <div class="list-item__stats">
+            {% spaceless %}
+            {% if object|has_feature:"rate" %}
+                <span class="rating">
+                    <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
+                        {{ object.positive_rating_count }}
+                        <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+                    </span>
+                    <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
+                        {{ object.negative_rating_count }}
+                        <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
+                    </span>
                 </span>
-                <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
-                    {{ object.negative_rating_count }}
-                    <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
-                </span>
+            {% endif %}
+            <span title="{% trans 'Comments' %}">
+                {{ object.comment_count }}
+                <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
             </span>
-        {% endif %}
-        <span title="{% trans 'Comments' %}">
-            {{ object.comment_count }}
-            <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
-        </span>
-        {% endspaceless %}
+            {% endspaceless %}
+        </div>
     </div>
-    <h3 class="list-item__title">
-        {% get_item_detail_url object as detail_url %}
-        <a href="{{ detail_url }}">
-        {{ object.name }}
-        </a>
-    </h3>
     <div class="list-item__labels">
         {% if object.category %}
             <span class="label label--big">{{ object.category }}</span>

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
@@ -38,7 +38,7 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    <span class="list-item__date">
-        {{ object.created | date }}
-    </span>
+    <time class="list-item__date" datetime="{{ object.created|date:'c' }}">
+        {{ object.created|date }}
+    </time>
 </li>

--- a/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html
+++ b/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html
@@ -1,32 +1,34 @@
 {% load i18n module_tags item_tags %}
 
 <li class="list-item list-item--squashed">
-    <div class="list-item__stats">
-        {% spaceless %}
-        {% if object|has_feature:"rate" %}
-            <span class="rating">
-                <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
-                    {{ object.positive_rating_count }}
-                    <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+    <div class="list-item__header">
+        <h3 class="list-item__title">
+            {% get_item_detail_url object as detail_url %}
+            <a href="{{ detail_url }}">
+            {{ object.name }}
+            </a>
+        </h3>
+        <div class="list-item__stats">
+            {% spaceless %}
+            {% if object|has_feature:"rate" %}
+                <span class="rating">
+                    <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
+                        {{ object.positive_rating_count }}
+                        <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+                    </span>
+                    <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
+                        {{ object.negative_rating_count }}
+                        <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
+                    </span>
                 </span>
-                <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
-                    {{ object.negative_rating_count }}
-                    <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
-                </span>
+            {% endif %}
+            <span title="{% trans 'Comments' %}">
+                {{ object.comment_count }}
+                <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
             </span>
-        {% endif %}
-        <span title="{% trans 'Comments' %}">
-            {{ object.comment_count }}
-            <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
-        </span>
-        {% endspaceless %}
+            {% endspaceless %}
+        </div>
     </div>
-    <h3 class="list-item__title">
-        {% get_item_detail_url object as detail_url %}
-        <a href="{{ detail_url }}">
-        {{ object.name }}
-        </a>
-    </h3>
     {% if object.category %}
         <div class="list-item__labels">
             <span class="label label--big">{{ object.category }}</span>

--- a/meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/includes/offlineevent_list_item.html
+++ b/meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/includes/offlineevent_list_item.html
@@ -8,9 +8,9 @@
                 {{ object.name }}
                 </a>
             </h3>
-            <span class="list-item__date">
-                {{ object.date | date }}
-            </span>
+            <time class="list-item__date" datetime="{{ object.date|date:'c' }}" >
+                {{ object.date|date }}
+            </time>
         </div>
         <div class="lr-bar__right">
             <a href="{% url 'a4dashboard:offlineevent-delete' slug=object.slug %}"

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
@@ -43,14 +43,14 @@
 
         {% if project.active_phase %}
             <p class="tile__hint">
-                {% blocktrans with project.last_active_phase.end_date|date:'d.m.Y' as date %}
-                    Participation possible until {{ date }}
+                {% blocktrans with date=project.last_active_phase.end_date|date:'d.m.Y' isodate=project.last_active_phase.end_date|date:'c' %}
+                    Participation possible until <time datetime="{{ isodate }}">{{ date }}</time>
                 {% endblocktrans %}
             </p>
         {% elif project.future_phases %}
             <p class="tile__hint">
-                {% blocktrans with project.future_phases.first.start_date|date:'d.m.Y' as date %}
-                    Participation starting from {{ date }}
+                {% blocktrans with date=project.future_phases.first.start_date|date:'d.m.Y' isodate=project.future_phases.first.start_date|date:'c' %}
+                    Participation starting from <time datetime="{{ isodate }}">{{ date }}</time>
                 {% endblocktrans %}
             </p>
         {% endif %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
@@ -48,11 +48,11 @@
                         <strong>
                             {% trans 'Participation is not possible at the moment.' %}
                             {% if not module.past_phases %}
-                                {% blocktrans with module.future_phases.first.start_date|date:'DATE_FORMAT' as date %}It starts on {{ date }}.{% endblocktrans%}
+                                {% blocktrans with date=module.future_phases.first.start_date|date:'DATE_FORMAT' isodate=module.future_phases.first.start_date|date:'c' %}It starts on <time datetime="{{ isodate }}">{{ date }}</time>.{% endblocktrans%}
                             {% elif module.future_phases %}
-                                {% blocktrans with module.future_phases.first.start_date|date:'DATE_FORMAT' as date %}It continues on {{ date }}.{% endblocktrans%}
+                                {% blocktrans with date=module.future_phases.first.start_date|date:'DATE_FORMAT' isodate=module.future_phases.first.start_date|date:'c' %}It continues on <time datetime="{{ isodate }}">{{ date }}</time>.{% endblocktrans%}
                             {% else %}
-                                {% blocktrans with module.past_phases.last.end_date|date:'DATE_FORMAT' as date %}It ended on {{ date }}.{% endblocktrans%}
+                                {% blocktrans with date=module.past_phases.last.end_date|date:'DATE_FORMAT' isodate=module.past_phases.first.start_date|date:'c' %}It ended on <time datetime="{{ isodate }}">{{ date }}</time>.{% endblocktrans%}
                             {% endif %}
                         </strong>
                     </div>
@@ -75,8 +75,8 @@
                                 {% endif %}
                             </div>
                             <div class="phase-info__item__subtitle">
-                                {{ phase.start_date|date:'DATE_FORMAT' }}
-                                &ndash; {{ phase.end_date|date:'DATE_FORMAT' }}
+                                <time datetime="{{ phase.start_date|date:'c' }}">{{ phase.start_date|date:'DATE_FORMAT' }}</time>
+                                &ndash; <time datetime="{{ phase.end_date|date:'c' }}">{{ phase.end_date|date:'DATE_FORMAT' }}</time>
                             </div>
                             <div class="phase-info__item__description">
                                 {{ phase.description }}
@@ -93,7 +93,7 @@
                 <div class="item-detail__meta">
                     <strong>
                         {% trans 'Participation is not possible at the moment.' %}
-                        {% blocktrans with project.future_phases.first.start_date|date:'DATE_FORMAT' as date %}It starts on {{ date }}.{% endblocktrans%}
+                        {% blocktrans with date=project.future_phases.first.start_date|date:'DATE_FORMAT' isodate=project.future_phases.first.start_date|date:'c' %}It starts on <time datetime="{{ isodate }}">{{ date }}</time>.{% endblocktrans%}
                     </strong>
                 </div>
             {% endif %}

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
@@ -1,32 +1,34 @@
 {% load i18n module_tags item_tags %}
 
 <li class="list-item list-item--squashed">
-    <div class="list-item__stats">
-        {% spaceless %}
-        {% if object|has_feature:"rate" %}
-            <span class="rating">
-                <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
-                    {{ object.positive_rating_count }}
-                    <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+    <div class="list-item__header">
+        <h3 class="list-item__title">
+            {% get_item_detail_url object as detail_url %}
+            <a href="{{ detail_url }}">
+            {{ object.name }}
+            </a>
+        </h3>
+        <div class="list-item__stats">
+            {% spaceless %}
+            {% if object|has_feature:"rate" %}
+                <span class="rating">
+                    <span class="rating-button rating-up is-read-only" title="{% trans 'Positive Ratings' %}">
+                        {{ object.positive_rating_count }}
+                        <i class="fa fa-chevron-up" aria-label="{% trans 'Positive Ratings' %}"></i>
+                    </span>
+                    <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
+                        {{ object.negative_rating_count }}
+                        <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
+                    </span>
                 </span>
-                <span class="rating-button rating-down is-read-only" title="{% trans 'Negative Ratings' %}">
-                    {{ object.negative_rating_count }}
-                    <i class="fa fa-chevron-down" aria-label="{% trans 'Negative Ratings' %}"></i>
-                </span>
+            {% endif %}
+            <span title="{% trans 'Comments' %}">
+                {{ object.comment_count }}
+                <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
             </span>
-        {% endif %}
-        <span title="{% trans 'Comments' %}">
-            {{ object.comment_count }}
-            <i class="fa fa-comment-o" aria-label="{% trans 'Comments' %}"></i>
-        </span>
-        {% endspaceless %}
+            {% endspaceless %}
+        </div>
     </div>
-    <h3 class="list-item__title">
-        {% get_item_detail_url object as detail_url %}
-        <a href="{{ detail_url }}">
-        {{ object.name }}
-        </a>
-    </h3>
     {% if object.category %}
         <div class="list-item__labels">
             <span class="label label--big">{{ object.category }}</span>

--- a/meinberlin/assets/scss/components/_list_item.scss
+++ b/meinberlin/assets/scss/components/_list_item.scss
@@ -51,9 +51,15 @@
     flex: 1 1 auto;
 }
 
+.list-item__header {
+    display: flex;
+    align-items: flex-start;
+}
+
 .list-item__title {
     margin: 0 0 0.5rem;
     font-size: $font-size-lg;
+    flex: 1 1 auto;
 
     a {
         color: inherit;
@@ -89,8 +95,8 @@
 }
 
 .list-item__stats {
-    float: right;
     margin-left: 0.5em;
+    flex: 0 0 auto;
 }
 
 .list-item__action {


### PR DESCRIPTION
1. wraps all dates in time elements. provides the (python) iso8601 formatted  date to the datetime attribute
2. Make item title the first element in item listings

@xi i'm still not sure if we shouldn't better use the lr-bar also for the listings as lr-bar is used for similiar listings in the dashboard. we could either keep it's behaviour on small screens or replace lr-bar with flexboxes, too

Note the difference to the current master on small screens:

Flex (pr):
![list-item-flex](https://user-images.githubusercontent.com/167407/30597929-be81d7fe-9d58-11e7-8b5d-83965f8a6f4e.png)

Float (master):
![list-item-float](https://user-images.githubusercontent.com/167407/30597931-bea30bd6-9d58-11e7-904b-cca05e3fc745.png)
