### PR TITLE
apps/users: Add new required argument allowed_hosts to is_safe_url

### DIFF
--- a/meinberlin/apps/users/adapters.py
+++ b/meinberlin/apps/users/adapters.py
@@ -34,7 +34,8 @@ class AccountAdapter(DefaultAccountAdapter):
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         url = super().get_email_confirmation_url(request, emailconfirmation)
-        if 'next' in request.POST and is_safe_url(request.POST['next']):
+        if 'next' in request.POST and is_safe_url(request.POST['next'],
+                                                  allowed_hosts=None):
             return '{}?next={}'.format(url, quote(request.POST['next']))
         else:
             return url


### PR DESCRIPTION
This was made a requirement in django 2.1. Passing 'None' means we must
stay on our site, which is what currently always do.

Fixes https://github.com/liqd/a4-meinberlin/issues/2276