### PR TITLE
Revert to npm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 test_db.sqlite3
 db.sqlite3*
 node_modules/
+package-lock.json
 meinberlin/config/settings/local.py
 .env/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 	@echo
 
 install:
-	npm update --dev
+	npm install
 	if [ ! -f $(VIRTUAL_ENV)/bin/python3 ]; then python3 -m venv $(VIRTUAL_ENV); fi
 	$(VIRTUAL_ENV)/bin/python3 -m pip install -r requirements/dev.txt
 	$(VIRTUAL_ENV)/bin/python3 manage.py migrate

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 	@echo
 
 install:
-	npm install
+	npm install --no-save
 	if [ ! -f $(VIRTUAL_ENV)/bin/python3 ]; then python3 -m venv $(VIRTUAL_ENV); fi
 	$(VIRTUAL_ENV)/bin/python3 -m pip install -r requirements/dev.txt
 	$(VIRTUAL_ENV)/bin/python3 manage.py migrate


### PR DESCRIPTION
Fixes #799

I am not relatlivly sure that `npm install` is what we want. I am not
sure whether it is bug-free, but that is another question.

package-lock.json should not do any harm, but I do not see any benefit
in committing it to the repo. We did not have trouble with different
versions on different systems so far and it might cause issues when
using `npm link`. So I added it to .gitignore.