### PR TITLE
webpack: Remove the 'browsers' argument from autoprefixer

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -101,8 +101,8 @@ module.exports = {
             loader: 'postcss-loader',
             options: {
               ident: 'postcss',
-              plugins: (loader) => [
-                autoprefixer({ browsers: ['last 3 versions', 'ie >= 11'] })
+              plugins: [
+                require('autoprefixer')
               ]
             }
           },


### PR DESCRIPTION
The same list is already set in `packages.json` and the new version
of autoprefixer throws a warning about that.