### PR TITLE
Use CKeditor widgets media attribute to initialize js

### DIFF
--- a/meinberlin/apps/documents/templates/meinberlin_documents/react_documents.html
+++ b/meinberlin/apps/documents/templates/meinberlin_documents/react_documents.html
@@ -1,5 +1,6 @@
 {% load static %}
 
-<script src="{% static 'ckeditor/ckeditor/ckeditor.js' %}"></script>
+{{ ckeditor_media.js }}
+
 
 <div data-mb-widget="document-management" data-module="{{ module }}" data-chapters="{{ chapters }}" data-config="{{ config }}" data-reloadOnSuccess="{{ reload_on_success }}"></div>

--- a/meinberlin/apps/documents/templatetags/react_documents.py
+++ b/meinberlin/apps/documents/templatetags/react_documents.py
@@ -27,6 +27,7 @@ def react_documents(context, module, reload_on_success=False):
         'config': config,
         'id': 'document-' + str(module.id),
         'reload_on_success': json.dumps(reload_on_success),
+        'ckeditor_media': widget.media
     }
 
     return context


### PR DESCRIPTION
CKeditor calls ckeditor-init.js from its Media.js to set the
window.CKEDITOR_BASEPATH
The fallback tries to guess the basepath by comparing every `<script>`
tags src with `ckeditor.js`. Since we are using cachebusting the file
was renamed to `ckeditor.0151.js` and the basepath could not be found
automatically.
This commit fixes the problem of broken richtextfields from within react
components like used for documents.
(Or at least i hope so, as i can't test cache busting locally)