### PR TITLE
send account-emails to right address

### DIFF
--- a/meinberlin/apps/users/adapters.py
+++ b/meinberlin/apps/users/adapters.py
@@ -40,9 +40,8 @@ class AccountAdapter(DefaultAccountAdapter):
             return url
 
     def send_mail(self, template_prefix, email, context):
-        user = context['user']
         return UserAccountEmail.send(
-            user,
+            email,
             template_name=template_prefix,
             **context
         )


### PR DESCRIPTION
fixes #2168 and hopefully doesn't destroy anything else. I think, I checked all account-emails: register and password-reset still go to the right addresses!