### PR TITLE
apps: Stop using 'date()'

### DIFF
--- a/meinberlin/apps/plans/models.py
+++ b/meinberlin/apps/plans/models.py
@@ -136,7 +136,7 @@ class Plan(UserGeneratedContentModel):
         if future_phases_with_start_date:
             future_phase = future_phases_with_start_date.first()
             return _('starts at {}')\
-                .format(future_phase.start_date.date().strftime('%d.%m.%Y'))
+                .format(future_phase.start_date.strftime('%d.%m.%Y'))
 
     def __str__(self):
         return self.title

--- a/meinberlin/apps/projects/serializers.py
+++ b/meinberlin/apps/projects/serializers.py
@@ -97,7 +97,7 @@ class ProjectSerializer(serializers.ModelSerializer, CommonFields):
                 try:
                     return (_('starts at {}').format
                             (project_phases.future_phases().first().
-                             start_date.date().strftime('%d.%m.%Y')),
+                             start_date.strftime('%d.%m.%Y')),
                             True)
                 except AttributeError as e:
                     print(e)
@@ -157,7 +157,7 @@ class ProjectSerializer(serializers.ModelSerializer, CommonFields):
         if (instance.future_phases and
                 instance.future_phases.first().start_date):
             return str(
-                instance.future_phases.first().start_date.date())
+                instance.future_phases.first().start_date)
         return False
 
     def get_active_phase(self, instance):
@@ -173,7 +173,7 @@ class ProjectSerializer(serializers.ModelSerializer, CommonFields):
         if (project_phases.past_phases() and
                 project_phases.past_phases().first().end_date):
             return str(
-                project_phases.past_phases().first().end_date.date())
+                project_phases.past_phases().first().end_date)
         return False
 
     def get_participation_string(self, instance):
@@ -283,7 +283,7 @@ class FutureProjectSerializer(ProjectSerializer):
         future_phase = self._future_phases\
             .filter(module__project=instance)\
             .first()
-        return str(future_phase.start_date.date())
+        return str(future_phase.start_date)
 
     def get_past_phase(self, instance):
         return False
@@ -314,7 +314,7 @@ class PastProjectSerializer(ProjectSerializer):
 
     def get_past_phase(self, instance):
         past_phase = self._past_phases.filter(module__project=instance).first()
-        return str(past_phase.end_date.date())
+        return str(past_phase.end_date)
 
     def get_participation_string(self, instance):
         return _('done')

--- a/tests/projects/test_serializer.py
+++ b/tests/projects/test_serializer.py
@@ -116,8 +116,8 @@ def test_project_serializer(client, project_factory,
         assert not project_data[5]['active_phase']
 
         assert not project_data[0]['future_phase']
-        assert project_data[1]['future_phase'] == str(tomorrow.date())
-        assert project_data[2]['future_phase'] == str(tomorrow.date())
+        assert project_data[1]['future_phase'] == str(tomorrow)
+        assert project_data[2]['future_phase'] == str(tomorrow)
         assert not project_data[3]['future_phase']
         assert not project_data[4]['future_phase']
         assert not project_data[5]['future_phase']
@@ -125,7 +125,7 @@ def test_project_serializer(client, project_factory,
         assert not project_data[0]['past_phase']
         assert not project_data[1]['past_phase']
         assert not project_data[2]['past_phase']
-        assert project_data[3]['past_phase'] == str(yesterday.date())
+        assert project_data[3]['past_phase'] == str(yesterday)
         assert not project_data[4]['past_phase']
         assert not project_data[5]['past_phase']
 


### PR DESCRIPTION
From the commit message:
```
The 'date()' function is not timezone aware, giving us the UTC date
rather than the date of the current timezone. Projects that start
at 0:00 CET will therefore counted as 22:00 of the previous day,
leading to a wrong date.
```