### PR TITLE
add logo to container detail page

### DIFF
--- a/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html
+++ b/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html
@@ -1,8 +1,9 @@
-{% load i18n rules wagtailcore_tags %}
+{% load i18n rules thumbnail wagtailcore_tags %}
 
 <div class="project-header u-after-dialogue-box">
     <div class="l-wrapper">
         <div class="l-center-6">
+            <img class="project-header__logo" src="{% thumbnail container.tile_image 'logo' %}" alt="" />
             <h1 class="project-header__title">{{ container.name }}</h1>
             <p class="project-header__description">{{ container.description }}</p>
         </div>

--- a/meinberlin/assets/scss/components/_project_header.scss
+++ b/meinberlin/assets/scss/components/_project_header.scss
@@ -75,3 +75,7 @@
         color: inherit;
     }
 }
+
+.project-header__logo {
+    border: 1px solid $border-color;
+}

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -209,6 +209,7 @@ THUMBNAIL_ALIASES = {
         'project_thumbnail': {'size': (520, 330), 'crop': 'smart'},
         'idea_image': {'size': (800, 0), 'crop': 'scale'},
         'idea_thumbnail': {'size': (240, 240), 'crop': 'smart'},
+        'logo': {'size': (120, 120), 'background': 'white'},
     }
 }
 


### PR DESCRIPTION
the logos should be in a square box. In most cases we crop images, but
here we add a white background to make it fit.