### PR TITLE
Set MapPreset category containing the region to "Bezirke - Berlin"

### DIFF
--- a/meinberlin/apps/maps/management/commands/import_geodata.py
+++ b/meinberlin/apps/maps/management/commands/import_geodata.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         self._import_regions()
 
     def _import_districts(self):
-        category = self._preset_category('Berlin')
+        category = self._preset_category('Bezirke - Berlin')
         tmpfile = '/tmp/bezirke.json'
         url = 'http://fbinter.stadt-berlin.de/fb/' \
               'wfs/geometry/senstadt/re_bezirke/'

--- a/meinberlin/apps/plans/models.py
+++ b/meinberlin/apps/plans/models.py
@@ -43,7 +43,7 @@ class Plan(UserGeneratedContentModel):
     )
     district = models.ForeignKey(
         MapPreset,
-        limit_choices_to=Q(category__name='Berlin') & ~Q(name='Berlin'))
+        limit_choices_to=Q(category__name='Bezirke - Berlin'))
     contact = models.TextField(max_length=255, verbose_name=_('Contact'))
     cost = models.PositiveIntegerField(blank=True, null=True,
                                        verbose_name=_('Cost'))

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -16,7 +16,6 @@ from adhocracy4.exports import views as export_views
 from adhocracy4.rules import mixins as rules_mixins
 from meinberlin.apps.contrib.views import CanonicalURLDetailView
 from meinberlin.apps.maps.models import MapPreset
-from meinberlin.apps.maps.models import MapPresetCategory
 from meinberlin.apps.plans.forms import PlanForm
 from meinberlin.apps.plans.models import Plan
 
@@ -43,10 +42,8 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
 
     def get_districts(self):
         try:
-            berlin = MapPresetCategory.objects.get(name='Berlin')
-            return MapPreset.objects\
-                .filter(category=berlin)\
-                .exclude(name='Berlin')
+            return MapPreset.objects.filter(
+                category__name='Bezirke - Berlin')
         except ObjectDoesNotExist:
             return []
 


### PR DESCRIPTION
Note that i changed the category containing bezirke on dev and stage to "Bezirke - Berlin" in accordance with prod. On the local machines the table should be cleared and the import script run again.

This is a really hacky solution that should be replaces as soon as possible by a more geo way.
For example separate table for bezirke and bezirksregionen which could then be used for the mappresetcategory instead of the other way around