### PR TITLE
Fix grid for right aligned filters within control bars

### DIFF
--- a/meinberlin/assets/scss/components/_filter_bar.scss
+++ b/meinberlin/assets/scss/components/_filter_bar.scss
@@ -25,10 +25,9 @@
         float: right;
 
         @media (max-width: $breakpoint) {
-            // grid-position does not include grid-cell automatically
-            @include grid-cell();
             // push to the right
             // NOTE: needs to overwrite grid-tiles
+            @include grid-cell();
             @include grid-position(6);
         }
     }

--- a/meinberlin/assets/scss/components/_filter_bar.scss
+++ b/meinberlin/assets/scss/components/_filter_bar.scss
@@ -25,7 +25,8 @@
         float: right;
 
         @media (max-width: $breakpoint) {
-            float: none;
+            // grid-position does not include grid-cell automatically
+            @include grid-cell();
             // push to the right
             // NOTE: needs to overwrite grid-tiles
             @include grid-position(6);


### PR DESCRIPTION
The float is set for larger screen to position the filter to the right.
The grid does not work as expected if the element does not float.
As grid-position does not include grid-cell automatically it is required
to include it manually to reset the correct grid floating and margins.
fixes #1052