### PR TITLE
Ka 2018 05 error pages

### DIFF
--- a/meinberlin/templates/403.html
+++ b/meinberlin/templates/403.html
@@ -1,0 +1,8 @@
+{% extends "base_errors.html" %}
+{% load i18n %}
+
+{% block error_status %}403{% endblock %}
+
+{% block error_description %}
+    <p>{% trans 'You are not allowed to access this page.' %}</p>
+{% endblock %}

--- a/meinberlin/templates/500.html
+++ b/meinberlin/templates/500.html
@@ -1,8 +1,60 @@
-{% extends "base_errors.html" %}
-{% load i18n %}
+{% load i18n static %}
+<html>
+    <head>
+        <title>Error &mdash; {% trans 'meinBerlin' %}</title>
+        <link rel="stylesheet" type="text/css" href="{% static 'vendor.css' %}" />
+        <link rel="stylesheet" type="text/css" href="{% static 'adhocracy4.css' %}" />
+    </head>
 
-{% block error_status %}500{% endblock %}
+    <body>
+        <a href="#main" class="sr-only sr-only-focusable">{% trans "Skip to content "%}</a>
 
-{% block error_description %}
-    <p>{% trans 'Internal server error.' %}</p>
-{% endblock %}
+        <div class="portal-header">
+            <div class="l-wrapper">
+                <div class="portal-header__red-line"></div>
+                <a class="portal-header__logo" href="http://www.berlin.de/">
+                    <img src="{% static 'images/berlin_de.png' %}" alt="Zur Homepage von Berlin.de" />
+                </a>
+
+                <nav aria-label="{% trans 'Portal Navigation' %}">
+                    <ul class="portal-header__nav">
+                        <li><a href="https://www.berlin.de/politik-verwaltung-buerger/">Politik, Verwaltung, Bürger</a></li>
+                        <li><a href="https://www.berlin.de/kultur-und-tickets/">Kultur &#38; Ausgehen</a></li>
+                        <li><a href="https://www.berlin.de/tourismus/">Tourismus</a></li>
+                        <li><a href="https://www.berlin.de/wirtschaft/">Wirtschaft</a></li>
+                        <li><a href="https://www.berlin.de/special/">Themen</a></li>
+                        <li><a href="https://www.berlin.de/adressen/">BerlinFinder</a></li>
+                        <li><a href="https://www.berlin.de/stadtplan/">Stadtplan</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+
+        <header class="main-header">
+            <div class="l-wrapper">
+                <nav class="main-nav">
+                    <img class="beberlin-logo" src="{% static 'images/beberlin.svg' %}" height="22" width="90" alt="be Berlin" />
+                    <a href="/" class="main-nav__logo" rel="home">
+                        <img src="{% static 'images/LOGO.png' %}" alt="mein.berlin"/>
+                    </a>
+                </nav>
+            </div>
+            <div class="dialogue-box">
+                {# Static markup to allow the blue border with the spike from Berlin's CD #}
+                <div class="dialogue-box__left"></div>
+                <div class="dialogue-box__center"></div>
+                <div class="dialogue-box__right"></div>
+            </div>
+        </header>
+
+        <div class="l-wrapper">
+            <div class="l-center-6">
+                <h1>500</h1>
+                <p>{% trans 'Internal server error.' %}</p>
+            </div>
+        </div>
+
+        <footer class="main-footer">
+        </footer>
+    </body>
+</html>

--- a/meinberlin/templates/500.html
+++ b/meinberlin/templates/500.html
@@ -51,6 +51,7 @@
             <div class="l-center-6">
                 <h1>500</h1>
                 <p>{% trans 'Internal server error.' %}</p>
+                <a href="/">{% trans 'Back to meinBerlin.' %}</a>
             </div>
         </div>
 

--- a/meinberlin/templates/base_errors.html
+++ b/meinberlin/templates/base_errors.html
@@ -8,6 +8,7 @@
     <div class="l-center-6">
         <h1>{% block error_status %}{% endblock %}</h1>
         {% block error_description %}{% endblock %}
+        <a href="/">{% trans 'Back to meinBerlin.' %}</a>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
fixes #1361 

also does not use the base template for server errors anymore

to test:  

-  set DEBUG=False and add ALLOWED_HOSTS = ['localhost'] in/to settings/dev.py

- start server with: python manage.py runserver --insecure
