### PR TITLE
Print tracebacks that happened in tasks

### DIFF
--- a/meinberlin/config/settings/dev.py
+++ b/meinberlin/config/settings/dev.py
@@ -31,6 +31,14 @@ try:
 except ImportError:
     pass
 
+LOGGING = {
+        'version': 1,
+        'handlers': {
+                'console': {
+                        'class': 'logging.StreamHandler'},
+        },
+        'loggers': {'background_task': {'handlers': ['console'], 'level': 'INFO'}}}
+
 try:
     INSTALLED_APPS += tuple(ADDITIONAL_APPS)
 except NameError:


### PR DESCRIPTION
With this we see if there are errors handling tasks.
It would be nice to also have it in the other projects