### PR TITLE
Configure sentry

### DIFF
--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = (
     'ckeditor_uploader',
     'capture_tag',
     'background_task',
+    'raven.contrib.django.raven_compat',
 
     'adhocracy4.actions.apps.ActionsConfig',
     'adhocracy4.categories.apps.CategoriesConfig',
@@ -155,6 +156,21 @@ TEMPLATES = [
         },
     },
 ]
+
+LOGGING = {
+        'version': 1,
+        'handlers': {
+                'console': {
+                        'class': 'logging.StreamHandler'},
+                'sentry': {
+                        'level': 'ERROR',
+                        'class': 'raven.handlers.logging.SentryHandler',
+                },
+        },
+        'loggers': {'background_task': {
+                'handlers': ['console', 'sentry'],
+                'level': 'INFO'}},
+}
 
 WSGI_APPLICATION = 'meinberlin.config.wsgi.application'
 

--- a/meinberlin/config/settings/dev.py
+++ b/meinberlin/config/settings/dev.py
@@ -31,14 +31,6 @@ try:
 except ImportError:
     pass
 
-LOGGING = {
-        'version': 1,
-        'handlers': {
-                'console': {
-                        'class': 'logging.StreamHandler'},
-        },
-        'loggers': {'background_task': {'handlers': ['console'], 'level': 'INFO'}}}
-
 try:
     INSTALLED_APPS += tuple(ADDITIONAL_APPS)
 except NameError:

--- a/meinberlin/config/settings/production.py
+++ b/meinberlin/config/settings/production.py
@@ -19,3 +19,7 @@ try:
     INSTALLED_APPS += tuple(ADDITIONAL_APPS)
 except NameError:
     pass
+
+# populate settings from RAVEN_CONFIG to LOGGING
+raven_config = locals().get('RAVEN_CONFIG', {})
+LOGGING['handlers']['sentry'].update(raven_config)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,5 +22,6 @@ html5lib==1.0.1
 jsonfield==2.0.2
 python-dateutil==2.7.3
 python-magic==0.4.15
+raven==6.9.0
 rules==1.3
 XlsxWriter==1.0.5


### PR DESCRIPTION
One small behavioral side effect: `python manage.py process_tasks` now makes more output in production.
The local settings then should be something like this:

```
RAVEN_CONFIG = {
    'dsn': 'https://username:password@server.io/something',
    'release': git_commit_hash,
}
```
@treba123 will take care of a self hosted sentry server.
