### PR TITLE
alias shariff in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,7 +110,8 @@ module.exports = {
   resolve: {
     extensions: ['*', '.js', '.jsx', '.scss', '.css'],
     alias: {
-      'jquery$': 'jquery/dist/jquery.min.js'
+      'jquery$': 'jquery/dist/jquery.min.js',
+      'shariff$': 'shariff/dist/shariff.complete.js'
     },
     // when using `npm link`, dependencies are resolved against the linked
     // folder by default. This may result in dependencies being included twice.


### PR DESCRIPTION
Without this, the call to `require('shariff')` in app.js will pull in the es6 sources of shariff. We tell babel to ignore most stuff from node_modules (due to issues in the past), so it will not be transpiled.

The fix is to pull in the pre-build file instead.