### PR TITLE
restructure mobile btn group to be radio btns for a11y

### DIFF
--- a/meinberlin/apps/plans/assets/MapListSwitch.jsx
+++ b/meinberlin/apps/plans/assets/MapListSwitch.jsx
@@ -25,15 +25,15 @@ class MapListSwitch extends React.Component {
       return (
         <div>
           <div className="u-spacer-left u-spacer-right">
-            <div className="switch-group" role="group" aria-label={django.gettext('Map list switch')}>
-              <div className="radio-group">
-                <label className={!this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showList} htmlFor="show_list">
-                  <input className="radio__input" type="radio" value="list" id="show_list" /> <i className="fa fa-list" />
-                </label>
-                <label className={this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showMap} htmlFor="show_map">
-                  <input className="radio__input" type="radio" value="map" id="show_map" /> <i className="fa fa-map" />
-                </label>
-              </div>
+            <div className="radio-group" role="group">
+              <label className={!this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showList} htmlFor="show_list">
+                <span className="sr-only">{django.gettext('Show List')}</span>
+                <input className="radio__input" type="radio" value="list" id="show_list" /> <i className="fa fa-list" />
+              </label>
+              <label className={this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showMap} htmlFor="show_map">
+                <span className="sr-only">{django.gettext('Show Map')}</span>
+                <input className="radio__input" type="radio" value="map" id="show_map" /> <i className="fa fa-map" />
+              </label>
             </div>
           </div>
         </div>

--- a/meinberlin/apps/plans/assets/MapListSwitch.jsx
+++ b/meinberlin/apps/plans/assets/MapListSwitch.jsx
@@ -26,9 +26,13 @@ class MapListSwitch extends React.Component {
         <div>
           <div className="u-spacer-left u-spacer-right">
             <div className="switch-group" role="group" aria-label={django.gettext('Map list switch')}>
-              <div className="btn-group">
-                <button className={!this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showList}><i className="fa fa-list" /></button>
-                <button className={this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showMap}><i className="fa fa-map" /></button>
+              <div className="radio-group">
+                <label className={!this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showList} htmlFor="show_list">
+                  <input className="radio__input" type="radio" value="list" id="show_list" /> <i className="fa fa-list" />
+                </label>
+                <label className={this.props.displayMap ? 'btn btn--light switch--btn active' : 'btn btn--light switch--btn'} onClick={this.props.showMap} htmlFor="show_map">
+                  <input className="radio__input" type="radio" value="map" id="show_map" /> <i className="fa fa-map" />
+                </label>
               </div>
             </div>
           </div>

--- a/meinberlin/assets/scss/components/_blocks.scss
+++ b/meinberlin/assets/scss/components/_blocks.scss
@@ -76,6 +76,12 @@
     }
 }
 
+.accordion__body .rich-text {
+    p, {
+        text-align: left;
+    }
+}
+
 .block--infographic {
     background-color: $brand-secondary;
     color: $body-bg;

--- a/meinberlin/assets/scss/components/_radio.scss
+++ b/meinberlin/assets/scss/components/_radio.scss
@@ -70,3 +70,10 @@ $checkbox-size: 20px;
         cursor: not-allowed;
     }
 }
+
+.radio-group {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    margin-bottom: $spacer;
+}


### PR DESCRIPTION
is it ok to leave the btn class names as we want them to look like that? 
Also added tiny fix quick to accordions which I think I broke with map teaser styling