### PR TITLE
Added container file

### DIFF
--- a/container
+++ b/container
@@ -1,0 +1,40 @@
+#!/usr/bin/env plash-exec
+# plash-exec: exec=/usr/local/bin/entrypoint
+
+--image
+alpine
+
+--layer
+apk
+python3
+make
+nodejs
+git
+libffi-dev
+build-base
+python3-dev
+zlib-dev
+jpeg-dev
+zlib-dev
+freetype-dev
+lcms2-dev
+openjpeg-dev
+tiff-dev
+libxml2-dev
+libxslt-dev
+libmagic
+
+--write-script
+/usr/local/bin/manage.py
+#!/bin/sh
+venv/bin/python manage.py "$@"
+
+--write-script
+/usr/local/bin/entrypoint
+#!/bin/sh
+
+# if no argument, start the shell
+if [ -z "$*" ]; then exec ash; fi
+
+export PATH=$PWD/venv/bin:$PWD/node_modules/.bin:$PATH
+exec /usr/bin/env "$@"


### PR DESCRIPTION
I played a little around with containerization
I am not totally sure if we need this, since we don't get a lot of problems with different development environments, but I will use it privately anyway.

So we have a new file in the root its called `container`, it is executable and all it does is to run stuff inside a container.
so instead of `make install` you would do `./container make install`
instead of `venv/bin/python manage.py shell`, its `./container manage.py shell` (some magic)
calling just `./container` opens up a shell inside our container.

So what are the advantages:
- every developer has exactly the same development environment, less variables for bugs
- less inital setup to run meinberlin for someone new.
- easier setup for local postgres, etc since we only need to set it up inside the container

#### The actual container software being used 
Is something that I am actually still developing :-) :-/ :-D :-\
Support for mac is coming soon (over docker)
So generally support is very good and bad at the same time

How to install
```
pip3 install plash
apt install unionfs-fuse # for unprivileged access
```

**Do you guys see value for the software in this?**

@treba123  may find this interesting

IMPORTANT:
that will only work after `make clean` and you can't mix local and container calls, you have to decide because of saving state in the project directory that classically would go to the os, that is venv and node_modules