### PR TITLE
increase z-index for dropdown menu

### DIFF
--- a/meinberlin/assets/scss/components/_dropdown.scss
+++ b/meinberlin/assets/scss/components/_dropdown.scss
@@ -16,7 +16,7 @@
     // the current dropdown-toggle should be above the dropdown-menu shadow
     .dropdown.show & {
         position: relative;
-        z-index: 2;
+        z-index: 3;
     }
 
     i {
@@ -42,7 +42,7 @@
     max-width: none;
     padding: 0;
     margin: 0;
-    z-index: 1;
+    z-index: 2;
     background-color: $body-bg;
     color: contrast-color($body-bg);
     border: 1px solid $text-color;


### PR DESCRIPTION
fixes #1281 

This gives dropdowns the highest z-index(es), we have in the whole project. IMHO that should be fine as normally dropdowns should open on top of other stuff.