### PR TITLE
Revert "Update dependency autoprefixer to v9.4.6"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "5.6.3",
     "acorn": "6.0.5",
     "adhocracy4": "liqd/adhocracy4#b1c4dad173f690e1d83b2ae5dec94e1c405ef567",
-    "autoprefixer": "9.4.6",
+    "autoprefixer": "9.4.5",
     "babel-core": "6.26.3",
     "babel-loader": "7.1.5",
     "babel-preset-env": "1.7.0",


### PR DESCRIPTION
Reverts liqd/a4-meinberlin#1828