### PR TITLE
dashboard: add topics and plans to external projects

### DIFF
--- a/meinberlin/apps/bplan/forms.py
+++ b/meinberlin/apps/bplan/forms.py
@@ -25,6 +25,7 @@ class BplanProjectForm(ExternalProjectForm):
     class Meta:
         model = models.Bplan
         fields = ['name', 'identifier', 'url', 'description', 'tile_image',
-                  'tile_image_copyright', 'is_archived', 'office_worker_email']
+                  'tile_image_copyright', 'is_archived', 'office_worker_email',
+                  'topics']
         required_for_project_publish = ['name', 'url', 'description',
-                                        'office_worker_email']
+                                        'office_worker_email', 'topics']

--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/includes/bplan_project_form.html
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/includes/bplan_project_form.html
@@ -16,6 +16,8 @@
 
 {% include 'a4dashboard/includes/form_field.html' with field=form.office_worker_email %}
 
+{% include 'meinberlin_contrib/includes/form_field.html' with field=form.topics %}
+
 {% include 'meinberlin_embed/includes/project_embed_code.html' with project=view.object %}
 
 {% if project.has_finished %}

--- a/tests/bplan/dashboard_components/test_views_project_bplan.py
+++ b/tests/bplan/dashboard_components/test_views_project_bplan.py
@@ -33,6 +33,7 @@ def test_edit_view(client, phase_factory, bplan, module_factory):
         'start_date_1': '18:00',
         'end_date_0': '2013-01-10',
         'end_date_1': '18:00',
+        'topics': 'BUI'
 
     }
     response = client.post(url, data)


### PR DESCRIPTION
Ok, I am already spending much too much time on this. I tried to add the same tabs for topics and location (and plans) to the external projects as in the projects. But I couldn't get it to work. Now I added the topics to the main settings tab of the bplans. The same didn't work for the point for external projects. Even though I also added the right widget to the external-project form, it only looked right and didn't work (existing points were not shown).
This was part of #1933, but I made a new issue to solve later: #1967