### PR TITLE
ManifestStaticFilesStorage Cachebusting

### DIFF
--- a/meinberlin/apps/contrib/staticfiles.py
+++ b/meinberlin/apps/contrib/staticfiles.py
@@ -1,0 +1,5 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class NonStrictManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    manifest_strict = False

--- a/meinberlin/config/settings/production.py
+++ b/meinberlin/config/settings/production.py
@@ -2,6 +2,7 @@ from .base import *
 
 COMPRESS = True
 COMPRESS_OFFLINE = True
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 DEBUG = False
 

--- a/meinberlin/config/settings/production.py
+++ b/meinberlin/config/settings/production.py
@@ -2,7 +2,7 @@ from .base import *
 
 COMPRESS = True
 COMPRESS_OFFLINE = True
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'meinberlin.apps.contrib.staticfiles.NonStrictManifestStaticFilesStorage'
 
 DEBUG = False
 


### PR DESCRIPTION
Trying out cachebusting provided by djangos `ManifestStaticFilesStorage`  as suggested in https://github.com/liqd/a4-meinberlin/issues/948.

Notes:
-  `collectstatic` needs to be called twice. Once with the default storage and once with  the ManifestStaticFilesStorage.
- The strict standard ManifestStaticFilesStorage did not work. As far I understood, this works only when the manifest file is predefined.
- Worked for CSS, Images and JS, but did break our react components.