### PR TITLE
change container icon

### DIFF
--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
@@ -17,7 +17,7 @@
 
         {% if project|is_container %}
             <div class="tile__badge tile__badge--container">
-                <i class="fa fa-folder-open" aria-label="{% trans 'Container' %}"></i>
+                <i class="fa fa-th" aria-label="{% trans 'Container' %}"></i>
             </div>
         {% elif project|is_external %}
             <div class="tile__badge tile__badge--external">

--- a/meinberlin/assets/scss/_shame.scss
+++ b/meinberlin/assets/scss/_shame.scss
@@ -55,10 +55,3 @@ input[type="search"] {
 .map-list [data-map] {
     min-height: 500px;
 }
-
-// This icon looks like an open folder with a blip to the right. When
-// centering, you would expect the basic folder to be centered. However, it is
-// a bit farther left because of the blip.
-.fa-folder-open {
-    margin-left: 0.2em;
-}


### PR DESCRIPTION
I am not totally convinced of this one. The candidates are.

-   http://fontawesome.io/icon/folder-open/ - what we use now
-   http://fontawesome.io/icon/clone/ - doesn't really work semantically
-   http://fontawesome.io/icon/th-large/ - looks like the windows logo
-   http://fontawesome.io/icon/th/ - okayish

I went with `th`, but it does not really looks centered in chromium (it looks fine in firefox).