### PR TITLE
Stop excluding *.min.js files from parsing

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,6 @@ module.exports = {
     'django': 'django'
   },
   module: {
-    noParse: /\.min\.js$/,
     rules: [
       {
         test: /\.jsx?$/,


### PR DESCRIPTION
Probably starting from version 16 react is using the filename
`react.production.min.js` which was excluded from parsing.
Thus the `require` was not replaced correctly as [mentioned in the webpack docs](https://webpack.js.org/configuration/module/#module-noparse)

This PR fixes the problem by allowing files ending on `.min.js` to
be parsed again. 
I tested if everything^TM works on the local site and could not find any problems. But still i am not 100% sure why this line was added to the webpack.config and if it is really safe to remove it. 

There are some other `*.min.js` files as can be seen from the verbose weboack output:

```
info/bower_components/smooth-scroll/dist/js/smooth-scroll.min.js    5.01 kB          [emitted]         
   [28] ./node_modules/timeago.js/dist/timeago.min.js 2.13 kB {0} [depth 3] [built]
        cjs require react [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:20-36
    [2] ./node_modules/jquery/dist/jquery.min.js 86.7 kB {7} [depth 1] [built]
        cjs require fbjs/lib/emptyFunction [79] ./node_modules/react/cjs/react.production.min.js 10:80-113
        cjs require fbjs/lib/emptyFunction [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:109-142
        cjs require object-assign [79] ./node_modules/react/cjs/react.production.min.js 10:19-43
        cjs require object-assign [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:82-106
        cjs require fbjs/lib/emptyObject [79] ./node_modules/react/cjs/react.production.min.js 10:46-77
        cjs require fbjs/lib/emptyObject [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:327-358
        amd require define.amd [2] ./node_modules/jquery/dist/jquery.min.js 4:22289-22299
   [79] ./node_modules/react/cjs/react.production.min.js 5.41 kB {7} [depth 2] [built]
        cjs require ./cjs/react.production.min.js [0] ./node_modules/react/index.js 4:19-59
   [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 92.7 kB {7} [depth 2] [built]
        cjs require ./cjs/react-dom.production.min.js [3] ./node_modules/react-dom/index.js 35:19-63
        cjs require fbjs/lib/ExecutionEnvironment [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:39-79
        cjs require fbjs/lib/EventListener [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:146-179
        cjs require fbjs/lib/getActiveElement [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:183-219
        cjs require fbjs/lib/shallowEqual [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:223-255
        cjs require fbjs/lib/containsNode [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:259-291
        cjs require fbjs/lib/focusNode [80] ./node_modules/react-dom/cjs/react-dom.production.min.js 13:295-324

```

@slomo  could you please take a look at this and merge it if you think it won't break the other dependencies.