### PR TITLE
Ka 2018 10 get bplan point

### DIFF
--- a/meinberlin/apps/bplan/management/commands/bplan_get_location.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_get_location.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
                 features = res_json.get('features')
                 if features:
                     geometry = features[0].get('geometry')
+                    print(geometry)
 
                     if geometry:
                         coordinates = geometry.get('coordinates')

--- a/meinberlin/apps/bplan/management/commands/bplan_get_location.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_get_location.py
@@ -23,12 +23,15 @@ class Command(BaseCommand):
         dis_json = res_json.get('features')
         if dis_json:
             for district in dis_json:
-                dis_dict[district['properties']['pk']] = \
-                    district['properties']['name']
-        print(dis_dict)
 
-        dis_model = AdministrativeDistrict.objects.all()
-        print(dis_model)
+                dis_model = AdministrativeDistrict.objects.filter(
+                    name=district['properties']['name']
+                )
+                if dis_model:
+                    dis_dict[district['properties']['pk']] = \
+                        dis_model[0]
+                else:
+                    dis_dict[district['properties']['pk']] = ''
 
         for bplan in Bplan.objects.all():
             print(bplan.identifier)
@@ -42,12 +45,13 @@ class Command(BaseCommand):
                     res_json = json.loads(res_body.decode("utf-8"))
 
                     features = res_json.get('features')
-                    print(features)
                     if features:
                         district_pk = features[0]['properties']['bezirk']
-                        print(district_pk)
+                        bplan.administrative_district = \
+                            dis_dict[district_pk]
                         bplan.point = features[0]
                         bplan.save()
 
                 except UnicodeEncodeError:
+                    # catches bplan-identifiers with problematic chars
                     pass

--- a/meinberlin/apps/bplan/management/commands/bplan_get_location.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_get_location.py
@@ -1,0 +1,31 @@
+import json
+import urllib.request
+
+from django.core.management.base import BaseCommand
+
+from meinberlin.apps.bplan.models import Bplan
+
+
+class Command(BaseCommand):
+    help = ('Uses the Bplan identifier to get the location '
+            'information from API of bplan-prod.liqd.net')
+
+    def handle(self, *args, **options):
+
+        for bplan in Bplan.objects.all():
+            print(bplan.identifier)
+            if bplan.identifier:
+                url = 'https://bplan-prod.liqd.net/api/bplan/points/' + \
+                    '?bplan={}'.format(bplan.identifier.replace(' ', '%20'))
+                req = urllib.request.Request(url)
+                res = urllib.request.urlopen(req)
+                res_body = res.read()
+                res_json = json.loads(res_body.decode("utf-8"))
+
+                features = res_json.get('features')
+                if features:
+                    geometry = features[0].get('geometry')
+
+                    if geometry:
+                        coordinates = geometry.get('coordinates')
+                        print(coordinates)

--- a/meinberlin/apps/bplan/management/commands/bplan_get_location.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_get_location.py
@@ -3,28 +3,49 @@ import urllib.request
 
 from django.core.management.base import BaseCommand
 
+from adhocracy4.administrative_districts.models import AdministrativeDistrict
 from meinberlin.apps.bplan.models import Bplan
 
 
 class Command(BaseCommand):
-    help = ('Uses the Bplan identifier to get the location '
-            'information from API of bplan-prod.liqd.net')
+    help = ('Uses the Bplan identifier to get the coordinates '
+            'and the district from API of bplan-prod.liqd.net')
 
     def handle(self, *args, **options):
+
+        url_dis = 'https://bplan-prod.liqd.net/api/bezirke/'
+        req = urllib.request.Request(url_dis)
+        res = urllib.request.urlopen(req)
+        res_body = res.read()
+        res_json = json.loads(res_body.decode("utf-8"))
+
+        dis_dict = {}
+        dis_json = res_json.get('features')
+        if dis_json:
+            for district in dis_json:
+                dis_dict[district['properties']['pk']] = \
+                    district['properties']['name']
+        print(dis_dict)
+
+        dis_model = AdministrativeDistrict.objects.all()
+        print(dis_model)
 
         for bplan in Bplan.objects.all():
             print(bplan.identifier)
             if bplan.identifier:
-                url = 'https://bplan-prod.liqd.net/api/bplan/points/' + \
+                url_poi = 'https://bplan-prod.liqd.net/api/bplan/points/' + \
                     '?bplan={}'.format(bplan.identifier.replace(' ', '%20'))
                 try:
-                    req = urllib.request.Request(url)
+                    req = urllib.request.Request(url_poi)
                     res = urllib.request.urlopen(req)
                     res_body = res.read()
                     res_json = json.loads(res_body.decode("utf-8"))
 
                     features = res_json.get('features')
+                    print(features)
                     if features:
+                        district_pk = features[0]['properties']['bezirk']
+                        print(district_pk)
                         bplan.point = features[0]
                         bplan.save()
 

--- a/meinberlin/apps/bplan/management/commands/bplan_get_location.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_get_location.py
@@ -31,10 +31,9 @@ class Command(BaseCommand):
                     dis_dict[district['properties']['pk']] = \
                         dis_model[0]
                 else:
-                    dis_dict[district['properties']['pk']] = ''
+                    dis_dict[district['properties']['pk']] = None
 
         for bplan in Bplan.objects.all():
-            print(bplan.identifier)
             if bplan.identifier:
                 url_poi = 'https://bplan-prod.liqd.net/api/bplan/points/' + \
                     '?bplan={}'.format(bplan.identifier.replace(' ', '%20'))

--- a/meinberlin/apps/bplan/management/commands/bplan_get_location.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_get_location.py
@@ -17,16 +17,16 @@ class Command(BaseCommand):
             if bplan.identifier:
                 url = 'https://bplan-prod.liqd.net/api/bplan/points/' + \
                     '?bplan={}'.format(bplan.identifier.replace(' ', '%20'))
-                req = urllib.request.Request(url)
-                res = urllib.request.urlopen(req)
-                res_body = res.read()
-                res_json = json.loads(res_body.decode("utf-8"))
+                try:
+                    req = urllib.request.Request(url)
+                    res = urllib.request.urlopen(req)
+                    res_body = res.read()
+                    res_json = json.loads(res_body.decode("utf-8"))
 
-                features = res_json.get('features')
-                if features:
-                    geometry = features[0].get('geometry')
-                    print(geometry)
+                    features = res_json.get('features')
+                    if features:
+                        bplan.point = features[0]
+                        bplan.save()
 
-                    if geometry:
-                        coordinates = geometry.get('coordinates')
-                        print(coordinates)
+                except UnicodeEncodeError:
+                    pass

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,6 @@ flake8==3.5.0
 freezegun==0.3.10
 isort==4.3.4
 pytest-cov==2.5.1
-pytest-django==3.4.3
+pytest-django==3.4.2
 pytest-factoryboy==2.0.1
 pytest==3.7.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,6 @@ flake8==3.5.0
 freezegun==0.3.10
 isort==4.3.4
 pytest-cov==2.5.1
-pytest-django==3.4.2
+pytest-django==3.4.3
 pytest-factoryboy==2.0.1
 pytest==3.7.4


### PR DESCRIPTION
This gets the districts and the point info from the bplan api with the identifier, that can now be added to the bplan.
There might be some error handling left to do. I thought of:

- unreachable or wrong URLs. They either thow a HTTPError  `urllib.error.HTTPError: HTTP Error 404: Not Found` or an URLError `urllib.error.URLError: <urlopen error [Errno -2] Name or service not known>`

- wrong identifiers. They just pass without returning a feature and leave the bplans untouched.

- characters that can't be put into a url in the URL (like 'ü'). They would throw an UnicodeEncodeError, which I catch and pass, so that the other bplans will still get their location.

- admin districts, that are on the bplan-map, but not in our database. They get a 'None', so the bplans with that district just don't get one.