### PR TITLE
2017 12 ka fix tab breaking

### DIFF
--- a/meinberlin/assets/scss/components/_tabs.scss
+++ b/meinberlin/assets/scss/components/_tabs.scss
@@ -67,3 +67,11 @@
 .tablist__left {
     float: left;
 }
+
+@media (max-width: $breakpoint) {
+    .tablist__right {
+        margin-bottom: 1em;
+        float: none;
+        text-align: right;
+    }
+}

--- a/meinberlin/assets/scss/components/_tabs.scss
+++ b/meinberlin/assets/scss/components/_tabs.scss
@@ -39,6 +39,14 @@
     }
 }
 
+@media (max-width: $breakpoint) {
+    .tab {
+        margin-right: 0;
+        padding-right: 0.4em;
+        padding-left: 0.4em;
+    }
+}
+
 .tablist--right {
     text-align: right;
 }

--- a/meinberlin/assets/scss/components/_tabs.scss
+++ b/meinberlin/assets/scss/components/_tabs.scss
@@ -74,4 +74,10 @@
         float: none;
         text-align: right;
     }
+
+    .tablist__left {
+        margin-bottom: 1em;
+        float: none;
+        text-align: left;
+    }
 }


### PR DESCRIPTION
This was a problem in product (https://github.com/liqd/a4-product/issues/204) and meinberlin. In meinBerlin it is in the projectlist, the container view and the dashboard. The mobile view is fixed in the project list and the container view, but in the dashboard the tabs still break into the next line because the text on the tabs is too long. We have to keep that in mind for tabs to follow.