### PR TITLE
Greenkeeper/react flip move 3.0.1

### DIFF
--- a/meinberlin/apps/documents/assets/ChapterForm.jsx
+++ b/meinberlin/apps/documents/assets/ChapterForm.jsx
@@ -1,8 +1,9 @@
+import FlipMove from 'react-flip-move'
+
 var React = require('react')
 var django = require('django')
 var ErrorList = require('../../contrib/assets/ErrorList')
 var ParagraphForm = require('./ParagraphForm')
-var FlipMove = require('react-flip-move')
 
 const ChapterForm = (props) => {
   return (

--- a/meinberlin/apps/documents/assets/ChapterForm.jsx
+++ b/meinberlin/apps/documents/assets/ChapterForm.jsx
@@ -1,6 +1,5 @@
-import FlipMove from 'react-flip-move'
-
 var React = require('react')
+var FlipMove = require('react-flip-move').default
 var django = require('django')
 var ErrorList = require('../../contrib/assets/ErrorList')
 var ParagraphForm = require('./ParagraphForm')

--- a/meinberlin/apps/documents/assets/ChapterNav.jsx
+++ b/meinberlin/apps/documents/assets/ChapterNav.jsx
@@ -1,6 +1,5 @@
-import FlipMove from 'react-flip-move'
-
 var React = require('react')
+var FlipMove = require('react-flip-move').default
 var django = require('django')
 var ChapterNavItem = require('./ChapterNavItem')
 

--- a/meinberlin/apps/documents/assets/ChapterNav.jsx
+++ b/meinberlin/apps/documents/assets/ChapterNav.jsx
@@ -1,7 +1,8 @@
+import FlipMove from 'react-flip-move'
+
 var React = require('react')
 var django = require('django')
 var ChapterNavItem = require('./ChapterNavItem')
-var FlipMove = require('react-flip-move')
 
 const ChapterNav = (props) => {
   const activeKey = props.activeChapter.id || props.activeChapter.key

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "leaflet": "1.3.1",
     "leaflet-draw": "1.0.2",
     "leaflet.markercluster": "1.3.0",
-    "react-flip-move": "2.10.0",
+    "react-flip-move": "3.0.1",
     "sass-planifolia": "0.5.0",
     "select2": "4.0.5",
     "shariff": "2.1.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,6 @@ bcrypt==3.1.4
 django-capture-tag==1.0
 requests==2.18.4
 wagtail==1.13.1
-XlsxWriter==1.0.2
 zeep==2.5.0
 
 # Inherited a4-core requirements
@@ -22,3 +21,4 @@ jsonfield==2.0.2
 python-dateutil==2.6.1
 python-magic==0.4.15
 rules==1.3
+XlsxWriter==1.0.2


### PR DESCRIPTION
Not sure why, but it flip-move does not work with `require` anymore. Using `import` is fine though and works with babel. 