### PR TITLE
load new scripts in ajax modal

### DIFF
--- a/meinberlin/apps/contrib/static/js/ajax_modal.js
+++ b/meinberlin/apps/contrib/static/js/ajax_modal.js
@@ -14,6 +14,22 @@ $(function () {
   )
   var $backdrop = $('<div class="modal-backdrop" />')
 
+  var extractScripts = function ($root, selector, attr) {
+    var $existingValues = $('head').find(selector).map(function (i, e) {
+      return $(e).attr(attr)
+    })
+
+    $root.find(selector).each(function (i, script) {
+      var $script = $(script)
+      var $matches = $existingValues.filter(function (i, v) {
+        return v === $script.attr(attr)
+      })
+      if ($matches.length === 0) {
+        $('head').append($script)
+      }
+    })
+  }
+
   $(document).on('click', '[data-toggle="ajax-modal"]', function (e) {
     e.preventDefault()
     var target = this.href + ' ' + this.dataset.targetSelector
@@ -26,8 +42,11 @@ $(function () {
     })
 
     $newModal.find('.modal-body').load(target, function (html) {
-      var title = $(html).find('h1').text()
+      var $root = $('<div>').html(html)
+      var title = $root.find('h1').text()
       $newModal.find('.modal-title').text(title)
+      extractScripts($root, 'script[src]', 'src')
+      extractScripts($root, 'link[rel="stylesheet"]', 'href')
       $backdrop.appendTo(document.documentElement)
       $newModal.insertAfter(_this).show()
     })


### PR DESCRIPTION
Fixes #795 

The fix is duplicated from embed.js: The content of the embed is loaded via ajax. Apart from the content, we also need to extract the script elements from the downloaded page and add them to the current one.