### PR TITLE
Ignore missing docstrings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max-complexity = 10
-ignore = D100,D101,D102,D103,D104,D105
+ignore = D100,D101,D102,D103,D104,D105,D106,D107


### PR DESCRIPTION
Somehow the linting failed on travis with error codes D106 and D107

(see http://www.pydocstyle.org/en/latest/error_codes.html for a complete list of error codes)