### PR TITLE
revert updating mapbox-gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "leaflet": "1.3.4",
     "leaflet-draw": "1.0.4",
     "leaflet.markercluster": "1.4.1",
-    "mapbox-gl": "0.50.0",
+    "mapbox-gl": "0.35.1",
     "mapbox-gl-leaflet": "0.0.3",
     "mini-css-extract-plugin": "0.4.4",
     "node-sass": "4.9.4",


### PR DESCRIPTION
The [mapbox-gl update](https://github.com/liqd/a4-meinberlin/commit/d8e3b03d1a20db88ee366a836a13ff2acdf5cd36) gave us strange linting errors for all the jsx-files. Downdating fixes it. Should be investigated further.