### PR TITLE
fix heading hierarchy for documents

### DIFF
--- a/meinberlin/apps/documents/templates/meinberlin_documents/chapter_detail.html
+++ b/meinberlin/apps/documents/templates/meinberlin_documents/chapter_detail.html
@@ -37,15 +37,15 @@
                     </nav>
                 {% endif %}
 
-                <h1 class="chapter-title">{{ object.name }}</h1>
+                <h2 class="chapter-title">{{ object.name }}</h2>
 
                 {% for paragraph in object.paragraphs.all %}
 
                     <section class="paragraph" id="paragraph-{{ object.pk }}-{{ paragraph.pk }}">
                         <div class="paragraph__content">
-                            <h2 class="paragraph__title">
+                            <h3 class="paragraph__title">
                                 {{ paragraph.name }}
-                            </h2>
+                            </h3>
                             {{ paragraph.text|richtext }}
                         </div>
                         <div class="paragraph__actions">


### PR DESCRIPTION
fixes #559

the document is shown on the project detail page where the project title
is `h1`. So it needs to start at `h2`.