### PR TITLE
Ka 2018 01 use distinct ordering filter

### DIFF
--- a/meinberlin/apps/contrib/filters.py
+++ b/meinberlin/apps/contrib/filters.py
@@ -1,6 +1,6 @@
-import django_filters
 from django.utils.translation import ugettext_lazy as _
 
+from adhocracy4.filters.filters import DistinctOrderingFilter
 from adhocracy4.filters.widgets import DropdownLinkWidget
 
 from . import mixins
@@ -12,7 +12,7 @@ class OrderingWidget(DropdownLinkWidget):
 
 
 class OrderingFilter(mixins.DynamicChoicesMixin,
-                     django_filters.OrderingFilter):
+                     DistinctOrderingFilter):
 
     def __init__(self, *args, **kwargs):
         if 'widget' not in kwargs:

--- a/meinberlin/apps/projects/views.py
+++ b/meinberlin/apps/projects/views.py
@@ -17,6 +17,7 @@ from rules.contrib.views import LoginRequiredMixin
 from adhocracy4.filters import views as filter_views
 from adhocracy4.filters import widgets as filters_widgets
 from adhocracy4.filters.filters import DefaultsFilterSet
+from adhocracy4.filters.filters import DistinctOrderingFilter
 from adhocracy4.filters.filters import FreeTextFilter
 from adhocracy4.filters.widgets import DropdownLinkWidget
 from adhocracy4.projects import models as project_models
@@ -78,7 +79,7 @@ class ProjectFilterSet(DefaultsFilterSet):
         'is_archived': 'false'
     }
 
-    ordering = django_filters.OrderingFilter(
+    ordering = DistinctOrderingFilter(
         choices=(
             ('-created', _('Most recent')),
         ),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "style-loader": "0.19.1",
     "webpack": "3.10.0",
     "webpack-merge": "4.1.1",
-    "adhocracy4": "liqd/adhocracy4#5c3bafbb34c296a78ec1f96aa26767ecc7b92a71",
+    "adhocracy4": "liqd/adhocracy4#57c977f776e5ae854ec1407052f245d2eb67b539",
     "bootstrap": "4.0.0-alpha.6",
     "datepicker": "git+https://github.com/liqd/datePicker.git",
     "font-awesome": "4.7.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-git+git://github.com/liqd/adhocracy4.git@5c3bafbb34c296a78ec1f96aa26767ecc7b92a71#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@57c977f776e5ae854ec1407052f245d2eb67b539#egg=adhocracy4
 bcrypt==3.1.4
 django-capture-tag==1.0
 requests==2.18.4


### PR DESCRIPTION
Uses the distinct ordering filters from a4.

I searched for ListViews with pagination not using the ordering filter. I found:
- Actions -- use timestamp for ordering
- LogEntry -- also timestamp
- Dashboard2 -- uses a filterset, but currently without ordering filter. I guess, we will remember for a wile that we have to be careful if we add one, but should we put that down somewhere as well? or hope, that django filters fixes it before it can go wrong? To order, it uses created
- ProjectContainers -- uses pagination, but I couldn't find an ordering. But this is shown in the normal project list view and ordered?! I can only find how the projects from the containers are filtered out of the project list view, not how the containers are put into the list.
