### PR TITLE
show warning on draft project detail

### DIFF
--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -3,6 +3,20 @@
 
 {% block title %}{{project.name}} &mdash; {{ block.super }}{% endblock %}
 
+{% block extra_messages %}
+    {{ block.super }}
+
+    {% if project.is_draft %}
+        <ul class="messages">
+            <li class="alert alert--dialog-box warning" role="alert">
+                <div class="l-wrapper">
+                    {% trans 'This project is in not published yet.' %}
+                </div>
+            </li>
+        </ul>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
     {% if project|is_container %}
         {% include 'meinberlin_projectcontainers/includes/container_detail.html' with container=project.projectcontainer %}

--- a/meinberlin/assets/scss/_variables.scss
+++ b/meinberlin/assets/scss/_variables.scss
@@ -4,9 +4,9 @@ $brand-primary: #cd0055;
 $brand-primary-tint: #f5ccdd;
 $brand-secondary: #253276;
 $brand-success: #0a820a;
-$brand-info: #fdd216;
-$brand-warning: #f0ad4e;
-$brand-danger: #dc3918;
+$brand-info: $brand-secondary;
+$brand-warning: #faee9e;
+$brand-danger: #a72b1e;
 
 $body-bg: #fff;
 $bg-secondary: #f6f6f6;

--- a/meinberlin/assets/scss/components/_alert.scss
+++ b/meinberlin/assets/scss/components/_alert.scss
@@ -16,22 +16,24 @@ $messages-margin-bottom: 25px;
 .alert {
     margin: 0;
     padding: $padding * 1.2 0;
-    background-color: $bg-secondary;
+    background-color: contrast-stretch($brand-info, $brand-info, 7);
+    color: $brand-info;
     text-align: center;
 
     &.success {
+        background-color: contrast-stretch($brand-success, $brand-success);
         color: $brand-success;
     }
 
     &.error,
     &.danger {
-        background-color: $brand-danger;
-        color: contrast-color($brand-danger);
+        background-color: contrast-stretch($brand-danger, $brand-danger);
+        color: $brand-danger;
     }
 
-    &.info {
-        background-color: $brand-secondary;
-        color: contrast-color($brand-secondary);
+    &.warning {
+        background-color: $brand-warning;
+        color: contrast-stretch($brand-warning, $brand-warning, 7);
     }
 }
 

--- a/meinberlin/assets/scss/components/_alert.scss
+++ b/meinberlin/assets/scss/components/_alert.scss
@@ -7,6 +7,10 @@ $messages-margin-bottom: 25px;
     li {
         display: block;
     }
+
+    + .messages {
+        margin-top: -$messages-margin-bottom;
+    }
 }
 
 .alert {
@@ -40,12 +44,10 @@ $messages-margin-bottom: 25px;
     padding: 0.5em;
 }
 
-.alert--dialog-box {
-    // If this directly follows the dialog box (see header.scss), add 16px
-    // additional padding to the default value (see above).
-    &:first-child {
-        padding-top: calc(16px + #{$padding * 1.2});
-    }
+// If this directly follows the dialog box (see header.scss), add 16px
+// additional padding to the default value (see above).
+.messages:first-child > :first-child {
+    padding-top: calc(16px + #{$padding * 1.2});
 }
 
 // compensate for margin-bottom on messages

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -1,3 +1,4 @@
+@import '~sass-planifolia/sass/math';
 @import '~sass-planifolia/sass/grid';
 @import '~sass-planifolia/sass/contrast';
 

--- a/meinberlin/templates/base.html
+++ b/meinberlin/templates/base.html
@@ -52,6 +52,8 @@
         </ul>
         {% endif %}
 
+        {% block extra_messages %}{% endblock %}
+
         {% block super_content %}
             {% block content %}{% endblock %}
         {% endblock %}


### PR DESCRIPTION
I also took the time to change the styling of our alerts. Before, alerts were often made up ad-hoc and were very inconsistent. With this PR they now look a lot like the [bootstrap alerts](https://getbootstrap.com/docs/4.0/components/alerts/). This includes adjusting some colors, most notably `$brand-danger` which is now a bit darker and therefore more distinguishable from our `$brand-primary` magenta.