### PR TITLE
z-index for phase bulltes auto on desktop

### DIFF
--- a/meinberlin/assets/scss/components/_timeline.scss
+++ b/meinberlin/assets/scss/components/_timeline.scss
@@ -103,6 +103,8 @@ $circle-size: 0.8em;
     }
 
     .timeline__button:after {
+        z-index: auto;
+
         top: auto;
         margin-top: 0;
 


### PR DESCRIPTION
The z-index was added here: https://github.com/liqd/a4-meinberlin/commit/6da1c202d7aff231666b870dee173ea2c038533c

fixes #1258 