### PR TITLE
Style markercluster and improve printing of plans

### DIFF
--- a/meinberlin/assets/scss/components/_map.scss
+++ b/meinberlin/assets/scss/components/_map.scss
@@ -70,3 +70,22 @@
         flex: 0 1 30em;
     }
 }
+
+.marker-cluster {
+    background-clip: padding-box;
+    border-radius: 20px;
+    background-color: rgba($brand-secondary, 0.6);
+
+    div {
+        width: 30px;
+        height: 30px;
+        margin-left: 5px;
+        margin-top: 5px;
+        text-align: center;
+        border-radius: 15px;
+        font-size: 12px $font-family-sans-serif;
+        background-color: $brand-secondary;
+        color: $text-color-inverted;
+        line-height: 30px;
+    }
+}

--- a/meinberlin/assets/scss/components/_map.scss
+++ b/meinberlin/assets/scss/components/_map.scss
@@ -51,6 +51,10 @@
         flex-direction: row;
         height: 36em;
     }
+
+    @media print {
+        max-height: none;
+    }
 }
 
 .map-list-combined__map {
@@ -68,6 +72,10 @@
 
     @media (min-width: $breakpoint) {
         flex: 0 1 30em;
+    }
+
+    @media print {
+        overflow: visible;
     }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,6 @@ module.exports = {
       'leaflet/dist/leaflet.css',
       'leaflet.markercluster',
       'leaflet.markercluster/dist/MarkerCluster.css',
-      'leaflet.markercluster/dist/MarkerCluster.Default.css',
       './meinberlin/assets/js/plans_map.jsx'
     ],
     datepicker: [


### PR DESCRIPTION
The styling is analogues to the bplan map: https://github.com/liqd/django_zbp/blob/master/bplan/static/scss/components/_markers.scss
