### PR TITLE
Fixup 5591ddc28

### DIFF
--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -117,11 +117,13 @@
 
 .btn--small {
     padding: 0.3em 0.6em;
+    height: 2.2em;  // explicitly set height for elements that ignore line-height
     font-weight: inherit;
 }
 
 .btn--huge {
     padding: 0.8em 2em;
+    height: 3.2em;  // explicitly set height for elements that ignore line-height
 }
 
 .btn--full {


### PR DESCRIPTION
Explicitly setting height fixes cases where line-height is ignored (e.g.
select) but breaks cases where the padding or line-height is changed.

I am not sure which is the best solution. For now I went with setting
the height every time the padding is overwritten.