### PR TITLE
open link to container outside of embed

### DIFF
--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -40,7 +40,7 @@
                 <div class="l-center-6">
                     {% with container=project.containers.first %}
                         {% if container %}
-                            <a href="{{ container.get_absolute_url }}" class="project-header__link">
+                            <a href="{{ container.get_absolute_url }}" class="project-header__link" data-embed-target="external">
                                 <i class="fa fa-arrow-left" aria-hidden="true"></i>
                                 {% blocktrans with name=container.name %}back to {{ name }}{% endblocktrans %}
                             </a>


### PR DESCRIPTION
-   If you embed a project that is inside of a container, the link back to the container should be treated as an external link.
-   If you embed a container, the link from a project back to the container should be handled as an internal link.

As we do show embed code for projects but not for containers, I think it is reasonable to ignore the second case.