### PR TITLE
dev.py: enable console logging and silence csp

### DIFF
--- a/meinberlin/config/settings/dev.py
+++ b/meinberlin/config/settings/dev.py
@@ -2,7 +2,6 @@ from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-CSP_REPORT_ONLY = True
 
 for template_engine in TEMPLATES:
     template_engine['OPTIONS']['debug'] = True
@@ -38,9 +37,22 @@ LOGGING = {
                 'console': {
                         'class': 'logging.StreamHandler'},
         },
-        'loggers': {'background_task': {'handlers': ['console'], 'level': 'INFO'}}}
+        'loggers': {
+                'django': {
+                        'handlers': ['console'],
+                        'level': 'INFO'
+                },
+                'background_task': {
+                        'handlers': ['console'],
+                        'level': 'INFO'
+                }
+        }
+}
 
 try:
     INSTALLED_APPS += tuple(ADDITIONAL_APPS)
 except NameError:
     pass
+
+CSP_REPORT_ONLY = True
+CSP_DEFAULT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'data:', 'blob:', '*']


### PR DESCRIPTION
This gives me better output in the terminal and silences csp warnings in dev mode.