### PR TITLE
remove scrollTo from code as it breaks in IE

### DIFF
--- a/meinberlin/apps/plans/assets/plans_map.jsx
+++ b/meinberlin/apps/plans/assets/plans_map.jsx
@@ -337,8 +337,6 @@ class PlansMap extends React.Component {
       // scroll list
       if (this.state.selected !== null && this.isInFilter(this.props.items[this.state.selected])) {
         $(this.listElement).find('.selected').scrollintoview()
-      } else {
-        this.listElement.scrollTo(0, 0)
       }
     }
   }


### PR DESCRIPTION
the scrollTo breaks the code completely in IE 11 (map disappears) and  as I could not really figure out why and when this is actually needed, I removed it.