### PR TITLE
Allow external projects without participation phase dates

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-13 14:37+0100\n"
+"POT-Creation-Date: 2017-12-13 15:25+0100\n"
 "PO-Revision-Date: 2017-10-16 13:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -234,7 +234,7 @@ msgstr "Anfangsdatum"
 
 #: adhocracy4/phases/models.py:72
 #: meinberlin/apps/dashboard2/forms.py:95
-#: meinberlin/apps/extprojects/forms.py:29
+#: meinberlin/apps/extprojects/forms.py:32
 msgid "End date"
 msgstr "Enddatum"
 
@@ -1233,7 +1233,7 @@ msgstr ""
 "Nur eingeladene Nutzerinnen und Nutzer können sich beteiligen (privat)."
 
 #: meinberlin/apps/dashboard2/forms.py:95
-#: meinberlin/apps/extprojects/forms.py:29
+#: meinberlin/apps/extprojects/forms.py:32
 msgid "End time"
 msgstr "Endzeit"
 
@@ -1587,7 +1587,22 @@ msgstr "Einstellungen"
 msgid "Edit external project settings"
 msgstr "Externes Projekt bearbeiten"
 
-#: meinberlin/apps/extprojects/forms.py:49
+#: meinberlin/apps/extprojects/forms.py:24
+msgid ""
+"Provide start and end dates if the external project allows participation. "
+"Either both, start and end date, have to be provided or none of them."
+msgstr ""
+"Geben Sie das Start- und Enddatum an, wenn das externe Projekt Beteiligung "
+"ermöglicht. Es muss entweder das Start- und das Enddatum oder keines der "
+"beiden angegeben werden."
+
+#: meinberlin/apps/extprojects/forms.py:53
+msgid "Either both start and end date have to be provided or none of them."
+msgstr ""
+"Entweder muss das Start- und das Enddatum oder keines der beiden angegeben "
+"werden."
+
+#: meinberlin/apps/extprojects/forms.py:58
 msgid "End date can not be smaller than the start date."
 msgstr "Das Enddatum kann nicht kleiner als das Startdatum sein."
 
@@ -2321,12 +2336,12 @@ msgstr "Externes Projekt"
 msgid "Project on meinBerlin"
 msgstr "Projekt auf meinBerlin"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:65
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:66
 #, python-format
 msgid "Participation possible until %(date)s"
 msgstr "Beteiligung möglich bis zum %(date)s"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:70
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:71
 #, python-format
 msgid "Participation starting from %(date)s"
 msgstr "Beteiligung fängt am %(date)s an"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-13 14:37+0100\n"
+"POT-Creation-Date: 2017-12-13 15:25+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -223,7 +223,7 @@ msgid "Start date"
 msgstr "Start date"
 
 #: adhocracy4/phases/models.py:72 meinberlin/apps/dashboard2/forms.py:95
-#: meinberlin/apps/extprojects/forms.py:29
+#: meinberlin/apps/extprojects/forms.py:32
 msgid "End date"
 msgstr "End date"
 
@@ -1204,7 +1204,7 @@ msgid "Only invited users can participate (private)."
 msgstr "Only invited users can participate (private)."
 
 #: meinberlin/apps/dashboard2/forms.py:95
-#: meinberlin/apps/extprojects/forms.py:29
+#: meinberlin/apps/extprojects/forms.py:32
 msgid "End time"
 msgstr "End time"
 
@@ -1554,7 +1554,19 @@ msgstr "External project settings"
 msgid "Edit external project settings"
 msgstr "Edit external project settings"
 
-#: meinberlin/apps/extprojects/forms.py:49
+#: meinberlin/apps/extprojects/forms.py:24
+msgid ""
+"Provide start and end dates if the external project allows participation. "
+"Either both, start and end date, have to be provided or none of them."
+msgstr ""
+"Provide start and end dates if the external project allows participation. "
+"Either both, start and end date, have to be provided or none of them."
+
+#: meinberlin/apps/extprojects/forms.py:53
+msgid "Either both start and end date have to be provided or none of them."
+msgstr "Either both start and end date have to be provided or none of them."
+
+#: meinberlin/apps/extprojects/forms.py:58
 msgid "End date can not be smaller than the start date."
 msgstr "End date can not be smaller than the start date."
 
@@ -2282,12 +2294,12 @@ msgstr "External Project"
 msgid "Project on meinBerlin"
 msgstr "Project on meinBerlin"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:65
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:66
 #, python-format
 msgid "Participation possible until %(date)s"
 msgstr "Participation possible until %(date)s"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:70
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html:71
 #, python-format
 msgid "Participation starting from %(date)s"
 msgstr "Participation starting from %(date)s"

--- a/meinberlin/apps/extprojects/dashboard.py
+++ b/meinberlin/apps/extprojects/dashboard.py
@@ -40,15 +40,5 @@ class ExternalProjectComponent(ProjectFormComponent):
             'dashboard-external-project-edit'
         )]
 
-    def get_progress(self, project):
-        project = project.externalproject
-
-        num_valid, num_required = super().get_progress(project)
-        phase_num_valid, phase_num_required = \
-            self._get_progress_for_object(project.phase,
-                                          ['start_date', 'end_date'])
-
-        return num_valid + phase_num_valid, num_required + phase_num_required
-
 
 components.register_project(ExternalProjectComponent())

--- a/meinberlin/apps/extprojects/forms.py
+++ b/meinberlin/apps/extprojects/forms.py
@@ -20,7 +20,10 @@ class ExternalProjectForm(ProjectDashboardForm):
         time_format='%H:%M',
         required=False,
         require_all_fields=False,
-        label=(_('Start date'), _('Start time'))
+        label=(_('Start date'), _('Start time')),
+        help_text=_('Provide start and end dates if the external project '
+                    'allows participation. Either both, start and end date, '
+                    'have to be provided or none of them.')
     )
     end_date = DateTimeField(
         time_format='%H:%M',
@@ -44,6 +47,12 @@ class ExternalProjectForm(ProjectDashboardForm):
     def clean_end_date(self, *args, **kwargs):
         start_date = self.cleaned_data.get('start_date')
         end_date = self.cleaned_data.get('end_date')
+
+        if start_date and not end_date or not start_date and end_date:
+            raise ValidationError(
+                _('Either both start and end date have to be provided '
+                  'or none of them.'))
+
         if start_date and end_date and end_date < start_date:
             raise ValidationError(
                 _('End date can not be smaller than the start date.'))

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_list_tile.html
@@ -58,7 +58,8 @@
                 <br/>
                 {% trans 'projects are currently active.' %}
             </p>
-        {% else %}
+        {% elif not project|is_external or project.externalproject.phase.start_date %}
+            {# Don't show for external projects without participation #}
             {% if project.active_phase %}
                 <p class="tile__hint">
                     {% html_date project.last_active_phase.end_date 'd.m.Y' as end_date %}


### PR DESCRIPTION
This allows to keep the start and end date of the external project clear. Either both or none of the dates is allowed to be given.
If no date is given the project tile won't show the 'Participation is possible until / starting from' text