### PR TITLE
More fine grained call to action in notifications, closes #1250

### DIFF
--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_new_item.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_new_item.de.email
@@ -7,7 +7,7 @@
 
 {% block content %}{{ action.actor.username }} hat einen neuen Beitrag im Projekt {{ action.project.name }} erstellt. Schauen Sie nach, was in dem Projekt aktuell passiert.{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_absolute_url }}{% endblock %}
-{% block cta_label %}Projekt anzeigen{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.get_absolute_url|default:action.obj.module.get_absolute_url }}{% endblock %}
+{% block cta_label %}{% if action.obj.get_absolute_url %}Beitrag anzeigen{% else %}Project anzeigen{% endif %}{% endblock %}
 
 {% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Die E-Mail wurde an Sie gesendet, da Sie einem Projekt folgen. Wenn Sie diese E-Mails nicht länger erhalten möchten, können Sie dem Projekt auf der Projektseite entfolgen oder Benachrichtigungen in Ihren Benutzerkonto Einstellungen komplett deaktivieren.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_new_item.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_new_item.en.email
@@ -7,7 +7,8 @@
 
 {% block content %}a {{ action.obj | verbose_name }} was added to project "{{ action.project.name }}" by "{{ action.project.organisation.name }}".{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_absolute_url }}{% endblock %}
-{% block cta_label %}Visit the project{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.get_absolute_url|default:action.obj.module.get_absolute_url }}{% endblock %}
+{% block cta_label %}{% if action.obj.get_absolute_url %}Visit the entry{% else %}Visit the project{% endif %}{% endblock %}
+
 
 {% block reason %}This email was sent to {{ receiver.email }}. This email was sent to you because you follow a project. If you don’t want to receive these notifications anymore, you can unfollow the project on the project page or disable notifications completely in your account settings.{% endblock %}


### PR DESCRIPTION
I am actually not so happy with this solution.
We use similar code in other templates: https://github.com/liqd/a4-meinberlin/tree/master/meinberlin/apps/notifications/templates/meinberlin_notifications/emails

And it's too much logic in the template. But somehow I did'nt came up with a better solution for this one.
