### PR TITLE
disable automatic git hash updates by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,9 @@
   "devDependencies": {
     "automerge": true
   },
+  "digest": {
+    "enabled": false
+  },
 
   "labels": [
     "renovate"


### PR DESCRIPTION
As the hash (for A4) also has to be updated in the python requirements, it seems to be a bad idea to do that automatically in the node modules.
This rule also needs to be updated in the other projects if it is working.