### PR TITLE
Delete statements from archived bplans

### DIFF
--- a/meinberlin/apps/bplan/management/commands/bplan_auto_archive.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_auto_archive.py
@@ -1,15 +1,29 @@
+from datetime import timedelta
+
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 
 from meinberlin.apps.bplan import models as bplan_models
 
 
 class Command(BaseCommand):
-    help = 'Archive finished bplan projects.'
+    help = 'Archive finished bplan projects and delete old statements.'
 
     def handle(self, *args, **options):
         bplans = bplan_models.Bplan.objects.filter(is_draft=False)
         for bplan in bplans:
-            if bplan.has_finished:
+            if bplan.has_finished and not bplan.is_archived:
                 bplan.is_archived = True
                 bplan.save()
                 self.stdout.write('Archived bplan {}.'.format(bplan.name))
+
+        # Delete statements of archived projects
+        # To prevent deleting statements that have not been sent by mail yet
+        # only statements older then 48h are deleted.
+        num_deleted, _ = bplan_models.Statement.objects\
+            .filter(module__project__is_archived=True)\
+            .filter(created__lt=timezone.now() - timedelta(hours=48))\
+            .delete()
+        if num_deleted:
+            self.stdout.write('Deleted {} statements from archived bplans.'
+                              .format(num_deleted))


### PR DESCRIPTION
After a bplan is archived it's related statements may be deleted.
For simpler development/deployment the auto_archive script is extended
to delete the statements, altough it may have been possible to add
another command.

To prevent from loosing statements that are created just before the
participation ends, the deletion is delayed for 48 hours.
(In rare cases a statement may not have been sent due to the async
nature of our email interface, when the project is already archived)