### PR TITLE
add select2

### DIFF
--- a/meinberlin/apps/contrib/widgets.py
+++ b/meinberlin/apps/contrib/widgets.py
@@ -1,0 +1,26 @@
+from django import forms
+from django.contrib.staticfiles.storage import staticfiles_storage
+
+
+class Select2Mixin:
+    def __init__(self, *args, **kwargs):
+        if 'attrs' not in kwargs:
+            kwargs['attrs'] = {}
+        if 'class' not in kwargs['attrs']:
+            kwargs['attrs']['class'] = ''
+        kwargs['attrs']['class'] += ' js-select2'
+
+        super().__init__(*args, **kwargs)
+
+    class Media:
+        js = (
+            staticfiles_storage.url('select2.js'),
+        )
+
+
+class Select2Widget(Select2Mixin, forms.Select):
+    pass
+
+
+class Select2MultipleWidget(Select2Mixin, forms.SelectMultiple):
+    pass

--- a/meinberlin/apps/projectcontainers/forms.py
+++ b/meinberlin/apps/projectcontainers/forms.py
@@ -1,6 +1,7 @@
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
+from meinberlin.apps.contrib.widgets import Select2MultipleWidget
 from meinberlin.apps.dashboard2.forms import ProjectCreateForm
 from meinberlin.apps.dashboard2.forms import ProjectDashboardForm
 
@@ -78,3 +79,6 @@ class ContainerProjectsForm(ProjectDashboardForm):
         model = models.ProjectContainer
         fields = ['projects']
         required_for_project_publish = ['projects']
+        widgets = {
+            'projects': Select2MultipleWidget,
+        }

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -12,7 +12,10 @@ var Shariff = require('shariff')
   $(document).on('a4.embed.ready', init)
 })(function () {
   new Shariff($('.shariff'))
-  $('select[multiple]').select2()
+
+  if ($.fn.select2) {
+    $('.js-select2').select2()
+  }
 })
 
 // load bootstrap components

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -5,7 +5,6 @@
 var $ = window.jQuery = window.$ = require('jquery')
 window.Tether = require('tether/dist/js/tether.js')
 
-// social share
 var Shariff = require('shariff')
 
 ;(function (init) {
@@ -13,6 +12,7 @@ var Shariff = require('shariff')
   $(document).on('a4.embed.ready', init)
 })(function () {
   new Shariff($('.shariff'))
+  $('select[multiple]').select2()
 })
 
 // load bootstrap components

--- a/meinberlin/assets/scss/components/_select2.scss
+++ b/meinberlin/assets/scss/components/_select2.scss
@@ -1,0 +1,45 @@
+// stylelint-disable selector-max-specificity
+
+@import '~select2/src/scss/core';
+
+.select2-container--default {
+    .select2-results__option [aria-selected="true"] {
+        background-color: $bg-secondary;
+        color: contrast-color($bg-secondary);
+    }
+
+    .select2-results__option--highlighted[aria-selected] {
+        background-color: $brand-secondary;
+        color: contrast-color($brand-secondary);
+    }
+
+    .select2-selection--multiple .select2-selection__choice {
+        background-color: $bg-secondary;
+        color: contrast-color($bg-secondary);
+        border-color: $border-color;
+    }
+
+    .select2-selection--multiple {
+        border: 1px solid $input-border-color;
+    }
+
+    &.select2-container--focus {
+        .select2-selection--single,
+        .select2-selection--multiple {
+            border-color: $brand-secondary;
+        }
+    }
+
+    &.select2-container--disabled {
+        .select2-selection--single,
+        .select2-selection--multiple {
+            color: $input-border-color;
+            cursor: not-allowed;
+            background-color: $body-bg;
+        }
+
+        .select2-selection--multiple .select2-selection__choice {
+            opacity: 0.5;
+        }
+    }
+}

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -54,6 +54,7 @@
 @import 'components/project_header';
 @import 'components/radio';
 @import 'components/rating';
+@import 'components/select2';
 @import 'components/select-item';
 @import 'components/simple_page';
 @import 'components/table';

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "leaflet-draw": "0.4.10",
     "react-flip-move": "2.9.14",
     "sass-planifolia": "0.4.2",
+    "select2": "^4.0.4",
     "shariff": "1.26.2",
     "tether": "1.4.0",
     "timeago.js": "3.0.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
       'immutability-helper',
       'react-dom',
       'react-flip-move',
+      'select2',
       'shariff',
       'shariff/build/shariff.min.css'
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,11 @@ module.exports = {
       'immutability-helper',
       'react-dom',
       'react-flip-move',
-      'select2',
       'shariff',
       'shariff/build/shariff.min.css'
+    ],
+    select2: [
+      'select2'
     ],
     leaflet: [
       'leaflet',


### PR DESCRIPTION
This is a proposal to add [select2](https://select2.org/getting-started/basic-usage) as a dependency. It greatly improves usability of select elements, especially for multi-selects and if there are many options. It even has decent accessibility!

On the downside, it depends on jquery and adds about 200kb to our frontend bundles (increase by 12% for js/css).

I have been thinking about adding this for a while. The trigger to do this now is the bad usability of the multi select element that is used to select projects in containers. We tried to imrpove that in 91470562b by adding resizing, but that is not enough and actually not supported in IE and safari.