### PR TITLE
add the list of projects to the plans map

### DIFF
--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -18,6 +18,7 @@ from meinberlin.apps.contrib.views import CanonicalURLDetailView
 from meinberlin.apps.maps.models import MapPreset
 from meinberlin.apps.plans.forms import PlanForm
 from meinberlin.apps.plans.models import Plan
+from meinberlin.apps.projects.models import Project
 
 from . import models
 
@@ -120,6 +121,37 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
                 'participation_active': active,
                 'participation': item.participation,
                 'participation_display': item.get_participation_display(),
+            })
+
+        projects = Project.objects.all().order_by('created')
+        for item in projects:
+            district_name = str(city_wide)
+            if item.administrative_district:
+                district_name = item.administrative_district.name
+            point_label = ''
+            cost = ''
+            status = 2  # what should happen here?
+            status_display = _('Implementation')  # what should happen here?
+            participation_string = _('Online participation')  # wshh?
+            active = True  # what should happen here?
+            participation = 1  # what should happen here?
+            participation_display = _('Yes')  # what should happen here?
+
+            result.append({
+                'title': item.name,
+                'url': item.get_absolute_url(),
+                'organisation': item.organisation.name,
+                'point': item.point,
+                'point_label': point_label,
+                'cost': cost,
+                'district': district_name,
+                'theme': item.topic,
+                'status': status,
+                'status_display': str(status_display),
+                'participation_string': str(participation_string),
+                'participation_active': active,
+                'participation': participation,
+                'participation_display': str(participation_display),
             })
 
         context['items'] = json.dumps(result)

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -81,6 +81,22 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
             else:
                 return item.get_participation_display(), False
 
+    def _get_participation_status_project(self, project):
+        if project.phases.active_phases():
+            return ugettext('running'), True
+        elif project.phases.future_phases():
+            return (ugettext('starts at {}').format
+                    (project.phases.future_phases().first().start_date.date()),
+                    True)
+        else:
+            return ugettext('done'), False
+
+    def _get_status_project(self, project):
+        if project.phases.active_phases() or project.phases.future_phases():
+            return 2, ugettext('Implementation')
+        else:
+            return 3, ugettext('Done')
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
@@ -130,12 +146,12 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
                 district_name = item.administrative_district.name
             point_label = ''
             cost = ''
-            status = 2  # what should happen here?
-            status_display = _('Implementation')  # what should happen here?
-            participation_string = _('Online participation')  # wshh?
-            active = True  # what should happen here?
-            participation = 1  # what should happen here?
-            participation_display = _('Yes')  # what should happen here?
+            participation_string, active = \
+                self._get_participation_status_project(item)
+            status, status_display = \
+                self._get_status_project(item)
+            participation = 1
+            participation_display = _('Yes')
 
             result.append({
                 'title': item.name,

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -139,36 +139,39 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
                 'participation_display': item.get_participation_display(),
             })
 
-        projects = Project.objects.all().order_by('created')
+        projects = Project.objects.all()\
+            .filter(is_draft=False, is_archived=False)\
+            .order_by('created')
         for item in projects:
-            district_name = str(city_wide)
-            if item.administrative_district:
-                district_name = item.administrative_district.name
-            point_label = ''
-            cost = ''
-            participation_string, active = \
-                self._get_participation_status_project(item)
-            status, status_display = \
-                self._get_status_project(item)
-            participation = 1
-            participation_display = _('Yes')
+            if self.request.user.has_perm('a4projects.view_project', item):
+                district_name = str(city_wide)
+                if item.administrative_district:
+                    district_name = item.administrative_district.name
+                point_label = ''
+                cost = ''
+                participation_string, active = \
+                    self._get_participation_status_project(item)
+                status, status_display = \
+                    self._get_status_project(item)
+                participation = 1
+                participation_display = _('Yes')
 
-            result.append({
-                'title': item.name,
-                'url': item.get_absolute_url(),
-                'organisation': item.organisation.name,
-                'point': item.point,
-                'point_label': point_label,
-                'cost': cost,
-                'district': district_name,
-                'theme': item.topic,
-                'status': status,
-                'status_display': str(status_display),
-                'participation_string': str(participation_string),
-                'participation_active': active,
-                'participation': participation,
-                'participation_display': str(participation_display),
-            })
+                result.append({
+                    'title': item.name,
+                    'url': item.get_absolute_url(),
+                    'organisation': item.organisation.name,
+                    'point': item.point,
+                    'point_label': point_label,
+                    'cost': cost,
+                    'district': district_name,
+                    'theme': item.topic,
+                    'status': status,
+                    'status_display': str(status_display),
+                    'participation_string': str(participation_string),
+                    'participation_active': active,
+                    'participation': participation,
+                    'participation_display': str(participation_display),
+                })
 
         context['items'] = json.dumps(result)
         context['baseurl'] = settings.A4_MAP_BASEURL


### PR DESCRIPTION
currently only works when all projects have a point. 

- [ ] plans_map.jsx needs to be changed to make it work if project doesn't have point

- [x] stati and participation need to get rules that fit with the later to be implemented filters/should work with the filters we keep

- [ ] gesamtstädtisch/city-wide needs to be added for pland and projects. Should both not have a point in this case? Or do we still force the plans to always have one? Or is this not related and gesamtstätdisch works like any district with or withour point?