### PR TITLE
Send signals when components update

### DIFF
--- a/meinberlin/apps/dashboard/views.py
+++ b/meinberlin/apps/dashboard/views.py
@@ -11,6 +11,7 @@ from adhocracy4.phases import models as phase_models
 from adhocracy4.projects import models as project_models
 from meinberlin.apps.contrib.views import ProjectContextMixin
 from meinberlin.apps.dashboard2 import mixins as a4dashboard_mixins
+from meinberlin.apps.dashboard2 import signals as a4dashboard_signals
 from meinberlin.apps.dashboard2 import views as a4dashboard_views
 from meinberlin.apps.dashboard2.blueprints import get_blueprints
 from meinberlin.apps.newsletters.forms import NewsletterForm
@@ -105,6 +106,9 @@ class ModuleCreateView(ProjectContextMixin,
             project=project,
         )
         module.save()
+        a4dashboard_signals.module_created.send(sender=None,
+                                                module=module,
+                                                user=self.request.user)
 
         self._create_module_settings(module)
         self._create_phases(module, self.blueprint.content)

--- a/meinberlin/apps/dashboard2/apps.py
+++ b/meinberlin/apps/dashboard2/apps.py
@@ -8,6 +8,3 @@ class Config(AppConfig):
     def ready(self):
         from django.utils.module_loading import autodiscover_modules
         autodiscover_modules('dashboard', register_to=self.module.components)
-
-        from . import signals
-        signals.connect_model_signal_handlers()

--- a/meinberlin/apps/dashboard2/components/forms/views.py
+++ b/meinberlin/apps/dashboard2/components/forms/views.py
@@ -7,6 +7,7 @@ from adhocracy4.projects import models as project_models
 from meinberlin.apps.contrib.views import ProjectContextMixin
 
 from ... import mixins
+from ... import signals
 
 
 class ProjectComponentFormView(ProjectContextMixin,
@@ -32,6 +33,14 @@ class ProjectComponentFormView(ProjectContextMixin,
     def get_permission_object(self):
         return self.project
 
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        signals.project_component_updated.send(sender=None,
+                                               project=self.project,
+                                               component=self.component,
+                                               user=self.request.user)
+        return response
+
 
 class ModuleComponentFormView(ProjectContextMixin,
                               mixins.DashboardBaseMixin,
@@ -55,3 +64,11 @@ class ModuleComponentFormView(ProjectContextMixin,
 
     def get_permission_object(self):
         return self.project
+
+    def form_valid(self, form):
+        response = super().form_valid(form)
+        signals.module_component_updated.send(sender=None,
+                                              module=self.module,
+                                              component=self.component,
+                                              user=self.request.user)
+        return response

--- a/meinberlin/apps/dashboard2/components/forms/views.py
+++ b/meinberlin/apps/dashboard2/components/forms/views.py
@@ -7,12 +7,12 @@ from adhocracy4.projects import models as project_models
 from meinberlin.apps.contrib.views import ProjectContextMixin
 
 from ... import mixins
-from ... import signals
 
 
 class ProjectComponentFormView(ProjectContextMixin,
                                mixins.DashboardBaseMixin,
                                mixins.DashboardComponentMixin,
+                               mixins.DashboardComponentUpdateSignalMixin,
                                SuccessMessageMixin,
                                generic.UpdateView):
 
@@ -33,18 +33,11 @@ class ProjectComponentFormView(ProjectContextMixin,
     def get_permission_object(self):
         return self.project
 
-    def form_valid(self, form):
-        response = super().form_valid(form)
-        signals.project_component_updated.send(sender=None,
-                                               project=self.project,
-                                               component=self.component,
-                                               user=self.request.user)
-        return response
-
 
 class ModuleComponentFormView(ProjectContextMixin,
                               mixins.DashboardBaseMixin,
                               mixins.DashboardComponentMixin,
+                              mixins.DashboardComponentUpdateSignalMixin,
                               SuccessMessageMixin,
                               generic.UpdateView):
 
@@ -64,11 +57,3 @@ class ModuleComponentFormView(ProjectContextMixin,
 
     def get_permission_object(self):
         return self.project
-
-    def form_valid(self, form):
-        response = super().form_valid(form)
-        signals.module_component_updated.send(sender=None,
-                                              module=self.module,
-                                              component=self.component,
-                                              user=self.request.user)
-        return response

--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -12,7 +12,6 @@ from adhocracy4.phases import models as phase_models
 from adhocracy4.projects import models as project_models
 from meinberlin.apps.maps.widgets import MapChoosePolygonWithPresetWidget
 
-from . import signals
 from .components.forms import ModuleDashboardForm
 from .components.forms import ModuleDashboardFormSet
 from .components.forms import ProjectDashboardForm
@@ -62,17 +61,6 @@ class ProjectBasicForm(ProjectDashboardForm):
                 ]
             ),
         }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        instance = kwargs.get('instance', None)
-        self._project_was_archived = instance and instance.is_archived
-
-    def save(self, commit=True):
-        project = super().save(commit)
-        if not self._project_was_archived and project.is_archived:
-            signals.project_archived.send(sender=None, project=project)
-        return project
 
 
 class ProjectInformationForm(ProjectDashboardForm):

--- a/meinberlin/apps/dashboard2/signals.py
+++ b/meinberlin/apps/dashboard2/signals.py
@@ -1,34 +1,8 @@
 from django import dispatch
-from django.apps import apps
-from django.db.models import signals as db_signals
 
-from adhocracy4.modules.models import Module
-from adhocracy4.projects.models import Project
-
-project_created = dispatch.Signal(providing_args=['project'])
-module_created = dispatch.Signal(providing_args=['module'])
+project_created = dispatch.Signal(providing_args=['project', 'user'])
+module_created = dispatch.Signal(providing_args=['module', 'user'])
 # Handlers may return an error message to prevent a project from publishing
-project_pre_publish = dispatch.Signal(providing_args=['project'])
-project_published = dispatch.Signal(providing_args=['project'])
-project_unpublished = dispatch.Signal(providing_args=['project'])
-project_archived = dispatch.Signal(providing_args=['project'])
-
-
-def _handle_project_signal(sender, instance, created, *args, **kwargs):
-    if created:
-        project_created.send(sender=None, project=instance)
-
-
-def _handle_module_signal(sender, instance, created, *args, **kwargs):
-    if created:
-        module_created.send(sender=None, module=instance)
-
-
-def connect_model_signal_handlers():
-    # Setup signals for all Models inheriting from Project
-    for model in apps.get_models():
-        if issubclass(model, Project):
-            db_signals.post_save.connect(_handle_project_signal, sender=model)
-
-    # Setup signals for Modules
-    db_signals.post_save.connect(_handle_module_signal, sender=Module)
+project_pre_publish = dispatch.Signal(providing_args=['project', 'user'])
+project_published = dispatch.Signal(providing_args=['project', 'user'])
+project_unpublished = dispatch.Signal(providing_args=['project', 'user'])

--- a/meinberlin/apps/dashboard2/signals.py
+++ b/meinberlin/apps/dashboard2/signals.py
@@ -6,3 +6,7 @@ module_created = dispatch.Signal(providing_args=['module', 'user'])
 project_pre_publish = dispatch.Signal(providing_args=['project', 'user'])
 project_published = dispatch.Signal(providing_args=['project', 'user'])
 project_unpublished = dispatch.Signal(providing_args=['project', 'user'])
+project_component_updated = dispatch.Signal(
+    providing_args=['project', 'component', 'user'])
+module_component_updated = dispatch.Signal(
+    providing_args=['module', 'component', 'user'])

--- a/meinberlin/apps/dashboard2/views.py
+++ b/meinberlin/apps/dashboard2/views.py
@@ -91,6 +91,10 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
 
     def form_valid(self, form):
         response = super().form_valid(form)
+        signals.project_created.send(sender=None,
+                                     project=self.object,
+                                     user=self.request.user)
+
         self._create_modules_and_phases(self.object)
 
         return response
@@ -103,6 +107,9 @@ class ProjectCreateView(mixins.DashboardBaseMixin,
             project=project,
         )
         module.save()
+        signals.module_created.send(sender=None,
+                                    module=module,
+                                    user=self.request.user)
 
         self._create_module_settings(module)
         self._create_phases(module, self.blueprint.content)
@@ -184,7 +191,8 @@ class ProjectPublishView(ProjectContextMixin,
             return
 
         responses = signals.project_pre_publish.send(sender=None,
-                                                     project=project)
+                                                     project=project,
+                                                     user=self.request.user)
         errors = [str(msg) for func, msg in responses if msg]
         if errors:
             msg = _('Project cannot be published.') + ' \n' + '\n'.join(errors)
@@ -193,7 +201,9 @@ class ProjectPublishView(ProjectContextMixin,
 
         project.is_draft = False
         project.save()
-        signals.project_published.send(sender=None, project=project)
+        signals.project_published.send(sender=None,
+                                       project=project,
+                                       user=self.request.user)
 
         messages.success(self.request,
                          _('Project successfully published.'))
@@ -206,6 +216,8 @@ class ProjectPublishView(ProjectContextMixin,
 
         project.is_draft = True
         project.save()
-        signals.project_unpublished.send(sender=None, project=project)
+        signals.project_unpublished.send(sender=None,
+                                         project=project,
+                                         user=self.request.user)
         messages.success(self.request,
                          _('Project successfully unpublished.'))

--- a/meinberlin/apps/documents/serializers.py
+++ b/meinberlin/apps/documents/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
 
 from adhocracy4.modules.models import Module
+from meinberlin.apps.dashboard2 import signals as a4dashboard_signals
+from meinberlin.apps.dashboard2 import components
 
 from .models import Chapter
 from .models import Paragraph
@@ -84,6 +86,11 @@ class DocumentSerializer(serializers.Serializer):
     def create(self, validated_data):
         chapters_data = validated_data['chapters']
         chapters = list(self._create_or_update(chapters_data))
+
+        # Send the component updated signal
+        # (the serializer is only used from within the dashboard)
+        self._send_component_updated_signal()
+
         return {
             'chapters': chapters
         }
@@ -108,3 +115,11 @@ class DocumentSerializer(serializers.Serializer):
                 yield chapter_serializer.update(instance, chapter_data)
             else:
                 yield chapter_serializer.create(chapter_data)
+
+    def _send_component_updated_signal(self):
+        a4dashboard_signals.module_component_updated.send(
+            sender=None,
+            module=Module.objects.get(id=self.context['module_pk']),
+            component=components.modules['document_settings'],
+            user=self.context['request'].user
+        )

--- a/meinberlin/apps/maptopicprio/views.py
+++ b/meinberlin/apps/maptopicprio/views.py
@@ -6,6 +6,7 @@ from adhocracy4.filters import filters as a4_filters
 from adhocracy4.filters import views as filter_views
 from meinberlin.apps.contrib import filters
 from meinberlin.apps.contrib.views import ProjectContextMixin
+from meinberlin.apps.dashboard2 import signals as a4dashboard_signals
 from meinberlin.apps.dashboard2 import mixins
 from meinberlin.apps.ideas import views as idea_views
 
@@ -101,6 +102,7 @@ class MapTopicListDashboardView(ProjectContextMixin,
 
 class MapTopicCreateView(mixins.DashboardBaseMixin,
                          mixins.DashboardComponentMixin,
+                         mixins.DashboardComponentUpdateSignalMixin,
                          idea_views.AbstractIdeaCreateView):
     model = models.MapTopic
     form_class = forms.MapTopicForm
@@ -118,6 +120,7 @@ class MapTopicCreateView(mixins.DashboardBaseMixin,
 
 class MapTopicUpdateView(mixins.DashboardBaseMixin,
                          mixins.DashboardComponentMixin,
+                         mixins.DashboardComponentUpdateSignalMixin,
                          idea_views.AbstractIdeaUpdateView):
     model = models.MapTopic
     form_class = forms.MapTopicForm
@@ -156,3 +159,12 @@ class MapTopicDeleteView(mixins.DashboardBaseMixin,
 
     def get_permission_object(self):
         return self.get_object()
+
+    def delete(self, request, *args, **kwargs):
+        response = super().delete(request, *args, **kwargs)
+        a4dashboard_signals.module_component_updated.send(
+            sender=None,
+            module=self.module,
+            component=self.component,
+            user=self.request.user)
+        return response

--- a/meinberlin/apps/offlineevents/views.py
+++ b/meinberlin/apps/offlineevents/views.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
 from meinberlin.apps.contrib.views import ProjectContextMixin
+from meinberlin.apps.dashboard2 import signals as a4dashboard_signals
 from meinberlin.apps.dashboard2 import mixins
 from meinberlin.apps.ideas import views as idea_views
 
@@ -34,6 +35,7 @@ class OfflineEventListView(ProjectContextMixin,
 class OfflineEventCreateView(ProjectContextMixin,
                              mixins.DashboardBaseMixin,
                              mixins.DashboardComponentMixin,
+                             mixins.DashboardComponentUpdateSignalMixin,
                              generic.CreateView):
     model = models.OfflineEvent
     form_class = forms.OfflineEventForm
@@ -57,6 +59,7 @@ class OfflineEventCreateView(ProjectContextMixin,
 class OfflineEventUpdateView(ProjectContextMixin,
                              mixins.DashboardBaseMixin,
                              mixins.DashboardComponentMixin,
+                             mixins.DashboardComponentUpdateSignalMixin,
                              generic.UpdateView):
     model = models.OfflineEvent
     form_class = forms.OfflineEventForm
@@ -89,7 +92,13 @@ class OfflineEventDeleteView(ProjectContextMixin,
 
     def delete(self, request, *args, **kwargs):
         messages.success(self.request, self.success_message)
-        return super().delete(request, *args, **kwargs)
+        response = super().delete(request, *args, **kwargs)
+        a4dashboard_signals.project_component_updated.send(
+            sender=None,
+            project=self.project,
+            component=self.component,
+            user=self.request.user)
+        return response
 
     def get_success_url(self):
         return reverse(

--- a/meinberlin/apps/polls/serializers.py
+++ b/meinberlin/apps/polls/serializers.py
@@ -1,5 +1,8 @@
 from rest_framework import serializers
 
+from meinberlin.apps.dashboard2 import signals as a4dashboard_signals
+from meinberlin.apps.dashboard2 import components
+
 from . import models
 from . import validators
 
@@ -49,6 +52,10 @@ class PollSerializer(serializers.ModelSerializer):
 
             self._update_choices(question, question_instance)
 
+        # Send the component updated signal
+        # (the serializer is only used from within the dashboard)
+        self._send_component_updated_signal(instance)
+
         return instance
 
     def _update_choices(self, question, question_instance):
@@ -68,6 +75,14 @@ class PollSerializer(serializers.ModelSerializer):
                     'label': choice['label']
                 }
             )
+
+    def _send_component_updated_signal(self, question_instance):
+        a4dashboard_signals.module_component_updated.send(
+            sender=None,
+            module=question_instance.module,
+            component=components.modules['polls'],
+            user=self.context['request'].user
+        )
 
 
 class VoteSerializer(serializers.ModelSerializer):

--- a/meinberlin/apps/topicprio/views.py
+++ b/meinberlin/apps/topicprio/views.py
@@ -8,6 +8,7 @@ from adhocracy4.filters import widgets as filters_widgets
 from adhocracy4.filters.filters import FreeTextFilter
 from meinberlin.apps.contrib import filters
 from meinberlin.apps.contrib.views import ProjectContextMixin
+from meinberlin.apps.dashboard2 import signals as a4dashboard_signals
 from meinberlin.apps.dashboard2 import mixins
 from meinberlin.apps.ideas import views as idea_views
 
@@ -101,6 +102,7 @@ class TopicListDashboardView(ProjectContextMixin,
 
 class TopicCreateView(mixins.DashboardBaseMixin,
                       mixins.DashboardComponentMixin,
+                      mixins.DashboardComponentUpdateSignalMixin,
                       idea_views.AbstractIdeaCreateView):
     model = models.Topic
     form_class = forms.TopicForm
@@ -118,6 +120,7 @@ class TopicCreateView(mixins.DashboardBaseMixin,
 
 class TopicUpdateView(mixins.DashboardBaseMixin,
                       mixins.DashboardComponentMixin,
+                      mixins.DashboardComponentUpdateSignalMixin,
                       idea_views.AbstractIdeaUpdateView):
     model = models.Topic
     form_class = forms.TopicForm
@@ -156,3 +159,12 @@ class TopicDeleteView(mixins.DashboardBaseMixin,
 
     def get_permission_object(self):
         return self.get_object()
+
+    def delete(self, request, *args, **kwargs):
+        response = super().delete(request, *args, **kwargs)
+        a4dashboard_signals.module_component_updated.send(
+            sender=None,
+            module=self.module,
+            component=self.component,
+            user=self.request.user)
+        return response


### PR DESCRIPTION
A signal is send if the form did update without raising an error on save. 
This also extends the existing signals by the user who triggered the action.