### PR TITLE
Hide date from adminlog 

### DIFF
--- a/meinberlin/apps/actions/templates/meinberlin_actions/includes/action.html
+++ b/meinberlin/apps/actions/templates/meinberlin_actions/includes/action.html
@@ -1,6 +1,6 @@
 {% load i18n contrib_tags %}
 
-<div class="action">
+<div class="action action--withdate">
     <i class="fa fa-{{ action.icon }} action__icon" aria-hidden="true"></i>
     <div class="action__main">
         <div class="action__line">

--- a/meinberlin/apps/adminlog/templates/meinberlin_adminlog/includes/logentry_list_item.html
+++ b/meinberlin/apps/adminlog/templates/meinberlin_adminlog/includes/logentry_list_item.html
@@ -6,8 +6,5 @@
         <div class="action__line">
             {{ object.message }}
         </div>
-        <div class="action__date">
-            {% html_date object.timestamp 'd.m.Y' class='relative' title=object.timestamp|date:'DATETIME_FORMAT' %}
-        </div>
     </div>
 </div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/component_library.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/component_library.html
@@ -133,7 +133,7 @@
                 <h2 id="cl-actions">Actions</h2>
 
                 <div class="cl-example">
-                    <div class="action">
+                    <div class="action action--withdate">
                         <i class="fa fa-clock-o action__icon" aria-hidden="true"></i>
                         <div class="action__main">
                             <div class="action__line">
@@ -147,11 +147,26 @@
                             </div>
                         </div>
                     </div>
+                    <div class="action action--withdate">
+                        <i class="fa fa-comment action__icon" aria-hidden="true"></i>
+                        <div class="action__main">
+                            <div class="action__line">
+                                Action of type comment
+                                {% lorem random %}
+                            </div>
+                            <div class="action__line">
+                                on <a href="#">Project</a>
+                            </div>
+                            <div class="action__date">
+                                03.11.2017
+                            </div>
+                        </div>
+                    </div>
                     <div class="action">
                         <i class="fa fa-comment action__icon" aria-hidden="true"></i>
                         <div class="action__main">
                             <div class="action__line">
-                                Action of type comment.
+                                Action of type comment without a date<br>
                                 {% lorem random %}
                             </div>
                             <div class="action__line">

--- a/meinberlin/assets/scss/components/_action.scss
+++ b/meinberlin/assets/scss/components/_action.scss
@@ -30,7 +30,7 @@
 }
 
 @media (min-width: $breakpoint) {
-    .action {
+    .action--withdate {
         padding-right: 8em;
         position: relative;
     }


### PR DESCRIPTION
This makes the current default styling with a date a variant `action--withdate`