### PR TITLE
don't add berlin polygon to the list of district polygons

### DIFF
--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -43,7 +43,9 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
     def get_districts(self):
         try:
             berlin = MapPresetCategory.objects.get(name='Berlin')
-            return MapPreset.objects.filter(category=berlin)
+            return MapPreset.objects\
+                .filter(category=berlin)\
+                .exclude(name='Berlin')
         except ObjectDoesNotExist:
             return []
 


### PR DESCRIPTION
On the development server there is an extra polygon for the border of berlin in mappresets, which does not get loaded when running 'import_geodata'. Because of this, on the plans map not only the district borders but also the city are displayed and therefore added twice which looks strange. 

To remove the district borders on the map I excluded the Berlin map preset from the query.

