### PR TITLE
Enable categories and disable reporting for map|topicprio 

### DIFF
--- a/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
+++ b/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
@@ -1,5 +1,5 @@
 {% extends "meinberlin_contrib/item_detail.html" %}
-{% load i18n rules react_comments module_tags react_ratings react_reports wagtailcore_tags item_tags maps_tags static %}
+{% load i18n rules react_comments module_tags react_ratings wagtailcore_tags item_tags maps_tags static %}
 
 {% block extra_js %}
     <script type="text/javascript" src="{% static 'leaflet.js' %}"></script>
@@ -51,27 +51,6 @@
                 {% if object|has_feature:"rate" %}
                     <div class="lr-bar__left">
                         {% react_ratings object %}
-                    </div>
-                {% endif %}
-                {% if request.user.is_authenticated %}
-                    <div class="lr-bar__right dropdown dropdown--right">
-                        <button
-                                title="{% trans 'Actions' %}"
-                                type="button"
-                                class="dropdown-toggle btn btn--light btn--small"
-                                data-toggle="dropdown"
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                id="topic-{{object.pk}}-actions"
-                        >
-                            <i class="fa fa-ellipsis-h" aria-label="{% trans 'Actions' %}"></i>
-                        </button>
-                        <ul class="dropdown-menu" aria-labelledby="topic-{{object.pk}}-actions">
-                            <li>
-                                {% trans 'Report' as report_text %}
-                                {% react_reports object text=report_text class='dropdown-item' %}
-                            </li>
-                        </ul>
                     </div>
                 {% endif %}
             </div>

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n rules react_comments module_tags react_ratings react_reports wagtailcore_tags item_tags %}
+{% load i18n rules react_comments module_tags react_ratings wagtailcore_tags item_tags %}
 
 {% block title %}{{object.name}} &mdash; {{ block.super }}{% endblock %}
 {% block content %}
@@ -33,27 +33,6 @@
                 {% if object|has_feature:"rate" %}
                     <div class="lr-bar__left">
                         {% react_ratings object %}
-                    </div>
-                {% endif %}
-                {% if request.user.is_authenticated %}
-                    <div class="lr-bar__right dropdown dropdown--right">
-                        <button
-                                title="{% trans 'Actions' %}"
-                                type="button"
-                                class="dropdown-toggle btn btn--light btn--small"
-                                data-toggle="dropdown"
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                id="topic-{{object.pk}}-actions"
-                        >
-                            <i class="fa fa-ellipsis-h" aria-label="{% trans 'Actions' %}"></i>
-                        </button>
-                        <ul class="dropdown-menu" aria-labelledby="topic-{{object.pk}}-actions">
-                            <li>
-                                {% trans 'Report' as report_text %}
-                                {% react_reports object text=report_text class='dropdown-item' %}
-                            </li>
-                        </ul>
                     </div>
                 {% endif %}
             </div>

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -331,22 +331,22 @@ A4_RATEABLES = (
     ('meinberlin_ideas', 'idea'),
     ('meinberlin_mapideas', 'mapidea'),
     ('meinberlin_budgeting', 'proposal'),
+    ('meinberlin_kiezkasse', 'proposal'),
     ('meinberlin_topicprio', 'topic'),
     ('meinberlin_maptopicprio', 'maptopic'),
-    ('meinberlin_kiezkasse', 'proposal'),
 )
 
 A4_COMMENTABLES = (
     ('a4comments', 'comment'),
     ('meinberlin_ideas', 'idea'),
-    ('meinberlin_documents', 'chapter'),
-    ('meinberlin_documents', 'paragraph'),
     ('meinberlin_mapideas', 'mapidea'),
     ('meinberlin_budgeting', 'proposal'),
+    ('meinberlin_kiezkasse', 'proposal'),
     ('meinberlin_topicprio', 'topic'),
     ('meinberlin_maptopicprio', 'maptopic'),
     ('meinberlin_polls', 'poll'),
-    ('meinberlin_kiezkasse', 'proposal'),
+    ('meinberlin_documents', 'chapter'),
+    ('meinberlin_documents', 'paragraph'),
 )
 
 A4_REPORTABLES = (
@@ -379,6 +379,8 @@ A4_CATEGORIZABLE = (
     ('meinberlin_mapideas', 'mapidea'),
     ('meinberlin_budgeting', 'proposal'),
     ('meinberlin_kiezkasse', 'proposal'),
+    ('meinberlin_topicprio', 'topic'),
+    ('meinberlin_maptopicprio', 'maptopic'),
 )
 
 

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -354,8 +354,6 @@ A4_REPORTABLES = (
     ('meinberlin_ideas', 'idea'),
     ('meinberlin_mapideas', 'mapidea'),
     ('meinberlin_budgeting', 'proposal'),
-    ('meinberlin_topicprio', 'topic'),
-    ('meinberlin_maptopicprio', 'maptopic'),
     ('meinberlin_kiezkasse', 'proposal'),
 )
 


### PR DESCRIPTION
The configuration option was missing.

Reporting was disabled for map|topicprio as the content is generated by the trusted initiators. 