### PR TITLE
Hide dropdown menu and disable button for external projects

### DIFF
--- a/meinberlin/templates/meinberlin_dashboard2/includes/project_list_item.html
+++ b/meinberlin/templates/meinberlin_dashboard2/includes/project_list_item.html
@@ -47,9 +47,12 @@
                                 aria-haspopup="true"
                                 aria-expanded="false"
                                 id="project-actions"
+                                {# Temporary solution, as duplicate currently the only list item and the future of the dropdown is still undecided #}
+                                {{ project|is_external|yesno:"disabled," }}
                         >
                             <i class="fa fa-caret-down" aria-hidden="true"></i>
                         </button>
+                        {% if not project|is_external %}
                         <ul class="dropdown-menu" aria-labelledby="project-actions">
                             <li>
                                 <form method="post" class="list-item__action">
@@ -63,6 +66,7 @@
                                 </form>
                             </li>
                         </ul>
+                        {% endif %}
                     </div>
                 {% endspaceless %}
                 </div>


### PR DESCRIPTION
Fixes #817

As the duplication code will be part of the a4 dashboard it would be
very complex to make the duplication code extensible and allow for
correct duplication of external and bplan projects.

Duplication of external and bplan projects is still possible but the
duplicated project looses its "type".

This PR simply hides the duplication from the user.