### PR TITLE
add webpack make target for production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ install:
 webpack: $(SCSS_FILES) $(JS_FILES)
 	$(NODE_BIN)/webpack
 
+webpack-prod: $(SCSS_FILES) $(JS_FILES)
+	$(NODE_BIN)/webpack --define process.env.NODE_ENV="'production'" --optimize-minimize --devtool none
+
 makemessages:
 	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d django
 	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d djangojs


### PR DESCRIPTION
-   use uglify
-   no sourcemaps (also see https://github.com/liqd/adhocracy4/issues/86)
-   activate react optimization by setting NODE_ENV to "production"

With these optimizations, the bundles shrink significantly:

                         before      after
       adhocracy4.js     295 kB     134 kB
       datepicker.js     158 kB    56.6 kB
     leaflet.draw.js    67.7 kB    64.3 kB
          leaflet.js     429 kB     137 kB
          select2.js     162 kB    65.5 kB
            embed.js    6.33 kB     2.8 kB
           vendor.js     1.1 MB     301 kB
      adhocracy4.css    84.8 kB    67.4 kB
          vendor.css    50.6 kB    41.4 kB
         leaflet.css      14 kB    11.1 kB
      datepicker.css    18.4 kB    16.3 kB
    leaflet.draw.css    6.25 kB    5.43 kB

Note that these are file sizes. The effect could be less if you count in gzip.

I am not sure what we need to do in order to get this into the actual deployment. @2e2a any ideas?