### PR TITLE
Revert "Fix select height"

### DIFF
--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -8,7 +8,6 @@ label {
     border: 1px solid $input-border-color;
     padding: 0.4em 0.6em;
     line-height: 1.6;
-    height: 2.4em;  // explicitly set height for elements that ignore line-height
     font-family: inherit;
     font-size: inherit;
 }

--- a/meinberlin/assets/scss/components/_button.scss
+++ b/meinberlin/assets/scss/components/_button.scss
@@ -117,13 +117,11 @@
 
 .btn--small {
     padding: 0.3em 0.6em;
-    height: 2.2em;  // explicitly set height for elements that ignore line-height
     font-weight: inherit;
 }
 
 .btn--huge {
     padding: 0.8em 2em;
-    height: 3.2em;  // explicitly set height for elements that ignore line-height
 }
 
 .btn--full {


### PR DESCRIPTION
As part of #1034 I set a fixed height on input elements to fix the height of select elements, which seem to ignore the line-height.

This negatively affects buttons, checkboxes, and textareas. We could attempt to set an explcit height for each of them, too. However, that is hard to maintain.

Since we diceded to not use select elements for filters in #1040, I now propose to roll back the previous changes and remove the fixed height from input elements.