### PR TITLE
use browser method scrollIntoView

### DIFF
--- a/meinberlin/apps/plans/assets/plans_map.jsx
+++ b/meinberlin/apps/plans/assets/plans_map.jsx
@@ -354,7 +354,7 @@ class PlansMap extends React.Component {
 
       // scroll list
       if (this.state.selected !== null && this.isInFilter(this.props.items[this.state.selected])) {
-        $(this.listElement).find('.selected').scrollintoview()
+        $(this.listElement).find('.selected')[0].scrollIntoView({ behavior: 'smooth' })
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "file-saver": "1.3.8",
     "@fortawesome/fontawesome-free-webfonts": "1.0.9",
     "immutability-helper": "2.8.1",
-    "jquery.scrollintoview": "1.9.4",
     "leaflet": "1.3.4",
     "leaflet-draw": "1.0.3",
     "leaflet.markercluster": "1.4.1",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -17,7 +17,6 @@ module.exports = {
       '@fortawesome/fontawesome-free-webfonts/scss/fa-regular.scss',
       '@fortawesome/fontawesome-free-webfonts/scss/fa-solid.scss',
       'jquery',
-      'jquery.scrollintoview',
       'js-cookie',
       'react',
       'immutability-helper',


### PR DESCRIPTION
Fixes #1587 

Works fine in firefox and chrome (scrolls smoothly), works in IE and edge, but not smoothly. Not tested in Safari.