### PR TITLE
always display phases and remove borders if there is just one phase

### DIFF
--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
@@ -67,7 +67,7 @@
                 {% endif %}
 
                 {% with phase_count=module.phases.count %}
-                <div class="phase-info" id="phase-overview">
+                <div class="phase-info">
                     {% for phase in module.phases %}{# FIXME: not ordered by start_date but by weight #}
                         <div class="phase-info__item {% if phase_count == 1 %} u-no-border {% endif %}">
                             <div class="phase-info__item__title{% if phase == module.active_phase %} lr-bar{% endif %}">

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/timeline.html
@@ -66,9 +66,10 @@
                     </div>
                 {% endif %}
 
-                <div class="phase-info collapse" id="phase-overview">
+                {% with phase_count=module.phases.count %}
+                <div class="phase-info" id="phase-overview">
                     {% for phase in module.phases %}{# FIXME: not ordered by start_date but by weight #}
-                        <div class="phase-info__item">
+                        <div class="phase-info__item {% if phase_count == 1 %} u-no-border {% endif %}">
                             <div class="phase-info__item__title{% if phase == module.active_phase %} lr-bar{% endif %}">
                                 {% if phase == module.active_phase %}
                                     <span class="lr-bar__left">{{ phase.name }}</span>
@@ -87,11 +88,8 @@
                         </div>
                     {% endfor %}
                 </div>
+            {% endwith %}
 
-                <button class="btn btn--link" type="button" data-toggle="collapse" data-target="#phase-overview" aria-expanded="false" aria-controls="phase-overview">
-                    <span class="u-if-collapsed">{% trans 'Show phase overview' %}</span>
-                    <span class="u-if-not-collapsed">{% trans 'Hide phase overview' %}</span>
-                </button>
             {% else %}
                 <div class="timeline-detail__meta">
                     <strong>

--- a/meinberlin/assets/scss/utility.scss
+++ b/meinberlin/assets/scss/utility.scss
@@ -76,6 +76,12 @@
     position: relative;
 }
 
+.u-no-border,
+.u-no-border:first-child,
+.u-no-border:last-child {
+    border: none;
+}
+
 .d-none {
     display: none;
 }


### PR DESCRIPTION
This PR removes the ability to hide/show phases in the project view. If there is just one phase the grey borders are not shown