### PR TITLE
css for IE11

### DIFF
--- a/meinberlin/assets/scss/components/_idea_remark.scss
+++ b/meinberlin/assets/scss/components/_idea_remark.scss
@@ -1,6 +1,9 @@
 .idea-remark {
+    width: 600%;
     background-color: $idea-remark-bg;
-    padding: $spacer;
+    padding-top: $spacer;
+    padding-left: $spacer;
+    padding-right: $spacer;
     box-shadow: 0 0 10px 0 $shadow;
     border: none;
 }
@@ -17,6 +20,7 @@
 }
 
 .idea-remark__text textarea {
+    min-height: 8em;
     background-color: $idea-remark-bg;
     font-style: italic;
     color: $black;


### PR DESCRIPTION
Added a width to the box, comparable to the button, fine in chrome, firefox, IE and on responsive, I know you said something about only using min-width? can't work with percentage. Added a min height to text area as Carolin requested it be larger, specially as IE cannot resize.  