### PR TITLE
make sure next parameters are urlencoded

### DIFF
--- a/meinberlin/apps/users/templates/meinberlin_users/indicator.html
+++ b/meinberlin/apps/users/templates/meinberlin_users/indicator.html
@@ -37,7 +37,7 @@
         <li>
             <form class="u-inline" action="{% url 'account_logout' %}" method="post" aria-label="{% trans 'Logout' %}">
                 {% csrf_token %}
-                <input type="hidden" name="next" value="{{ redirect_field_value }}">
+                <input type="hidden" name="next" value="{{ redirect_field_value|urlencode }}">
                 <button type="submit" class="dropdown-item">{% trans "Logout" %}</button>
             </form>
         </li>
@@ -58,10 +58,10 @@
     </button>
     <ul class="dropdown-menu" aria-labelledby="login-register">
         <li>
-            <a class="dropdown-item" href="{% url 'account_login' %}?next={{ redirect_field_value }}">{% trans "Login" %}</a>
+            <a class="dropdown-item" href="{% url 'account_login' %}?next={{ redirect_field_value|urlencode }}">{% trans "Login" %}</a>
         </li>
         <li>
-            <a class="dropdown-item" href="{% url 'account_signup' %}?next={{ redirect_field_value }}">{% trans "Register" %}</a>
+            <a class="dropdown-item" href="{% url 'account_signup' %}?next={{ redirect_field_value|urlencode }}">{% trans "Register" %}</a>
         </li>
     </ul>
 

--- a/meinberlin/templates/account/email.html
+++ b/meinberlin/templates/account/email.html
@@ -8,7 +8,7 @@
 {% block dashboard_content %}
 <h1 class="u-first-heading">{% trans 'Email Addresses' %}</h1>
 
-<form class="multiform" action="{% url 'account_email' %}?next={{ request.path }}" method="post">
+<form class="multiform" action="{% url 'account_email' %}?next={{ request.path|urlencode }}" method="post">
     {% csrf_token %}
     {% for emailaddress in user.emailaddress_set.all %}
     <div class="form-check">

--- a/meinberlin/templates/account/login.html
+++ b/meinberlin/templates/account/login.html
@@ -19,7 +19,7 @@
         </div>
 
         {% if redirect_field_value %}
-            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value|urlencode }}"/>
         {% endif %}
 
         <div class="u-spacer-bottom">

--- a/meinberlin/templates/account/logout.html
+++ b/meinberlin/templates/account/logout.html
@@ -10,7 +10,7 @@
     <form method="post" action="{% url 'account_logout' %}">
         {% csrf_token %}
         {% if redirect_field_value %}
-            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value|urlencode }}"/>
         {% endif %}
         <button class="btn btn--primary" type="submit">{% trans 'Sign Out' %}</button>
     </form>

--- a/meinberlin/templates/account/signup.html
+++ b/meinberlin/templates/account/signup.html
@@ -27,7 +27,7 @@
             {{ form.terms_of_use.errors }}
         </div>
         {% if redirect_field_value %}
-            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
+            <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value|urlencode }}"/>
         {% endif %}
         <div class="u-spacer-bottom">
             <button class="btn btn--primary" type="submit">{% trans "Register" %}</button>


### PR DESCRIPTION
We had a problem in the user profiles in ae and opin: https://github.com/liqd/a4-advocate-europe/issues/527

Currently there shouldn't be a problem in meinBerlin, but just to make sure, this PR urlencodes all next-parameters.