### PR TITLE
Use textarea for module description input

### DIFF
--- a/meinberlin/apps/dashboard2/forms.py
+++ b/meinberlin/apps/dashboard2/forms.py
@@ -86,6 +86,10 @@ class ModuleBasicForm(ModuleDashboardForm):
         fields = ['name', 'description']
         required_for_project_publish = '__all__'
 
+        widgets = {
+            'description': forms.Textarea,
+        }
+
 
 class PhaseForm(forms.ModelForm):
     end_date = DateTimeField(

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
@@ -62,7 +62,7 @@
                 {% endif %}
                 {% if module_event_count > 1 and  module.description %}
                     <div class="item-detail__meta">
-                        {{ module.description }}
+                        {{ module.description|linebreaksbr }}
                     </div>
                 {% endif %}
 


### PR DESCRIPTION
This is due to a requirement from beteiligung.in
This kind of depends on liqd/adhocracy4#223 which increases the module description char limit
