### PR TITLE
Mn 2019 02 test serializers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,10 @@ from adhocracy4.test import helpers
 from adhocracy4.test.factories.maps import AreaSettingsFactory
 from meinberlin.test import factories
 from meinberlin.test.factories.activities import ActivityFactory
+from meinberlin.test.factories.bplan import BplanFactory
+from meinberlin.test.factories.extprojects import ExternalProjectFactory
 from meinberlin.test.factories.organisations import OrganisationFactory
+from meinberlin.test.factories.projectcontainers import ProjectContainerFactory
 
 
 def pytest_configure(config):
@@ -37,8 +40,12 @@ register(factories.RatingFactory)
 register(factories.ModeratorStatementFactory)
 register(factories.CategoryFactory)
 register(ActivityFactory)
+register(ProjectContainerFactory)
+register(ExternalProjectFactory)
+register(BplanFactory)
 
 register(a4_factories.ProjectFactory)
+register(a4_factories.PhaseFactory)
 register(a4_factories.ModuleFactory)
 register(AreaSettingsFactory)
 

--- a/tests/plans/conftest.py
+++ b/tests/plans/conftest.py
@@ -1,9 +1,11 @@
 from pytest_factoryboy import register
 
 from adhocracy4.test.factories import AdministrativeDistrictFactory
+from adhocracy4.test.factories import PhaseFactory
 from adhocracy4.test.factories import ProjectFactory
 from meinberlin.test.factories import plans as plan_factories
 
 register(ProjectFactory)
+register(PhaseFactory)
 register(AdministrativeDistrictFactory)
 register(plan_factories.PlanFactory)

--- a/tests/plans/test_serializer.py
+++ b/tests/plans/test_serializer.py
@@ -1,0 +1,95 @@
+import pytest
+from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
+from freezegun import freeze_time
+
+from meinberlin.apps.plans.models import Plan
+from meinberlin.apps.plans.serializers import PlanSerializer
+
+
+@pytest.mark.django_db
+def test_serializer(client, plan_factory, project_factory, phase_factory):
+
+    project1 = project_factory()
+    project2 = project_factory()
+    project3 = project_factory(is_draft=True)
+    project4 = project_factory()
+    project5 = project_factory()
+
+    now = timezone.now()
+    yesterday = now - timezone.timedelta(days=1)
+    next_week = now - timezone.timedelta(days=7)
+    tomorrow = now + timezone.timedelta(days=1)
+    last_week = now - timezone.timedelta(days=7)
+
+    phase_factory(
+        start_date=yesterday,
+        end_date=tomorrow,
+        module__project=project1,
+    )
+
+    phase_factory(
+        start_date=tomorrow,
+        end_date=next_week,
+        module__project=project2,
+    )
+
+    phase_factory(
+        start_date=yesterday,
+        end_date=tomorrow,
+        module__project=project4,
+    )
+
+    phase_factory(
+        start_date=tomorrow,
+        end_date=next_week,
+        module__project=project4,
+    )
+
+    phase_factory(
+        start_date=last_week,
+        end_date=yesterday,
+        module__project=project5,
+    )
+
+    with freeze_time(now):
+        plan_factory.create(projects=[project1])
+        plan_factory.create(projects=[project2])
+        plan_factory.create(projects=[project3])
+        plan_factory.create(projects=[project4])
+        plan_factory.create(projects=[project5])
+
+        plans = Plan.objects.all()
+
+        plan_serializer = PlanSerializer(plans, many=True)
+        plan_data = plan_serializer.data
+        assert len(plan_data) == 5
+
+        assert plan_data[0]['type'] == 'plan'
+        assert plan_data[1]['type'] == 'plan'
+        assert plan_data[2]['type'] == 'plan'
+        assert plan_data[3]['type'] == 'plan'
+        assert plan_data[4]['type'] == 'plan'
+
+        assert plan_data[0]['published_projects_count'] == 1
+        assert plan_data[1]['published_projects_count'] == 1
+        assert plan_data[2]['published_projects_count'] == 0
+        assert plan_data[3]['published_projects_count'] == 1
+        assert plan_data[4]['published_projects_count'] == 1
+
+        assert plan_data[0]['participation_string'] == \
+            _('running')
+        assert plan_data[1]['participation_string'] == \
+            _('starts at {}').format(tomorrow.strftime('%d.%m.%Y'))
+        assert plan_data[2]['participation_string'] == \
+            Plan.PARTICIPATION_CHOICES[2][1]
+        assert plan_data[3]['participation_string'] == \
+            _('running')
+        assert plan_data[4]['participation_string'] == \
+            Plan.PARTICIPATION_CHOICES[2][1]
+
+        assert plan_data[0]['participation_active']
+        assert plan_data[1]['participation_active']
+        assert not plan_data[2]['participation_active']
+        assert plan_data[3]['participation_active']
+        assert not plan_data[4]['participation_active']

--- a/tests/projects/test_serializer.py
+++ b/tests/projects/test_serializer.py
@@ -1,0 +1,137 @@
+import pytest
+from dateutil.parser import parse
+from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
+from freezegun import freeze_time
+
+from adhocracy4.projects.models import Project
+from meinberlin.apps.projects.serializers import ProjectSerializer
+
+
+@pytest.mark.django_db
+def test_project_serializer(client, project_factory,
+                            project_container_factory,
+                            external_project_factory,
+                            bplan_factory,
+                            phase_factory):
+
+    project_active = project_factory(name='active')
+    project_future = project_factory(name='future')
+    project_active_and_future = project_factory(name='active and future')
+    project_past = project_factory(name='past')
+    project_container_factory()
+    external_project_factory()
+    bplan_factory()
+
+    now = parse('2013-01-01 18:00:00 UTC')
+    yesterday = now - timezone.timedelta(days=1)
+    last_week = now - timezone.timedelta(days=7)
+    tomorrow = now + timezone.timedelta(days=1)
+    next_week = now + timezone.timedelta(days=7)
+
+    # active phase
+    phase_factory(
+        start_date=last_week,
+        end_date=next_week,
+        module__project=project_active,
+    )
+
+    # future phase
+    phase_factory(
+        start_date=tomorrow,
+        end_date=next_week,
+        module__project=project_future,
+    )
+
+    # active phase
+    phase_factory(
+        start_date=yesterday,
+        end_date=tomorrow,
+        module__project=project_active_and_future,
+    )
+
+    # future_phase
+    phase_factory(
+        start_date=tomorrow,
+        end_date=next_week,
+        module__project=project_active_and_future,
+    )
+
+    # past phase
+    phase_factory(
+        start_date=last_week,
+        end_date=yesterday,
+        module__project=project_past,
+    )
+
+    with freeze_time(now):
+
+        projects = Project.objects.all().order_by('created')
+
+        project_serializer = ProjectSerializer(projects, many=True, now=now)
+        project_data = project_serializer.data
+        assert len(project_data) == 8
+
+        assert project_data[0]['type'] == 'project'
+        assert project_data[1]['type'] == 'project'
+        assert project_data[2]['type'] == 'project'
+        assert project_data[3]['type'] == 'project'
+        assert project_data[4]['type'] == 'project'
+        assert project_data[5]['type'] == 'project'
+        assert project_data[6]['type'] == 'project'
+        assert project_data[7]['type'] == 'project'
+
+        assert project_data[0]['subtype'] == 'default'
+        assert project_data[1]['subtype'] == 'default'
+        assert project_data[2]['subtype'] == 'default'
+        assert project_data[3]['subtype'] == 'default'
+        assert project_data[4]['subtype'] == 'container'
+        assert project_data[5]['subtype'] == 'default'
+        assert project_data[6]['subtype'] == 'external'
+        assert project_data[7]['subtype'] == 'external'
+
+        assert project_data[0]['title'] == 'active'
+        assert project_data[1]['title'] == 'future'
+        assert project_data[2]['title'] == 'active and future'
+        assert project_data[3]['title'] == 'past'
+
+        assert project_data[0]['participation_string'] == \
+            _('running')
+        assert project_data[1]['participation_string'] == \
+            _('starts at {}').format(tomorrow.strftime('%d.%m.%Y'))
+        assert project_data[2]['participation_string'] == \
+            _('running')
+        assert project_data[3]['participation_string'] == \
+            _('done')
+
+        assert project_data[0]['active_phase'][0] == 50
+        assert '7' in project_data[0]['active_phase'][1]
+        assert project_data[0]['active_phase'][2] == str(next_week)
+        assert not project_data[1]['active_phase']
+        assert project_data[2]['active_phase'][0] == 50
+        assert '1' in project_data[2]['active_phase'][1]
+        assert project_data[2]['active_phase'][2] == str(tomorrow)
+        assert not project_data[3]['active_phase']
+        assert not project_data[4]['active_phase']
+        assert not project_data[5]['active_phase']
+
+        assert not project_data[0]['future_phase']
+        assert project_data[1]['future_phase'] == str(tomorrow.date())
+        assert project_data[2]['future_phase'] == str(tomorrow.date())
+        assert not project_data[3]['future_phase']
+        assert not project_data[4]['future_phase']
+        assert not project_data[5]['future_phase']
+
+        assert not project_data[0]['past_phase']
+        assert not project_data[1]['past_phase']
+        assert not project_data[2]['past_phase']
+        assert project_data[3]['past_phase'] == str(yesterday.date())
+        assert not project_data[4]['past_phase']
+        assert not project_data[5]['past_phase']
+
+        assert project_data[0]['participation_active']
+        assert project_data[1]['participation_active']
+        assert project_data[2]['participation_active']
+        assert not project_data[3]['participation_active']
+        assert not project_data[4]['participation_active']
+        assert not project_data[5]['participation_active']


### PR DESCRIPTION
while writing the tests I noticed that the participation_string method in plan serializer behaves a bit strange when there are no projects and when the projects are over: it will always return the the participation field value of the plan.