### PR TITLE
Allow user invites via file upload

### DIFF
--- a/meinberlin/apps/projects/forms.py
+++ b/meinberlin/apps/projects/forms.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from meinberlin.apps.users.fields import CommaSeparatedEmailField
+from meinberlin.apps.users import fields as user_fields
 
 from .models import ModeratorInvite
 from .models import ParticipantInvite
@@ -41,13 +41,30 @@ class ModeratorInviteForm(InviteForm):
 
 
 class InviteUsersFromEmailForm(forms.Form):
-    add_users = CommaSeparatedEmailField(
+    add_users = user_fields.CommaSeparatedEmailField(
+        required=False,
         label=_('Invite users via email')
     )
 
+    add_users_upload = user_fields.EmailFileField(
+        required=False,
+        label=_('Invite users via file upload'),
+        help_text=_('Upload a csv file containing email addresses.')
+    )
+
     def __init__(self, *args, **kwargs):
-        label = kwargs.pop('label', None)
+        labels = kwargs.pop('labels', None)
         super().__init__(*args, **kwargs)
 
-        if label:
-            self.fields['add_users'].label = label
+        if labels:
+            self.fields['add_users'].label = labels[0]
+            self.fields['add_users_upload'].label = labels[1]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        add_users = self.data.get('add_users')
+        add_users_upload = self.files.get('add_users_upload')
+        if not self.errors and not add_users and not add_users_upload:
+            raise ValidationError(
+                _('Please enter email addresses or upload a file'))
+        return cleaned_data

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/users_from_email_form.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/users_from_email_form.html
@@ -2,6 +2,14 @@
 
 <form method="POST">
     {% csrf_token %}
+    {% if form.non_field_errors %}
+    <div class="form-errors">
+        {% for error in form.non_field_errors %}
+        <p class="alert danger">{{ error }}</p>
+        {% endfor %}
+    </div>
+    {% endif %}
+
     <div class="form-group">
         <label for="{{ form.add_users.id_for_label }}">
             {{ form.add_users.label }}
@@ -13,10 +21,29 @@
         {% endif %}
         <div class="input-group">
             <div class="input-group__input widget widget--{{ form.add_users|widget_type }}">
-                {{ form.add_users }}
+                {{ form.add_users|attr:'required' }}
             </div>
             <input type="submit" class="btn btn--primary input-group__after" value="{% trans 'Add' %}"/>
         </div>
         {{ form.add_users.errors }}
+    </div>
+</form>
+
+<form method="POST" enctype="multipart/form-data">
+    {% csrf_token %}
+    <div class="form-group">
+        <label for="{{ form.add_users_upload.id_for_label }}">
+            {{ form.add_users_upload.label }}
+        </label>
+        <div class="form-hint">
+            {{ form.add_users_upload.help_text }}
+        </div>
+        <div class="widget widget--{{ form.add_users_upload|widget_type }}">
+            <div class="input-group">
+                {{ form.add_users_upload|attr:'required'|add_class:'input-group__input' }}
+                <input type="submit" class="btn btn--primary input-group__after" value="{% trans 'Upload' %}"/>
+            </div>
+        </div>
+        {{ form.add_users_upload.errors }}
     </div>
 </form>

--- a/meinberlin/apps/projects/views.py
+++ b/meinberlin/apps/projects/views.py
@@ -211,7 +211,6 @@ class AbstractProjectUserInviteListView(
         generic.edit.ProcessFormView):
 
     form_class = forms.InviteUsersFromEmailForm
-    upload_form_class = forms.InviteUsersFromEmailForm
     invite_model = None
 
     def get(self, request, *args, **kwargs):

--- a/meinberlin/apps/projects/views.py
+++ b/meinberlin/apps/projects/views.py
@@ -1,3 +1,4 @@
+import itertools
 from datetime import datetime
 
 import django_filters
@@ -210,6 +211,7 @@ class AbstractProjectUserInviteListView(
         generic.edit.ProcessFormView):
 
     form_class = forms.InviteUsersFromEmailForm
+    upload_form_class = forms.InviteUsersFromEmailForm
     invite_model = None
 
     def get(self, request, *args, **kwargs):
@@ -258,7 +260,9 @@ class AbstractProjectUserInviteListView(
         return filtered_emails, pending
 
     def form_valid(self, form):
-        emails = form.cleaned_data['add_users']
+        emails = list(set(
+            itertools.chain(form.cleaned_data['add_users'],
+                            form.cleaned_data['add_users_upload'])))
 
         emails, existing = self.filter_existing(emails)
         if existing:
@@ -293,7 +297,8 @@ class AbstractProjectUserInviteListView(
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs['label'] = self.add_user_field_label
+        kwargs['labels'] = (self.add_user_field_label,
+                            self.add_user_upload_field_label)
         return kwargs
 
 
@@ -307,6 +312,7 @@ class DashboardProjectModeratorsView(AbstractProjectUserInviteListView):
 
     related_users_field = 'moderators'
     add_user_field_label = _('Invite moderators via email')
+    add_user_upload_field_label = _('Invite moderators via file upload')
     success_message = ('{} moderator invited.', '{} moderators invited.')
     success_message_removal = _('Moderator successfully removed.')
 
@@ -323,6 +329,7 @@ class DashboardProjectParticipantsView(AbstractProjectUserInviteListView):
 
     related_users_field = 'participants'
     add_user_field_label = _('Invite users via email')
+    add_user_upload_field_label = _('Invite users via file upload')
     success_message = ('{} participant invited.', '{} participants invited.')
     success_message_removal = _('Participant successfully removed.')
 

--- a/meinberlin/apps/users/fields.py
+++ b/meinberlin/apps/users/fields.py
@@ -1,20 +1,22 @@
 import re
 
 from django.core.validators import RegexValidator
-from django.forms.fields import Field
-from django.forms.widgets import TextInput
+from django import forms
+from django.core.exceptions import ValidationError
+from django.core.validators import EmailValidator
+from django.forms import widgets
 from django.utils.translation import ugettext_lazy as _
 
 
-class CommaSeparatedEmailField(Field):
     default_validators = [RegexValidator(
         # a list of emails, separated by commas with optional space after
         regex=r'^([^@]+@[^@\s]+\.[^@\s,]+((,\s?)|$))+$',
+class CommaSeparatedEmailField(forms.Field):
         message=_('Please enter correct email addresses, separated by '
                   'commas.')
     )]
 
-    widget = TextInput(attrs={
+    widget = widgets.TextInput(attrs={
         'placeholder': 'maria@example.com, peter@example.com, '
                        'nicola@example.com,…'
     })
@@ -22,3 +24,41 @@ class CommaSeparatedEmailField(Field):
     def to_python(self, value):
         emails_str = value.strip(' ,')
         return re.split(r',\s?', emails_str)
+
+
+class EmailFileField(forms.FileField):
+    """Extract emails from uploaded text files."""
+
+    widget = widgets.FileInput
+    # Find possible email strings. Emails may be quoted and separated by
+    # whitespaces, commas or semicolons.
+    email_regex = re.compile(r'[^\s;,"\']+@[^\s;,"\']+\.[a-z]{2,}')
+    email_validator = EmailValidator()
+
+    def clean(self, data, initial=None):
+        file = super().clean(data, initial)
+        try:
+            return self._extract_emails(file)
+        except UnicodeDecodeError:
+            raise ValidationError(_('Invalid file format.'
+                                    ' Only text files are allowed.'))
+
+    def _extract_emails(self, file):
+        if not file:
+            return []
+
+        emails = []
+        for byteline in file:
+            line = byteline.decode('utf-8')
+            for match in self.email_regex.finditer(line):
+                email = match.group(0)
+                if self.is_valid_email(email):
+                    emails.append(email)
+        return emails
+
+    def is_valid_email(self, email):
+        try:
+            self.email_validator(email)
+            return True
+        except ValidationError:
+            return False

--- a/meinberlin/apps/users/fields.py
+++ b/meinberlin/apps/users/fields.py
@@ -1,6 +1,5 @@
 import re
 
-from django.core.validators import RegexValidator
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator
@@ -8,13 +7,11 @@ from django.forms import widgets
 from django.utils.translation import ugettext_lazy as _
 
 
-    default_validators = [RegexValidator(
-        # a list of emails, separated by commas with optional space after
-        regex=r'^([^@]+@[^@\s]+\.[^@\s,]+((,\s?)|$))+$',
 class CommaSeparatedEmailField(forms.Field):
+    email_validator = EmailValidator(
         message=_('Please enter correct email addresses, separated by '
                   'commas.')
-    )]
+    )
 
     widget = widgets.TextInput(attrs={
         'placeholder': 'maria@example.com, peter@example.com, '
@@ -22,8 +19,16 @@ class CommaSeparatedEmailField(forms.Field):
     })
 
     def to_python(self, value):
-        emails_str = value.strip(' ,')
-        return re.split(r',\s?', emails_str)
+        if not value:
+            return []
+
+        emails = []
+        for email in value.split(','):
+            email = email.strip()
+            self.email_validator(email)
+            emails.append(email)
+
+        return emails
 
 
 class EmailFileField(forms.FileField):


### PR DESCRIPTION
The uploaded file has to be a utf8 compatible text file that may contain emails. 
The addresses are scraped without further regard to a maybe existent logical document structure. 
While everything that looks like an email is found only valid emails are returned.