### PR TITLE
Enable scrolling in long modals

### DIFF
--- a/meinberlin/apps/contrib/static/js/ajax_modal.js
+++ b/meinberlin/apps/contrib/static/js/ajax_modal.js
@@ -12,7 +12,6 @@ $(function () {
       '</div>' +
     '</div>'
   )
-  var $backdrop = $('<div class="modal-backdrop" />')
 
   var extractScripts = function ($root, selector, attr) {
     var $existingValues = $('head').find(selector).map(function (i, e) {
@@ -34,11 +33,9 @@ $(function () {
     e.preventDefault()
     var target = this.href + ' ' + this.dataset.targetSelector
     var $newModal = $(modalHTML)
-    var _this = this
 
-    $newModal.find('.close').on('click', function () {
+    $newModal.on('hidden.bs.modal', function () {
       $newModal.remove()
-      $backdrop.remove()
     })
 
     $newModal.find('.modal-body').load(target, function (html) {
@@ -47,8 +44,9 @@ $(function () {
       $newModal.find('.modal-title').text(title)
       extractScripts($root, 'script[src]', 'src')
       extractScripts($root, 'link[rel="stylesheet"]', 'href')
-      $backdrop.appendTo(document.documentElement)
-      $newModal.insertAfter(_this).show()
+
+      $newModal.appendTo('body')
+      $newModal.modal()
     })
   })
 })

--- a/meinberlin/apps/contrib/static/js/ajax_modal.js
+++ b/meinberlin/apps/contrib/static/js/ajax_modal.js
@@ -1,7 +1,7 @@
 /* globals $ django */
 $(function () {
   var modalHTML = (
-    '<div class="modal">' +
+    '<div class="modal" tabindex="-1">' +
       '<div class="modal-dialog modal-lg" role="document">' +
         '<div class="modal-content">' +
           '<div class="modal-header"><h2 class="modal-title u-first-heading"></h2>' +

--- a/meinberlin/apps/contrib/static/js/ajax_modal.js
+++ b/meinberlin/apps/contrib/static/js/ajax_modal.js
@@ -1,7 +1,7 @@
 /* globals $ django */
 $(function () {
   var modalHTML = (
-    '<div class="modal" tabindex="-1">' +
+    '<div class="modal" tabindex="-1" role="dialog">' +
       '<div class="modal-dialog modal-lg" role="document">' +
         '<div class="modal-content">' +
           '<div class="modal-header"><h2 class="modal-title u-first-heading"></h2>' +
@@ -42,6 +42,7 @@ $(function () {
       var $root = $('<div>').html(html)
       var title = $root.find('h1').text()
       $newModal.find('.modal-title').text(title)
+      $newModal.attr('aria-label', title)
       extractScripts($root, 'script[src]', 'src')
       extractScripts($root, 'link[rel="stylesheet"]', 'href')
 

--- a/meinberlin/apps/contrib/static/js/ajax_modal.js
+++ b/meinberlin/apps/contrib/static/js/ajax_modal.js
@@ -33,6 +33,7 @@ $(function () {
     e.preventDefault()
     var target = this.href + ' ' + this.dataset.targetSelector
     var $newModal = $(modalHTML)
+    var _this = this
 
     $newModal.on('hidden.bs.modal', function () {
       $newModal.remove()
@@ -46,7 +47,7 @@ $(function () {
       extractScripts($root, 'script[src]', 'src')
       extractScripts($root, 'link[rel="stylesheet"]', 'href')
 
-      $newModal.appendTo('body')
+      $newModal.insertAfter(_this)
       $newModal.modal()
     })
   })


### PR DESCRIPTION
The core problem was a missing `overflow-y: auto;` on the modal.

It was missing because the body was missing the `modal-open` class which
is set via the Bootstrap javascript when a modal is opened. As we did
not initialize the modal via javascript but rather tried to simply use
the classes directly on the html elements the scrolling has not been
enabled.

Using the javascript initialization also fixes the need for the custom
creation of a backdrop, as this will created and removed automatically
by bootstrap.

Furthermore the modal was not added to the body but rather somewhere in
the dom tree which is advised against by the bootstrap docs:

> Modals use position: fixed, which can sometimes be a bit particular
> about its rendering. Whenever possible, place your modal HTML in a
> top-level position to avoid potential interference from other
> elements. You’ll likely run into issues when nesting a .modal within
> another fixed element.

This PR fixes #804 but introduces the problem of two scrollbars, as we set the `overflow-y: auto;` on the `html` element instead of the `body` element. Bootstrap proposes to use scrolling on the body element
