### PR TITLE
 List container projects only if user may view them

### DIFF
--- a/meinberlin/apps/projectcontainers/models.py
+++ b/meinberlin/apps/projectcontainers/models.py
@@ -13,15 +13,35 @@ class ProjectContainer(project_models.Project):
     )
 
     @property
-    def not_archived_projects(self):
-        return self.projects.filter(is_archived=False)
+    def published_not_archived_projects(self):
+        return self.projects \
+            .filter(is_draft=False, is_archived=False)
 
     @property
-    def active_projects(self):
+    def active_project_count(self):
+        """Return the number of active projects within the container.
+
+        If a container is public (default) only public projects are counted.
+        For future private containers all projects should be counted.
+        """
         now = timezone.now()
-        return self.projects.filter(
-            module__phase__start_date__lte=now,
-            module__phase__end_date__gt=now).distinct()
+        return self.projects\
+            .filter(is_public=True, is_draft=False, is_archived=False)\
+            .filter(module__phase__start_date__lte=now,
+                    module__phase__end_date__gt=now)\
+            .distinct()\
+            .count()
+
+    @property
+    def total_project_count(self):
+        """Return the number of total projects within the container.
+
+        If a container is public (default) only public projects are counted.
+        For future private containers all projects should be counted.
+        """
+        return self.projects \
+            .filter(is_public=True, is_draft=False, is_archived=False)\
+            .count()
 
     @property
     def phases(self):

--- a/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html
+++ b/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html
@@ -1,4 +1,4 @@
-{% load i18n rules thumbnail wagtailcore_tags %}
+{% load i18n rules thumbnail wagtailcore_tags contrib_tags %}
 
 <div class="project-header u-after-dialogue-box">
     <div class="l-wrapper">
@@ -10,7 +10,7 @@
                     <div class="project-header__description">
                         <p>{{ container.description }}</p>
                         <p>
-                            {% blocktrans with count=project.projectcontainer.projects.count active_count=project.projectcontainer.active_projects.count %}{{ active_count }} of {{ count }}{% endblocktrans %}
+                            {% blocktrans with count=project.projectcontainer.total_project_count active_count=project.projectcontainer.active_project_count %}{{ active_count }} of {{ count }}{% endblocktrans %}
                             {% trans 'projects are currently active.' %}
                         </p>
                     </div>
@@ -74,10 +74,15 @@
     aria-labelledby="tab-project-{{ project.pk }}-participation"
     aria-expanded="true">
     <div class="l-wrapper">
-        <ul class="l-tiles-4">
-            {% for project in container.not_archived_projects.all %}
-                {% include "meinberlin_projects/includes/project_list_tile.html" with project=project %}
-            {% endfor %}
-        </ul>
+        {% filter_has_perm 'a4projects.view_project' request.user container.published_not_archived_projects.all as filtered_projects %}
+        {% if filtered_projects|length > 0 %}
+            <ul class="l-tiles-4">
+                {% for project in filtered_projects %}
+                    {% include "meinberlin_projects/includes/project_list_tile.html" with project=project %}
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>{% trans 'We could not find any projects.' %}</p>
+        {% endif %}
     </div>
 </div>

--- a/meinberlin/apps/projects/query.py
+++ b/meinberlin/apps/projects/query.py
@@ -1,0 +1,21 @@
+from django.db.models import Q
+
+
+def filter_viewable(queryset, user):
+    # FIXME: has to be in sync with a4projects.view_project and should
+    #        be implemented on the Project's QueryManager/QuerySet.
+    #        Unfortunately that is not possible, as the QueryManager may not
+    #        be overwritten and the Project model is not swappable.
+    if user.is_superuser:
+        return queryset
+    elif user.is_authenticated:
+        return queryset.filter(
+            Q(is_public=True) |
+            Q(participants__pk=user.pk) |
+            Q(organisation__initiators__pk=user.pk) |
+            Q(moderators__pk=user.pk)
+        )
+    else:
+        return queryset.filter(
+            is_public=True
+        )

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
@@ -53,7 +53,7 @@
         {% if project|is_container %}
             <p class="tile__hint tile__hint--container">
                 <span class="tile__hint__big">
-                    {% blocktrans with count=project.projectcontainer.projects.count active_count=project.projectcontainer.active_projects.count %}{{ active_count }} of {{ count }}{% endblocktrans %}
+                    {% blocktrans with count=project.projectcontainer.total_project_count active_count=project.projectcontainer.active_project_count %}{{ active_count }} of {{ count }}{% endblocktrans %}
                 </span>
                 <br/>
                 {% trans 'projects are currently active.' %}


### PR DESCRIPTION
The project list within containers will be filtered by the permission of
the currently logged in users. Only projects that may be viewed by the
user are listed.

Furthermore this adapts the number of active and total projects.
For public containers it only counts published projects that are public
and not archived.
In the future (if containers may be private) the count for private
containers should reflect the total number of published, not archived
projects.

Furthermore this makes  the ORM project list filtering reusable.