### PR TITLE
add management script to display failed tasks

### DIFF
--- a/meinberlin/apps/contrib/management/commands/errored_task_notification.py
+++ b/meinberlin/apps/contrib/management/commands/errored_task_notification.py
@@ -1,0 +1,21 @@
+from background_task.models_completed import CompletedTask
+from django.core.management.base import BaseCommand
+from django.core.urlresolvers import reverse
+
+
+class Command(BaseCommand):
+    help = 'Send notifications to inform admins about taks that errored'
+
+    def handle(self, *args, **options):
+        broken_tasks = CompletedTask\
+            .objects.exclude(last_error='')\
+            .order_by('-run_at')
+
+        for task in broken_tasks:
+            url = reverse(
+                'admin:{}_{}_change'.format(
+                    task._meta.app_label,
+                    task._meta.model_name),
+                args=[task.id])
+            self.stdout.write(
+                'Error in Task {}, see: {} \n'.format(task.task_params, url))


### PR DESCRIPTION
The idea behind this, is to make this a cron job. So in addition to this PR #1394 which makes sure that a task is not restarted after an error, admins would also be notified via email that a task failed. 

Adding better exception handling for sending emails (with a log that displays all the emails that failed) should be added in a separate user story.

