### PR TITLE
Fix html_date template tag timezone handling

### DIFF
--- a/meinberlin/apps/contrib/templatetags/contrib_tags.py
+++ b/meinberlin/apps/contrib/templatetags/contrib_tags.py
@@ -63,6 +63,9 @@ def html_date(value, displayfmt=None, datetimefmt='c', **kwargs):
     """Format a date and wrap it in a html <time> element.
 
     Additional html attributes may be provided as kwargs (e.g. 'class').
+
+    Note: Converts the value to localtime as we loose the expects_localtime
+    flag functionality by directly calling the date flag.
     """
     localtime_value = timezone.localtime(value)
     displaydate = defaultfilters.date(localtime_value, displayfmt)

--- a/meinberlin/apps/contrib/templatetags/contrib_tags.py
+++ b/meinberlin/apps/contrib/templatetags/contrib_tags.py
@@ -5,6 +5,7 @@ from django import template
 from django.forms.utils import flatatt
 from django.template import defaultfilters
 from django.template.loader import render_to_string
+from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
@@ -63,8 +64,9 @@ def html_date(value, displayfmt=None, datetimefmt='c', **kwargs):
 
     Additional html attributes may be provided as kwargs (e.g. 'class').
     """
-    displaydate = defaultfilters.date(value, displayfmt)
-    datetime = defaultfilters.date(value, datetimefmt)
+    localtime_value = timezone.localtime(value)
+    displaydate = defaultfilters.date(localtime_value, displayfmt)
+    datetime = defaultfilters.date(localtime_value, datetimefmt)
     attribs = flatatt(kwargs)
     result = '<time %s datetime="%s">%s</time>' % (attribs,
                                                    datetime,

--- a/meinberlin/apps/contrib/templatetags/contrib_tags.py
+++ b/meinberlin/apps/contrib/templatetags/contrib_tags.py
@@ -65,7 +65,7 @@ def html_date(value, displayfmt=None, datetimefmt='c', **kwargs):
     Additional html attributes may be provided as kwargs (e.g. 'class').
 
     Note: Converts the value to localtime as we loose the expects_localtime
-    flag functionality by directly calling the date flag.
+    flag functionality by directly calling the date filter from django.
     """
     localtime_value = timezone.localtime(value)
     displaydate = defaultfilters.date(localtime_value, displayfmt)


### PR DESCRIPTION
The `date` and `time` template filters expect the value in localtime. 