### PR TITLE
Enable HTTP2-push for static files

### DIFF
--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -112,6 +112,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = (
+    'django_cloudflare_push.middleware.push_middleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,6 +13,7 @@ django-allauth==0.35.0
 django-autoslug==1.9.3
 django-background-tasks==1.1.13
 django-ckeditor==5.4.0
+django-cloudflare-push==0.2.0
 django-filter==1.1.0
 django-widget-tweaks==1.4.1
 djangorestframework==3.7.7


### PR DESCRIPTION
This enables the http2 feature of pushing files before they get
requested by the browser. It can speed up browser rendering,
especially on on cold caches/first page landings.

Important to note: this does NOT disable browser caching and
browsers do cancel unnessecary file transmissions. But in cases
where the push is faster than the cache (which does happen quite
often, even on SSDs but more often on HDDs), some browsers
rather redownload the file. The network overhead should be
negitable, as media images make up for most of the traffic and
the pushes use streams instead of new connections (HTTP2, yeah!)