### PR TITLE
switch from babel-preset-2015 to babel-perset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "autoprefixer": "7.1.6",
     "babel-core": "6.26.0",
     "babel-loader": "7.1.2",
-    "babel-preset-es2015": "6.24.1",
+    "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "css-loader": "0.28.7",
     "copy-webpack-plugin": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "sass-loader": "6.0.6",
     "style-loader": "0.19.0",
     "webpack": "3.8.1",
-
     "adhocracy4": "liqd/adhocracy4#master",
     "bootstrap": "4.0.0-alpha.6",
     "datepicker": "git+https://github.com/liqd/datePicker.git",
@@ -59,5 +58,6 @@
   },
   "scripts": {
     "precommit": "make lint-quick"
-  }
+  },
+  "browserslist": "last 3 versions, ie >= 10"
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,7 @@ module.exports = {
         exclude: /node_modules\/(?!adhocracy4|bootstrap)/, // exclude most dependencies
         loader: 'babel-loader',
         options: {
-          presets: ['babel-preset-es2015', 'babel-preset-react'].map(require.resolve)
+          presets: ['babel-preset-env', 'babel-preset-react'].map(require.resolve)
         }
       },
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,9 +78,7 @@ module.exports = {
               options: {
                 ident: 'postcss',
                 plugins: (loader) => [
-                  autoprefixer({
-                    browsers: ['last 3 versions', 'ie >= 10']
-                  })
+                  autoprefixer()
                 ]
               }
             },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
       'immutability-helper',
       'react-dom',
       'react-flip-move',
-      'shariff',
+      'shariff/dist/shariff.complete.js',
       'shariff/dist/shariff.min.css'
     ],
     select2: [
@@ -61,7 +61,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: /node_modules\/(?!adhocracy4|bootstrap|shariff)/, // exclude most dependencies
+        exclude: /node_modules\/(?!adhocracy4|bootstrap)/, // exclude most dependencies
         loader: 'babel-loader',
         options: {
           presets: ['babel-preset-es2015', 'babel-preset-react'].map(require.resolve)


### PR DESCRIPTION
babel-preset-env is similar to autoprefixer in that it will configure babel to only apply transformations that are necessary for your target browsers.

This fixes a warning on npm install:

```
WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
```