### PR TITLE
avoid styling checkboxes

### DIFF
--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -36,6 +36,12 @@ select {
     }
 }
 
+input[type="checkbox"],
+input[type="radio"] {
+    padding: 0;
+    border: 0;
+}
+
 div.cke_focus {
     border-color: $brand-secondary;
 }


### PR DESCRIPTION
We have general styling for input elements. This is meant for input elements which look roughly like text input (which is most of them: password, url, date, email, number, …). However, there are also few input elements that are very different, notably checkbox and radio.

Chromium mostly ignores our styling for these elements, but IE adds a boirder and padding around it. This pull request removes them.

I did it this way instead of excluding checkboxes and radios from the initial styling to keep the selectors short and simple.