### PR TITLE
add asterisk to required fields

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
@@ -1,8 +1,8 @@
-{% load widget_tweaks %}
+{% load i18n widget_tweaks %}
 
 <div class="form-group">
     <label for="{{ field.id_for_label }}">
-        {{ field.label }}
+        {{ field.label }}{% if field.field.required %}<span role="presentation" title="{% trans 'This field is required' %}">*</span>{% endif %}
         {% block after_label %}
         {% endblock %}
     </label>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
@@ -3,14 +3,18 @@
 <div class="form-group">
     <label for="{{ field.id_for_label }}">
         {{ field.label }}
+        {% block after_label %}
+        {% endblock %}
     </label>
     {% if field.help_text %}
     <div class="form-hint">
         {{ field.help_text }}
     </div>
     {% endif %}
-    <div class="widget widget--{{ field|widget_type }}">
-        {{ field }}
-    </div>
+    {% block field %}
+        <div class="widget widget--{{ field|widget_type }}">
+            {{ field }}
+        </div>
+    {% endblock %}
     {{ field.errors }}
 </div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field_with_addon.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field_with_addon.html
@@ -1,14 +1,6 @@
-{% load widget_tweaks %}
+{% extends "meinberlin_contrib/includes/form_field.html" %}
 
-<div class="form-group">
-    <label for="{{ field.id_for_label }}">
-        {{ field.label }}
-    </label>
-    {% if field.help_text %}
-    <div class="form-hint">
-        {{ field.help_text }}
-    </div>
-    {% endif %}
+{% block field %}
     <div class="widget widget--{{ field|widget_type }} input-group">
         {% if before %}
             <span class="input-group__before addon">{{ before }}</span>
@@ -18,5 +10,4 @@
             <span class="input-group__after addon">{{ after }}</span>
         {% endif %}
     </div>
-    {{ field.errors }}
-</div>
+{% endblock %}

--- a/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/form_field.html
+++ b/meinberlin/apps/dashboard2/templates/meinberlin_dashboard2/includes/form_field.html
@@ -1,19 +1,8 @@
-{% load widget_tweaks i18n %}
+{% extends "meinberlin_contrib/includes/form_field.html" %}
+{% load i18n %}
 
-<div class="form-group">
-    <label for="{{ field.id_for_label }}">
-        {{ field.label }}
-        {% if field.field.required_for_publish and not field.value %}
-            <i class="fa fa-exclamation-circle u-danger" title="{% trans 'Missing field for publication' %}" aria-label="{% trans 'Missing field for publication' %}"></i>
-        {% endif %}
-    </label>
-    {% if field.help_text %}
-    <div class="form-hint">
-        {{ field.help_text }}
-    </div>
+{% block after_label %}
+    {% if field.field.required_for_publish and not field.value %}
+        <i class="fa fa-exclamation-circle u-danger" title="{% trans 'Missing field for publication' %}" aria-label="{% trans 'Missing field for publication' %}"></i>
     {% endif %}
-    <div class="widget widget--{{ field|widget_type }}">
-        {{ field }}
-    </div>
-    {{ field.errors }}
-</div>
+{% endblock %}


### PR DESCRIPTION
fixes #406

There was the feeling that not all forms should have the asterisks (e.g. login). It was not clear though how to differeenciate the two cases. The decision was to just add it everywhere for now and add exceptions later (if required).