### PR TITLE
Overlap vorhaben filterbar with the map

### DIFF
--- a/meinberlin/apps/plans/assets/plans_map.jsx
+++ b/meinberlin/apps/plans/assets/plans_map.jsx
@@ -277,85 +277,87 @@ class PlansMap extends React.Component {
   render () {
     return (
       <div>
-        <div className="l-wrapper">
-          <div className="control-bar" role="group" aria-label={django.gettext('Filter bar')}>
-            <form onSubmit={this.onFreeTextFilterSubmit.bind(this)} data-embed-target="ignore" className="input-group form-group u-inline-flex">
-              <input
-                onChange={this.onFreeTextFilterChange.bind(this)}
-                className="input-group__input"
-                name="search"
-                type="search"
-                placeholder={django.gettext('Search')} />
-              <button className="input-group__after btn btn--light" type="submit" title={django.gettext('Search')}>
-                <i className="fa fa-search" aria-label={django.gettext('Search')} />
-              </button>
-            </form>
-            &nbsp;
-            <div className="dropdown ">
-              <button type="button" className="dropdown-toggle btn btn--light btn--select" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="id_filter_status">
-                {django.gettext('Status')}: {statusNames[this.state.filters.status] || django.gettext('All')}
-                <i className="fa fa-caret-down" aria-hidden="true" />
-              </button>
-              <ul aria-labelledby="id_filter_status" className="dropdown-menu">
-                <li>
-                  <button
-                    type="button"
-                    className="dropdown-item select-item"
-                    value="-1"
-                    onClick={this.onStatusFilterChange.bind(this)}>
-                    {django.gettext('All')}
-                  </button>
-                </li>
-                {
-                  statusNames.map((name, i) => {
-                    return (
-                      <li key={i}>
-                        <button
-                          type="button"
-                          className="dropdown-item select-item"
-                          value={i}
-                          onClick={this.onStatusFilterChange.bind(this)}>
-                          <i className={`select-item-indicator fa fa-${statusIconNames[i]}`} aria-hidden="true" />
-                          {name}
-                        </button>
-                      </li>
-                    )
-                  })
-                }
-              </ul>
-            </div>
-            &nbsp;
-            <div className="dropdown ">
-              <button type="button" className="dropdown-toggle btn btn--light btn--select" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="id_filter_participation">
-                {django.gettext('Participation')}: {participationNames[this.state.filters.participation] || django.gettext('All')}
-                <i className="fa fa-caret-down" aria-hidden="true" />
-              </button>
-              <ul aria-labelledby="id_filter_participation" className="dropdown-menu">
-                <li>
-                  <button
-                    type="button"
-                    className="dropdown-item select-item"
-                    value="-1"
-                    onClick={this.onParticipationFilterChange.bind(this)}>
-                    {django.gettext('All')}
-                  </button>
-                </li>
-                {
-                  participationNames.map((name, i) => {
-                    return (
-                      <li key={i}>
-                        <button
-                          type="button"
-                          className="dropdown-item select-item"
-                          value={i}
-                          onClick={this.onParticipationFilterChange.bind(this)}>
-                          {name}
-                        </button>
-                      </li>
-                    )
-                  })
-                }
-              </ul>
+        <div className="control-bar__top-overlap">
+          <div className="l-wrapper">
+            <div className="control-bar" role="group" aria-label={django.gettext('Filter bar')}>
+              <form onSubmit={this.onFreeTextFilterSubmit.bind(this)} data-embed-target="ignore" className="input-group form-group u-inline-flex">
+                <input
+                  onChange={this.onFreeTextFilterChange.bind(this)}
+                  className="input-group__input"
+                  name="search"
+                  type="search"
+                  placeholder={django.gettext('Search')} />
+                <button className="input-group__after btn btn--light" type="submit" title={django.gettext('Search')}>
+                  <i className="fa fa-search" aria-label={django.gettext('Search')} />
+                </button>
+              </form>
+              &nbsp;
+              <div className="dropdown ">
+                <button type="button" className="dropdown-toggle btn btn--light btn--select" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="id_filter_status">
+                  {django.gettext('Status')}: {statusNames[this.state.filters.status] || django.gettext('All')}
+                  <i className="fa fa-caret-down" aria-hidden="true" />
+                </button>
+                <ul aria-labelledby="id_filter_status" className="dropdown-menu">
+                  <li>
+                    <button
+                      type="button"
+                      className="dropdown-item select-item"
+                      value="-1"
+                      onClick={this.onStatusFilterChange.bind(this)}>
+                      {django.gettext('All')}
+                    </button>
+                  </li>
+                  {
+                    statusNames.map((name, i) => {
+                      return (
+                        <li key={i}>
+                          <button
+                            type="button"
+                            className="dropdown-item select-item"
+                            value={i}
+                            onClick={this.onStatusFilterChange.bind(this)}>
+                            <i className={`select-item-indicator fa fa-${statusIconNames[i]}`} aria-hidden="true" />
+                            {name}
+                          </button>
+                        </li>
+                      )
+                    })
+                  }
+                </ul>
+              </div>
+              &nbsp;
+              <div className="dropdown ">
+                <button type="button" className="dropdown-toggle btn btn--light btn--select" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="id_filter_participation">
+                  {django.gettext('Participation')}: {participationNames[this.state.filters.participation] || django.gettext('All')}
+                  <i className="fa fa-caret-down" aria-hidden="true" />
+                </button>
+                <ul aria-labelledby="id_filter_participation" className="dropdown-menu">
+                  <li>
+                    <button
+                      type="button"
+                      className="dropdown-item select-item"
+                      value="-1"
+                      onClick={this.onParticipationFilterChange.bind(this)}>
+                      {django.gettext('All')}
+                    </button>
+                  </li>
+                  {
+                    participationNames.map((name, i) => {
+                      return (
+                        <li key={i}>
+                          <button
+                            type="button"
+                            className="dropdown-item select-item"
+                            value={i}
+                            onClick={this.onParticipationFilterChange.bind(this)}>
+                            {name}
+                          </button>
+                        </li>
+                      )
+                    })
+                  }
+                </ul>
+              </div>
             </div>
           </div>
         </div>

--- a/meinberlin/apps/plans/assets/plans_map.jsx
+++ b/meinberlin/apps/plans/assets/plans_map.jsx
@@ -22,6 +22,10 @@ const statusIconNames = [
   'pause'
 ]
 
+const participationNames = [
+  django.gettext('Planned')
+]
+
 const icons = statusIconNames.map((cls, i) => L.divIcon({
   className: 'map-list-combined__icon',
   html: `<i class="fa fa-${cls}" title="${statusNames[i]}" aria-hidden="true"></i>`,
@@ -92,7 +96,7 @@ class PlansMap extends React.Component {
   onParticipationFilterChange (event) {
     this.setState({
       filters: update(this.state.filters, {
-        $merge: {participation: parseInt(event.target.value, 10)}
+        $merge: {participation: parseInt(event.currentTarget.value, 10)}
       })
     })
   }
@@ -321,10 +325,38 @@ class PlansMap extends React.Component {
               </ul>
             </div>
             &nbsp;
-            <select onChange={this.onParticipationFilterChange.bind(this)} className="u-inline btn btn--light">
-              <option value="-1">{django.gettext('Participation')}: {django.gettext('All')}</option>
-              <option value="1">{django.gettext('Participation')}: {django.gettext('Planned')}</option>
-            </select>
+            <div className="dropdown ">
+              <button type="button" className="dropdown-toggle btn btn--light btn--select" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="id_filter_participation">
+                {django.gettext('Participation')}: {participationNames[this.state.filters.participation] || django.gettext('All')}
+                <i className="fa fa-caret-down" aria-hidden="true" />
+              </button>
+              <ul aria-labelledby="id_filter_participation" className="dropdown-menu">
+                <li>
+                  <button
+                    type="button"
+                    className="dropdown-item select-item"
+                    value="-1"
+                    onClick={this.onParticipationFilterChange.bind(this)}>
+                    {django.gettext('All')}
+                  </button>
+                </li>
+                {
+                  participationNames.map((name, i) => {
+                    return (
+                      <li key={i}>
+                        <button
+                          type="button"
+                          className="dropdown-item select-item"
+                          value={i}
+                          onClick={this.onParticipationFilterChange.bind(this)}>
+                          {name}
+                        </button>
+                      </li>
+                    )
+                  })
+                }
+              </ul>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
The first commit replaces the `<select>` input element with a dropdown and the second applies the control-bar__top-overlap styling.
But i am not longer really convinced the second is a good idea, as the filterbar overlaps with the zoom buttons and the first element of the list, too (see screenshot).

Maybe we should refrain from the overlap, but still keep the dropdown commit.


![vorhaben-map-overlap](https://user-images.githubusercontent.com/167407/33276961-6ea670d0-d397-11e7-9a06-716f74f977c1.png)
