### PR TITLE
Remove alerts on CKEDITOR fields change

### DIFF
--- a/meinberlin/apps/documents/assets/DocumentManagement.jsx
+++ b/meinberlin/apps/documents/assets/DocumentManagement.jsx
@@ -210,7 +210,9 @@ class DocumentManagement extends React.Component {
       }
     }
     this.setState({
-      chapters: update(this.state.chapters, diff)
+      chapters: update(this.state.chapters, diff),
+      // Workaround missing change events when using CKEDITOR
+      alert: null
     })
   }
 


### PR DESCRIPTION
Fixes #754

CKEDITOR does not fire change events in the DOM when the field is
modified. This is the simplest but kinda hacky solution to fix #754.
It requires knowledge about the child components inner structure.

Fixing the problem at its core would be possible if we'd handle change
events on the CKEDITOR editor instance, adapt the textarea accordingly
and fire change events manually. For example like:
```
window.CKEDITOR.on('instanceReady', (e) => {
	e.editor.on('change', (e2) =>  {
		$textarea.value = e2.value
		$textarea.change()
	})
})
```
But this is out of the scope of this issue