### PR TITLE
Ka 2018 05 add item tag tests

### DIFF
--- a/tests/ideas/test_item_tags.py
+++ b/tests/ideas/test_item_tags.py
@@ -27,3 +27,21 @@ def test_get_change_perm(rf, idea_factory):
     assert 'meinberlin_ideas.change_idea' == context['change_perm']
     assert rules.perm_exists(context['change_perm'])
     assert 'meinberlin_ideas.delete_idea' == context['delete_perm']
+
+
+@pytest.mark.django_db
+def test_get_item_url(rf, idea_factory):
+    obj = idea_factory()
+    request = rf.get('/')
+    template = ('{% load item_tags %}'
+                '{% get_item_update_url obj as update_url %}'
+                '{% get_item_delete_url obj as delete_url %}'
+                '{{ update_url }}'
+                '{{ delete_url }}')
+    context = {'request': request, 'obj': obj}
+    helpers.render_template(template, context)
+
+    assert ('/ideas/{}-{}/update/'.format(obj.created.year,
+            '{:05d}'.format(obj.pk)) == context['update_url'])
+    assert ('/ideas/{}-{}/delete/'.format(obj.created.year,
+            '{:05d}'.format(obj.pk)) == context['delete_url'])

--- a/tests/ideas/test_item_tags.py
+++ b/tests/ideas/test_item_tags.py
@@ -1,0 +1,29 @@
+import pytest
+import rules
+
+from adhocracy4.test import helpers
+
+
+@pytest.mark.django_db
+def test_get_change_perm(rf, idea_factory):
+    obj = idea_factory()
+    request = rf.get('/')
+    template = ('{% load item_tags %}'
+                '{% get_item_view_permission obj as view_perm %}'
+                '{% get_item_add_permission obj as add_perm %}'
+                '{% get_item_change_permission obj as change_perm %}'
+                '{% get_item_delete_permission obj as delete_perm %}'
+                '{{ view_perm }}'
+                '{{ add_perm }}'
+                '{{ change_perm }}'
+                '{{ delete_perm }}')
+    context = {'request': request, 'obj': obj}
+    helpers.render_template(template, context)
+
+    assert 'meinberlin_ideas.view_idea' == context['view_perm']
+    assert rules.perm_exists(context['view_perm'])
+    assert 'meinberlin_ideas.add_idea' == context['add_perm']
+    assert rules.perm_exists(context['add_perm'])
+    assert 'meinberlin_ideas.change_idea' == context['change_perm']
+    assert rules.perm_exists(context['change_perm'])
+    assert 'meinberlin_ideas.delete_idea' == context['delete_perm']

--- a/tests/mapideas/test_item_tags.py
+++ b/tests/mapideas/test_item_tags.py
@@ -1,0 +1,29 @@
+import pytest
+import rules
+
+from adhocracy4.test import helpers
+
+
+@pytest.mark.django_db
+def test_get_change_perm(rf, map_idea_factory):
+    obj = map_idea_factory()
+    request = rf.get('/')
+    template = ('{% load item_tags %}'
+                '{% get_item_view_permission obj as view_perm %}'
+                '{% get_item_add_permission obj as add_perm %}'
+                '{% get_item_change_permission obj as change_perm %}'
+                '{% get_item_delete_permission obj as delete_perm %}'
+                '{{ view_perm }}'
+                '{{ add_perm }}'
+                '{{ change_perm }}'
+                '{{ delete_perm }}')
+    context = {'request': request, 'obj': obj}
+    helpers.render_template(template, context)
+
+    assert 'meinberlin_mapideas.view_mapidea' == context['view_perm']
+    assert rules.perm_exists(context['view_perm'])
+    assert 'meinberlin_mapideas.add_mapidea' == context['add_perm']
+    assert rules.perm_exists(context['add_perm'])
+    assert 'meinberlin_mapideas.change_mapidea' == context['change_perm']
+    assert rules.perm_exists(context['change_perm'])
+    assert 'meinberlin_mapideas.delete_mapidea' == context['delete_perm']

--- a/tests/maptopicprio/test_item_tags.py
+++ b/tests/maptopicprio/test_item_tags.py
@@ -1,0 +1,29 @@
+import pytest
+import rules
+
+from adhocracy4.test import helpers
+
+
+@pytest.mark.django_db
+def test_get_change_perm(rf, maptopic_factory):
+    obj = maptopic_factory()
+    request = rf.get('/')
+    template = ('{% load item_tags %}'
+                '{% get_item_view_permission obj as view_perm %}'
+                '{% get_item_add_permission obj as add_perm %}'
+                '{% get_item_change_permission obj as change_perm %}'
+                '{% get_item_delete_permission obj as delete_perm %}'
+                '{{ view_perm }}'
+                '{{ add_perm }}'
+                '{{ change_perm }}'
+                '{{ delete_perm }}')
+    context = {'request': request, 'obj': obj}
+    helpers.render_template(template, context)
+
+    assert 'meinberlin_maptopicprio.view_maptopic' == context['view_perm']
+    assert rules.perm_exists(context['view_perm'])
+    assert 'meinberlin_maptopicprio.add_maptopic' == context['add_perm']
+    assert rules.perm_exists(context['add_perm'])
+    assert 'meinberlin_maptopicprio.change_maptopic' == context['change_perm']
+    assert rules.perm_exists(context['change_perm'])
+    assert 'meinberlin_maptopicprio.delete_maptopic' == context['delete_perm']

--- a/tests/topicprio/test_item_tags.py
+++ b/tests/topicprio/test_item_tags.py
@@ -1,0 +1,29 @@
+import pytest
+import rules
+
+from adhocracy4.test import helpers
+
+
+@pytest.mark.django_db
+def test_get_change_perm(rf, topic_factory):
+    obj = topic_factory()
+    request = rf.get('/')
+    template = ('{% load item_tags %}'
+                '{% get_item_view_permission obj as view_perm %}'
+                '{% get_item_add_permission obj as add_perm %}'
+                '{% get_item_change_permission obj as change_perm %}'
+                '{% get_item_delete_permission obj as delete_perm %}'
+                '{{ view_perm }}'
+                '{{ add_perm }}'
+                '{{ change_perm }}'
+                '{{ delete_perm }}')
+    context = {'request': request, 'obj': obj}
+    helpers.render_template(template, context)
+
+    assert 'meinberlin_topicprio.view_topic' == context['view_perm']
+    assert rules.perm_exists(context['view_perm'])
+    assert 'meinberlin_topicprio.add_topic' == context['add_perm']
+    assert rules.perm_exists(context['add_perm'])
+    assert 'meinberlin_topicprio.change_topic' == context['change_perm']
+    assert rules.perm_exists(context['change_perm'])
+    assert 'meinberlin_topicprio.delete_topic' == context['delete_perm']


### PR DESCRIPTION
Some tests, unluckily the tags from the item tags are not actually all in use. I'd propose, we merge nonetheless and do a rewrite (or at least some deleting) at some points it fits.