### PR TITLE
improve comment-author styling

### DIFF
--- a/meinberlin/assets/scss/components/_comments.scss
+++ b/meinberlin/assets/scss/components/_comments.scss
@@ -75,6 +75,7 @@
     white-space: pre-line;
 }
 
+.comment-deleted-author,
 .comment-author {
     display: inline;
     margin-right: 0.4em;

--- a/meinberlin/assets/scss/components/_comments.scss
+++ b/meinberlin/assets/scss/components/_comments.scss
@@ -77,12 +77,23 @@
 
 .comment-author {
     display: inline;
+    margin-right: 0.4em;
     font-size: inherit;
-    font-weight: inherit;
-    color: inherit;
+    font-weight: bold;
+
+    a {
+        color: inherit;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+        }
+    }
 
     .label {
         margin-left: 0.2em;
+        font-weight: normal;
     }
 }
 


### PR DESCRIPTION
fixes #435

Note that we had actually just forgotten to style `comment-deleted-author`.