### PR TITLE
fix external projects on participation list

### DIFF
--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -85,9 +85,14 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
         if project.phases.active_phases():
             return ugettext('running'), True
         elif project.phases.future_phases():
-            return (ugettext('starts at {}').format
-                    (project.phases.future_phases().first().start_date.date()),
-                    True)
+            try:
+                return (ugettext('starts at {}').format
+                        (project.phases.future_phases().first().
+                         start_date.date()),
+                        True)
+            except AttributeError:
+                return (ugettext('starts in the future'),
+                        True)
         else:
             return ugettext('done'), False
 

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -160,12 +160,15 @@ class PlanListView(rules_mixins.PermissionRequiredMixin,
                     self._get_status_project(item)
                 participation = 1
                 participation_display = _('Yes')
+                point = item.point
+                if point == '""':
+                    point = ''
 
                 result.append({
                     'title': item.name,
                     'url': item.get_absolute_url(),
                     'organisation': item.organisation.name,
-                    'point': item.point,
+                    'point': point,
                     'point_label': point_label,
                     'cost': cost,
                     'district': district_name,


### PR DESCRIPTION
It finds the future phases that do not yet have a date.

But it still needs to work with the very strange escaped empty string in the point field, that gets saved when an external project is added via the django admin