### PR TITLE
project module tile: adding template for module styles

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/component_library.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/component_library.html
@@ -1367,7 +1367,7 @@
                         <div class="list-container map-list-combined__list">
                             <div>
                                 <ul class="u-list-reset maplist-list">
-                                    <li class="maplist-item__horizontal" key=>
+                                    <li class="participation-tile__horizontal" key=>
                                         <a href="" >
                                             <div class="maplist-item__proj">
                                                 <div class="maplist-item__content">
@@ -1402,7 +1402,7 @@
                         <div class="list-container map-list-combined__list">
                             <div>
                                 <ul class="u-list-reset maplist-list">
-                                    <li class="maplist-item__vertical" key=>
+                                    <li class="participation-tile__vertical" key=>
                                         <a href="">
                                             <div class="maplist-item__proj">
                                                 <div class="maplist-item__img" style="background-image: url(/static/images/cl-brainstorming.svg); background-position: center; background-repeat: no-repeat;" alt="">
@@ -1427,7 +1427,7 @@
                                             </div>
                                         </a>
                                     </li>
-                                    <li class="maplist-item__vertical" key=>
+                                    <li class="participation-tile__vertical" key=>
                                         <a href="">
                                             <div class="maplist-item__proj">
                                                 <div class="maplist-item__img" style="background-image: url(/static/images/cl-brainstorming.svg); background-position: center; background-repeat: no-repeat;" alt="">
@@ -1449,7 +1449,7 @@
                                             </div>
                                         </a>
                                     </li>
-                                    <li class="maplist-item__vertical" key=>
+                                    <li class="participation-tile__vertical" key=>
                                         <a href="">
                                             <div class="maplist-item__plan">
                                                 <span class="maplist-item__roofline">District</span>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/component_library.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/component_library.html
@@ -140,6 +140,9 @@
                             <a href="#cl-multiform" class="dashboard-nav__item dashboard-nav__item--interactive">Multiform</a>
                         </li>
                         <li class="dashboard-nav__page">
+                            <a href="#cl-participation-tile" class="dashboard-nav__item dashboard-nav__item--interactive">Participation Tile</a>
+                        </li>
+                        <li class="dashboard-nav__page">
                             <a href="#cl-pagination" class="dashboard-nav__item dashboard-nav__item--interactive">Pagination</a>
                         </li>
                         <li class="dashboard-nav__page">
@@ -1366,11 +1369,11 @@
                     <div class="map-list-combined">
                         <div class="list-container map-list-combined__list">
                             <div>
-                                <ul class="u-list-reset maplist-list">
+                                <ul class="u-list-reset participation-tile__list">
                                     <li class="participation-tile__horizontal" key=>
                                         <a href="" >
-                                            <div class="maplist-item__proj">
-                                                <div class="maplist-item__content">
+                                            <div class="participation-tile__body maplist-item__proj">
+                                                <div class="participation-tile__content">
                                                     <div class="maplist-item__label-spacer">
                                                         <span key="" class="label label--secondary maplist-item__label u-spacer-bottom">Topic</span>
                                                     </div>
@@ -1381,7 +1384,7 @@
                                                     </div>
                                                     <div class="maplist-item__link"></div>
                                                     <div class="status-item status__future">
-                                                        <span class="maplist-item__status"><i class="fas fa-clock" aria-hidden="true"></i>Participation: from 10/04/2019</span>
+                                                        <span class="participation-tile__status"><i class="fas fa-clock" aria-hidden="true"></i>Participation: from 10/04/2019</span>
                                                     </div>
                                                 </div>
                                                 <div class="status-item_spacer"></div>
@@ -1396,22 +1399,24 @@
                 </div>
 
                 <h2 id="cl-maplist-item-vertical">Map List Item Vertical</h2>
+                <note>
 
                 <div class="cl-example">
+                    <p>Note: size of container means tiles are shown as thinner than when in container that reflects size of screen.</p>
                     <div class="map-list-combined">
                         <div class="list-container map-list-combined__list">
                             <div>
-                                <ul class="u-list-reset maplist-list">
+                                <ul class="u-list-reset participation-tile__list">
                                     <li class="participation-tile__vertical" key=>
                                         <a href="">
-                                            <div class="maplist-item__proj">
+                                            <div class="participation-tile__body maplist-item__proj">
                                                 <div class="maplist-item__img" style="background-image: url(/static/images/cl-brainstorming.svg); background-position: center; background-repeat: no-repeat;" alt="">
                                                     <div class="maplist-item__label-img">
                                                         <span key="" class="label label--secondary maplist-item__label u-spacer-bottom">Topic</span>
                                                     </div>
                                                     <span class="maplist-item__img-copyright copyright">© Copyright</span>
                                                 </div>
-                                                <div class="maplist-item__content">
+                                                <div class="participation-tile__content">
                                                     <span class="maplist-item__roofline">District</span>
                                                     <h3 class="maplist-item__title">Title of the project - still active</h3>
                                                     <div class="maplist-item__description">
@@ -1420,7 +1425,7 @@
                                                     <div class="maplist-item__link"></div>
                                                     <div class="status-item status__active">
                                                         <div class="status-bar__active"><span class="status-bar__active-fill" style="width: 20%;"></span></div>
-                                                        <span class="maplist-item__status"><i class="fas fa-clock" aria-hidden="true"></i>remaining 5 days</span>
+                                                        <span class="participation-tile__status"><i class="fas fa-clock" aria-hidden="true"></i>remaining 5 days</span>
                                                     </div>
                                                 </div>
                                                 <div class="status-item_spacer"></div>
@@ -1429,14 +1434,14 @@
                                     </li>
                                     <li class="participation-tile__vertical" key=>
                                         <a href="">
-                                            <div class="maplist-item__proj">
+                                            <div class="participation-tile__body maplist-item__proj">
                                                 <div class="maplist-item__img" style="background-image: url(/static/images/cl-brainstorming.svg); background-position: center; background-repeat: no-repeat;" alt="">
                                                     <div class="maplist-item__label-img">
                                                         <span key="" class="label label--secondary maplist-item__label u-spacer-bottom">Topic</span>
                                                     </div>
                                                     <span class="maplist-item__img-copyright copyright">© Copyright</span>
                                                 </div>
-                                                <div class="maplist-item__content">
+                                                <div class="participation-tile__content">
                                                     <span class="maplist-item__roofline">District</span>
                                                     <h3 class="maplist-item__title">Title of the project - ended</h3>
                                                     <div class="maplist-item__description">
@@ -1451,16 +1456,16 @@
                                     </li>
                                     <li class="participation-tile__vertical" key=>
                                         <a href="">
-                                            <div class="maplist-item__plan">
+                                            <div class="participation-tile__body maplist-item__plan">
                                                 <span class="maplist-item__roofline">District</span>
                                                 <h3 class="maplist-item__title">Title of the plan</h3>
                                                 <div class="maplist-item__link"></div>
                                                 <div class="maplist-item__stats">
-                                                    <span class="maplist-item__proj-count"><i class="fas fa-th" aria-hidden="true"></i>Participation projects: </span>
+                                                    <span class="participation-tile__proj-count"><i class="fas fa-th" aria-hidden="true"></i>Participation projects: </span>
                                                     <span>4</span>
                                                     <br />
-                                                    <span class="maplist-item__status"><i class="fas fa-clock" aria-hidden="true"></i>Status: </span>
-                                                    <span class="maplist-item__status-active">running</span>
+                                                    <span class="participation-tile__status"><i class="fas fa-clock" aria-hidden="true"></i>Status: </span>
+                                                    <span class="participation-tile__status-active">running</span>
                                                 </div>
                                                 <div class="status-item_spacer"></div>
                                             </div>
@@ -1549,6 +1554,72 @@
                             </li>
                         </ul>
                     </nav>
+                </div>
+
+
+                <h2 id="cl-participation-tile">Participation Tile</h2>
+
+                <div class="cl-example">
+                    <p>Note: basis for the <a href="#cl-maplist-item-vertical">maplist tile/item</a></p>
+                    <div class="participation-tile__wrapper">
+                        <div class="participation-tile__list-container">
+                            <ul class="u-list-reset participation-tile__list">
+                                <li class="participation-tile__vertical">
+                                    <div class="participation-tile__type">
+                                        <div class="participation-tile__content">
+                                            <h3 class="participation-tile__title">Project name</h3>
+                                            <div class="status-item status__active">
+                                                <div class="status-bar__active">
+                                                    <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
+                                                </div>
+                                                <span class="participation-tile__status">
+                                                    <i class="fas fa-clock" aria-hidden="true"></i>
+                                                remaining 28 days
+                                                </span>
+                                            </div>
+                                            <div class="participation-tile__spacer"></div>
+                                            <div class="participation-tile__btn">
+                                                <a class="btn btn--full btn--small" href="">Join now</a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li class="participation-tile__vertical">
+                                    <a href="" target="">
+                                        <div class="participation-tile__type">
+                                            <div class="participation-tile__content">
+                                                <h3 class="participation-tile__title">Project name</h3>
+                                                <div class="status-item status__future">
+                                                    <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>Participation: starts on 12.04.2019
+                                                    </span>
+                                                </div>
+                                                <div class="participation-tile__spacer"></div>
+                                                <div class="participation-tile__btn">
+                                                    <a class="btn btn--full btn--small" href="">Join now</a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </a>
+                                </li>
+                                <li class="participation-tile__vertical">
+                                    <a href="" target="">
+                                        <div class="participation-tile__type">
+                                            <div class="participation-tile__content">
+                                                <h3 class="participation-tile__title">Project name</h3>
+                                                <div class="status-item status-bar__past status-bar__past--sm">
+                                                    <span class="participation-tile__status">Participation ended. Read result</span>
+                                                </div>
+                                                <div class="participation-tile__spacer"></div>
+                                                <div class="participation-tile__btn">
+                                                    <a class="btn btn--full btn--small" href="">Join now</a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
 
                 <h2 id="cl-poll">Poll and Radio</h2>

--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -66,13 +66,13 @@ class PlansList extends React.Component {
   }
 
   renderListItem (item, i) {
-    let statusClass = (item.participation_active === true) ? 'maplist-item__status-active' : 'maplist-item__status-inactive'
+    let statusClass = (item.participation_active === true) ? 'participation-tile__status-active' : 'participation-tile__status-inactive'
     return (
       <li className={this.props.isHorizontal ? 'participation-tile__horizontal' : 'participation-tile__vertical'} key={i}>
 
         <a href={item.url} target={item.subtype === 'external' ? '_blank' : '_self'}>
           {item.type === 'project' &&
-            <div className="maplist-item__proj">
+            <div className="participation-tile__body maplist-item__proj">
               {item.tile_image &&
               <div className={this.props.isHorizontal ? 'u-lg-only-display maplist-item__img' : 'maplist-item__img'} style={this.getImage(item)} alt="">
                 {!this.props.isHorizontal && this.renderTopics(item)}
@@ -81,7 +81,7 @@ class PlansList extends React.Component {
                 }
               </div>
               }
-              <div className="maplist-item__content">
+              <div className="participation-tile__content">
                 {(this.props.isHorizontal || !item.tile_image) && this.renderTopics(item)}
                 <span className="maplist-item__roofline">{item.district}</span>
                 <h3 className="maplist-item__title">{item.title}</h3>
@@ -93,19 +93,19 @@ class PlansList extends React.Component {
                 <div className="maplist-item__link" />
                 {item.subtype === 'container' &&
                   <div className="maplist-item__stats">
-                    <span className="maplist-item__proj-count"><i className="fas fa-th" aria-hidden="true" />{django.gettext('Participation projects: ')}</span>
+                    <span className="participation-tile__proj-count"><i className="fas fa-th" aria-hidden="true" />{django.gettext('Participation projects: ')}</span>
                     <span>{item.published_projects_count}</span>
                   </div>
                 }
                 {item.future_phase && !item.active_phase &&
                   <div className="status-item status__future">
-                    <span className="maplist-item__status"><i className="fas fa-clock" aria-hidden="true" />{django.gettext('Participation: from ')}{this.getDate(item)}</span>
+                    <span className="participation-tile__status"><i className="fas fa-clock" aria-hidden="true" />{django.gettext('Participation: from ')}{this.getDate(item)}</span>
                   </div>
                 }
                 {item.active_phase &&
                 <div className="status-item status__active">
                   <div className="status-bar__active"><span className="status-bar__active-fill" style={this.getWidth(item)} /></div>
-                  <span className="maplist-item__status"><i className="fas fa-clock" aria-hidden="true" />
+                  <span className="participation-tile__status"><i className="fas fa-clock" aria-hidden="true" />
                     {this.getTimespan(item)}
                   </span>
                 </div>
@@ -120,16 +120,16 @@ class PlansList extends React.Component {
             </div>
           }
           {item.type === 'plan' &&
-            <div className="maplist-item__plan">
+            <div className="participation-tile__body maplist-item__plan">
               {this.renderTopics(item)}
               <span className="maplist-item__roofline">{item.district}</span>
               <h3 className="maplist-item__title">{item.title}</h3>
               <div className="maplist-item__link" />
               <div className="maplist-item__stats">
-                <span className="maplist-item__proj-count"><i className="fas fa-th" aria-hidden="true" />{django.gettext('Participation projects: ')}</span>
+                <span className="participation-tile__proj-count"><i className="fas fa-th" aria-hidden="true" />{django.gettext('Participation projects: ')}</span>
                 <span>{item.published_projects_count}</span>
                 <br />
-                <span className="maplist-item__status"><i className="fas fa-clock" aria-hidden="true" />{django.gettext('Status: ')}</span>
+                <span className="participation-tile__status"><i className="fas fa-clock" aria-hidden="true" />{django.gettext('Status: ')}</span>
                 <span className={statusClass}>{item.participation_string }</span>
               </div>
               <div className="status-item_spacer" />
@@ -154,7 +154,7 @@ class PlansList extends React.Component {
 
     if (list.length > 0) {
       return (
-        <ul className="u-list-reset maplist-list">
+        <ul className="u-list-reset participation-tile__list">
           {list}
         </ul>
       )

--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -68,7 +68,7 @@ class PlansList extends React.Component {
   renderListItem (item, i) {
     let statusClass = (item.participation_active === true) ? 'maplist-item__status-active' : 'maplist-item__status-inactive'
     return (
-      <li className={this.props.isHorizontal ? 'maplist-item__horizontal' : 'maplist-item__vertical'} key={i}>
+      <li className={this.props.isHorizontal ? 'participation-tile__horizontal' : 'participation-tile__vertical'} key={i}>
 
         <a href={item.url} target={item.subtype === 'external' ? '_blank' : '_self'}>
           {item.type === 'project' &&

--- a/meinberlin/apps/plans/assets/PopUp.jsx
+++ b/meinberlin/apps/plans/assets/PopUp.jsx
@@ -43,7 +43,7 @@ class PopUp extends React.Component {
   }
 
   render () {
-    let statusClass = (this.props.item.participation_active === true) ? 'maplist-item__status-active' : 'maplist-item__status-inactive'
+    let statusClass = (this.props.item.participation_active === true) ? 'participation-tile__status-active' : 'participation-tile__status-inactive'
     if (this.props.item.type === 'project') {
       return (
         <div className="maps-popups-popup-text-content">

--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -118,7 +118,7 @@
     <div class="item-detail-2__project-list">
         <div class="l-wrapper">
             <h3 class="item-detail-2__project-title" id="participation-plans">{% trans "Participation projects" %}</h3>
-            <ul class="u-list-reset maplist-list">
+            <ul class="u-list-reset participation-tile__list">
             {% for project in object.published_projects %}
 
                     {% include "meinberlin_projects/includes/project_tile.html" with project=project %}

--- a/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html
+++ b/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html
@@ -76,7 +76,7 @@
     <div class="l-wrapper">
         {% filter_has_perm 'a4projects.view_project' request.user container.published_not_archived_projects.all as filtered_projects %}
         {% if filtered_projects|length > 0 %}
-            <ul class="u-list-reset maplist-list">
+            <ul class="u-list-reset participation-tile__list">
                 {% for project in filtered_projects %}
                     {% include "meinberlin_projects/includes/project_tile.html" with project=project %}
                 {% endfor %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -2,41 +2,34 @@
 {% project_tile_image project as project_image %}
 {% project_tile_image_copyright project as project_image_copyright %}
 
-<div class="project-module-tile">
-    <div class="maplist-item__vertical">
-        <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
-            <div class="maplist-item__proj">
-                <div class="maplist-item__content">
-                    <h3 class="maplist-item__title">{{ project.name }}</h3>
-                    {% if project.active_phase %}
-                    <div class="status-item status__active">
-                        <div class="status-bar__active">
-                            <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
-                        </div>
-                        <span class="maplist-item__status">
-                            <i class="fas fa-clock" aria-hidden="true"></i>
-                        {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
-                        </span>
+<div class="participation-tile__vertical">
+    <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
+        <div class="maplist-item__proj">
+            <div class="maplist-item__content participation-tile__content">
+                <h3 class="maplist-item__title participation-tile__title">{{ project.name }}</h3>
+                {% if project.active_phase %}
+                <div class="status-item status__active">
+                    <div class="status-bar__active">
+                        <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
                     </div>
-                    {% elif project.future_phases %}
-                    <div class="status-item status__future">
-                        <span class="maplist-item__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
-                        {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
-                        </span>
-                    </div>
-                    {% elif project.has_finished %}
-                        <div class="status-item status-bar__past">
-                        {% blocktrans %}Participation ended. Read result{% endblocktrans %}
-                        </div>
-                    {% endif %}
-                    <a class="btn btn--full btn--small" href="">{% trans 'Join now' %}</a>
+                    <span class="participation-tile__status">
+                        <i class="fas fa-clock" aria-hidden="true"></i>
+                    {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
+                    </span>
                 </div>
+                {% elif project.future_phases %}
+                <div class="status-item status__future">
+                    <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
+                    {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
+                    </span>
+                </div>
+                {% elif project.has_finished %}
+                    <div class="status-item status-bar__past">
+                    {% blocktrans %}Participation ended. Read result{% endblocktrans %}
+                    </div>
+                {% endif %}
+                <a class="btn btn--full btn--small" href="">{% trans 'Join now' %}</a>
             </div>
-            {% if project|is_external %}
-            <div class="maplist-item__corner-badge maplist-item__corner-badge--external"></div>
-            {% elif not project.is_public %}
-            <div class="maplist-item__corner-badge maplist-item__corner-badge--private"></div>
-            {% endif %}
-        </a>
-    </div>
+        </div>
+    </a>
 </div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -1,35 +1,44 @@
 {% load i18n project_tags meinberlin_project_tags contrib_tags thumbnail static %}
 {% project_tile_image project as project_image %}
 {% project_tile_image_copyright project as project_image_copyright %}
-
-<div class="participation-tile__vertical">
-    <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
-        <div class="maplist-item__proj">
-            <div class="maplist-item__content participation-tile__content">
-                <h3 class="maplist-item__title participation-tile__title">{{ project.name }}</h3>
-                {% if project.active_phase %}
-                <div class="status-item status__active">
-                    <div class="status-bar__active">
-                        <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
+<div class="participation-tile__wrapper">
+    <div class="participation-tile__list-container">
+        <ul class="u-list-reset participation-tile__list">
+            <li class="participation-tile__vertical">
+                <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
+                    <div class="participation-tile__type">
+                        <div class="participation-tile__content">
+                            <h3 class="participation-tile__title">{{ project.name }}</h3>
+                            <span class="participation-tile__item-count"><i class="fas fa-comments" aria-hidden="true"></i>123 Betrag</span>
+                            {% if project.active_phase %}
+                            <div class="status-item status__active">
+                                <div class="status-bar__active">
+                                    <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
+                                </div>
+                                <span class="participation-tile__status">
+                                    <i class="fas fa-clock" aria-hidden="true"></i>
+                                {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
+                                </span>
+                            </div>
+                            {% elif project.future_phases %}
+                            <div class="status-item status__future">
+                                <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
+                                {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
+                                </span>
+                            </div>
+                            {% elif project.has_finished %}
+                                <div class="status-item status-bar__past status-bar__past--sm">
+                                <span class="participation-tile__status">{% blocktrans %}Participation ended. Read result{% endblocktrans %}</span>
+                                </div>
+                            {% endif %}
+                            <div class="participation-tile__spacer"></div>
+                            <div class="participation-tile__btn">
+                                <a class="btn btn--full btn--small" href="">{% trans 'Join now' %}</a>
+                            </div>
+                        </div>
                     </div>
-                    <span class="participation-tile__status">
-                        <i class="fas fa-clock" aria-hidden="true"></i>
-                    {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
-                    </span>
-                </div>
-                {% elif project.future_phases %}
-                <div class="status-item status__future">
-                    <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
-                    {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
-                    </span>
-                </div>
-                {% elif project.has_finished %}
-                    <div class="status-item status-bar__past">
-                    {% blocktrans %}Participation ended. Read result{% endblocktrans %}
-                    </div>
-                {% endif %}
-                <a class="btn btn--full btn--small" href="">{% trans 'Join now' %}</a>
-            </div>
-        </div>
-    </a>
+                </a>
+            </li>
+        </ul>
+    </div>
 </div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -1,0 +1,42 @@
+{% load i18n project_tags meinberlin_project_tags contrib_tags thumbnail static %}
+{% project_tile_image project as project_image %}
+{% project_tile_image_copyright project as project_image_copyright %}
+
+<div class="project-module-tile">
+    <div class="maplist-item__vertical">
+        <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
+            <div class="maplist-item__proj">
+                <div class="maplist-item__content">
+                    <h3 class="maplist-item__title">{{ project.name }}</h3>
+                    {% if project.active_phase %}
+                    <div class="status-item status__active">
+                        <div class="status-bar__active">
+                            <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
+                        </div>
+                        <span class="maplist-item__status">
+                            <i class="fas fa-clock" aria-hidden="true"></i>
+                        {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
+                        </span>
+                    </div>
+                    {% elif project.future_phases %}
+                    <div class="status-item status__future">
+                        <span class="maplist-item__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
+                        {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
+                        </span>
+                    </div>
+                    {% elif project.has_finished %}
+                        <div class="status-item status-bar__past">
+                        {% blocktrans %}Participation ended. Read result{% endblocktrans %}
+                        </div>
+                    {% endif %}
+                    <a class="btn btn--full btn--small" href="">{% trans 'Join now' %}</a>
+                </div>
+            </div>
+            {% if project|is_external %}
+            <div class="maplist-item__corner-badge maplist-item__corner-badge--external"></div>
+            {% elif not project.is_public %}
+            <div class="maplist-item__corner-badge maplist-item__corner-badge--private"></div>
+            {% endif %}
+        </a>
+    </div>
+</div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -1,44 +1,39 @@
 {% load i18n project_tags meinberlin_project_tags contrib_tags thumbnail static %}
 {% project_tile_image project as project_image %}
 {% project_tile_image_copyright project as project_image_copyright %}
-<div class="participation-tile__wrapper">
-    <div class="participation-tile__list-container">
-        <ul class="u-list-reset participation-tile__list">
-            <li class="participation-tile__vertical">
-                <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
-                    <div class="participation-tile__type">
-                        <div class="participation-tile__content">
-                            <h3 class="participation-tile__title">{{ project.name }}</h3>
-                            <span class="participation-tile__item-count"><i class="fas fa-comments" aria-hidden="true"></i>123 Betrag</span>
-                            {% if project.active_phase %}
-                            <div class="status-item status__active">
-                                <div class="status-bar__active">
-                                    <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
-                                </div>
-                                <span class="participation-tile__status">
-                                    <i class="fas fa-clock" aria-hidden="true"></i>
-                                {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
-                                </span>
-                            </div>
-                            {% elif project.future_phases %}
-                            <div class="status-item status__future">
-                                <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
-                                {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
-                                </span>
-                            </div>
-                            {% elif project.has_finished %}
-                                <div class="status-item status-bar__past status-bar__past--sm">
-                                <span class="participation-tile__status">{% blocktrans %}Participation ended. Read result{% endblocktrans %}</span>
-                                </div>
-                            {% endif %}
-                            <div class="participation-tile__spacer"></div>
-                            <div class="participation-tile__btn">
-                                <a class="btn btn--full btn--small" href="">{% trans 'Join now' %}</a>
-                            </div>
-                        </div>
+<li class="participation-tile__vertical">
+    <a href="{% url 'module-detail' module.slug %}">
+        <div class="participation-tile__type">
+            <div class="participation-tile__content">
+                <h3 class="participation-tile__title">{{ module.name }}</h3>
+                <span class="participation-tile__item-count">
+                    <i class="fas fa-comments" aria-hidden="true"></i>
+                    {% get_num_entries module as num_entries %}
+                    {% blocktrans with num_entries=num_entries %}{{ num_entries }} Contributions{% endblocktrans %}
+                </span>
+                {% if module.active_phase %}
+                <div class="status-item status__active">
+                    <div class="status-bar__active">
+                        <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
                     </div>
-                </a>
-            </li>
-        </ul>
-    </div>
-</div>
+                    <span class="participation-tile__status">
+                        <i class="fas fa-clock" aria-hidden="true"></i>
+                    {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
+                    </span>
+                </div>
+                {% elif module.future_phases %}
+                <div class="status-item status__future">
+                    <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
+                    {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
+                    </span>
+                </div>
+                {% endif %}
+                <div class="participation-tile__spacer"></div>
+                <div class="participation-tile__btn">
+                    <a class="btn btn--full btn--small" href="{% url 'module-detail' module.slug %}">{% trans 'Join now' %}</a>
+                </div>
+            </div>
+        </div>
+    </a>
+</li>
+

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
@@ -5,7 +5,7 @@
 <li class="participation-tile__vertical">
     <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
 
-        <div class="maplist-item__proj">
+        <div class="participation-tile__body maplist-item__proj">
             {% if project_image %}
             <div class="maplist-item__img" alt="" style="background-image: url({{ project_image|thumbnail_url:'project_tile' }})">
                 {% if project.topics %}
@@ -22,7 +22,7 @@
                 {% endif %}
             </div>
             {% endif %}
-            <div class="maplist-item__content">
+            <div class="participation-tile__content">
                 {% if project.topics and not project_image %}
                 <div class="maplist-item__label-spacer">
                     {% for topic in project.topic_names %}
@@ -46,7 +46,7 @@
                 <div class="maplist-item__link"></div>
                 {% if project|is_container %}
                 <div class="maplist-item__stats">
-                    <span class="maplist-item__proj-count">
+                    <span class="participation-tile__proj-count">
                         <i class="fas fa-th" aria-hidden="true"></i>
                         {% trans 'Participation projects: ' %}
                     </span>
@@ -58,14 +58,14 @@
                         <div class="status-bar__active">
                             <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
                         </div>
-                        <span class="maplist-item__status">
+                        <span class="participation-tile__status">
                             <i class="fas fa-clock" aria-hidden="true"></i>
                         {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
                         </span>
                     </div>
                     {% elif project.future_phases %}
                     <div class="status-item status__future">
-                        <span class="maplist-item__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
+                        <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
                         {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
                         </span>
                     </div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
@@ -2,7 +2,7 @@
 {% project_tile_image project as project_image %}
 {% project_tile_image_copyright project as project_image_copyright %}
 
-<li class="maplist-item__vertical">
+<li class="participation-tile__vertical">
     <a href="{{ project|project_url }}" target="{{ project|is_external|yesno:"_blank,_self" }}">
 
         <div class="maplist-item__proj">

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -178,16 +178,18 @@
                     <P>{{ event.description | safe}}</P>
                 {% endif %}
                 {% if modules %}
-                    {% for module in modules %}
-                        <div>
-                            <h3>{{ module.name }}</h3>
-                            <p>{{ module.description }}</p>
-                            <a href="{% url 'module-detail' module_slug=module.slug %}">Link</a>
+                    <div class="participation-tile__wrapper">
+                        <div class="participation-tile__list-container">
+                            <ul class="u-list-reset participation-tile__list">
+                            {% for module in modules %}
+                                {% include "meinberlin_projects/includes/project_module_tile.html" with project=project module=module %}
+                            {% endfor %}
+                            </ul>
                         </div>
-                    {% endfor %}
+                    </div>
                  {% endif %}
                 </div>
-                {% include "meinberlin_projects/includes/project_module_tile.html" with project=project %}
+
                 <div class="l-center-6">
                     {% block project_action %}{% endblock %}
                 </div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -187,7 +187,7 @@
                     {% endfor %}
                  {% endif %}
                 </div>
-
+                {% include "meinberlin_projects/includes/project_module_tile.html" with project=project %}
                 <div class="l-center-6">
                     {% block project_action %}{% endblock %}
                 </div>

--- a/meinberlin/assets/scss/components/_maplist.scss
+++ b/meinberlin/assets/scss/components/_maplist.scss
@@ -10,14 +10,6 @@
     }
 }
 
-.maplist-item__vertical,
-.maplist-item__horizontal {
-    border: 1px solid $border-color;
-    position: relative;
-    overflow-wrap: break-word;
-    background-color: $body-bg;
-}
-
 .maplist-item__plan,
 .maplist-item__content {
     padding: 1.5*$padding;
@@ -107,12 +99,7 @@
 }
 
 // vertical tile structure
-.maplist-item__vertical {
-    width: 100%;
-    margin: $r-spacer;
-    flex-grow: 1 0 100%;
-    min-height: 250px;
-
+.participation-tile__vertical {
     .maplist-item__proj { // for image
         flex-direction: column;
     }
@@ -130,35 +117,10 @@
         margin-top: $r-spacer;
         margin-left: $r-spacer;
     }
-
-    @media screen and (min-width: $breakpoint-xs) {
-        flex-basis: auto;
-        flex-grow: 1;
-        max-width: calc(100% * (1 / 2) - 2rem - 1px);
-    }
-
-    @media screen and (min-width: $breakpoint) {
-        flex-basis: auto;
-        flex-grow: 1;
-        max-width: calc(100% * (1 / 3) - 2rem - 1px);
-    }
-
-    @media screen and (min-width: $breakpoint-lg) {
-        flex-basis: auto;
-        flex-grow: 1;
-        max-width: calc(100% * (1 / 4) - 2rem - 1px);
-    }
 }
 
 // horizontal tile structure
-.maplist-item__horizontal {
-    width: 100%;
-    margin: 0 $r-spacer $r-spacer $r-spacer;
-
-    @media screen and (min-width: $breakpoint-md) {
-        margin: 0 $r-spacer $r-spacer 5*$r-spacer;
-    }
-
+.participation-tile__horizontal {
     .maplist-item__proj,
     .maplist-item__plan { // statusbar position
         height: 250px;

--- a/meinberlin/assets/scss/components/_maplist.scss
+++ b/meinberlin/assets/scss/components/_maplist.scss
@@ -1,4 +1,4 @@
-.maplist-list {
+.participation-tile__list {
     max-width: calc(100% + 2rem); //this is all to fit within the frame to be inline with above items
     display: flex;
     flex-wrap: wrap;
@@ -10,8 +10,7 @@
     }
 }
 
-.maplist-item__plan,
-.maplist-item__content {
+.maplist-item__plan {
     padding: 1.5*$padding;
 }
 
@@ -22,7 +21,6 @@
 .maplist-item__img {
     position: relative;
     flex-basis: 250px;
-
     background-size: cover;
     background-position: 50%;
     background-repeat: no-repeat;
@@ -43,10 +41,6 @@
     color: $gray;
 }
 
-.maplist-popup-item__roofline {
-    font-size: $font-size-sm;
-}
-
 .maplist-item__title {
     margin-top: $r-spacer;
 }
@@ -60,23 +54,38 @@
     bottom: $padding;
 }
 
-.maplist-item__proj-count,
+.maplist-item__corner-badge {
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
+    height: 50px;
+    width: 50px;
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.maplist-item__corner-badge--external {
+    background-image: url('/static/images/badge_external_link.png');
+}
+
+.maplist-item__corner-badge--private {
+    background-image: url('/static/images/badge_priva_projekt.png');
+}
+
+//popup specific styling
+.maplist-popup-item__roofline {
+    font-size: $font-size-sm;
+}
+
 .maplist-item-popup__proj-count,
-.maplist-item__status,
 .maplist-item-popup__status {
     color: $text-color;
     font-size: $font-size-xs;
 
     i {
-        padding-right: $padding;
-        color: $brand-secondary;
-    }
-}
-
-.maplist-item-popup__proj-count,
-.maplist-item-popup__status {
-    i {
         padding-right: 0.5*$padding;
+        color: $brand-secondary;
     }
 }
 
@@ -88,14 +97,6 @@
     background-color: $bg-secondary;
     padding: 0.5*$padding $padding;
     margin: 0.5*$padding (-$padding) auto;
-}
-
-.maplist-item__status-active {
-    color: $brand-primary;
-}
-
-.maplist-item__status-inactive {
-    color: $gray;
 }
 
 // vertical tile structure
@@ -121,37 +122,7 @@
 
 // horizontal tile structure
 .participation-tile__horizontal {
-    .maplist-item__proj,
-    .maplist-item__plan { // statusbar position
-        height: 250px;
-    }
-
     .maplist-item__proj { // image
         flex-direction: row;
     }
-
-    .maplist-item__content { // for status bar flex for image
-        height: inherit;
-        position: relative;
-        flex: 1;
-    }
-}
-
-.maplist-item__corner-badge {
-    background-position: center;
-    background-size: contain;
-    background-repeat: no-repeat;
-    height: 50px;
-    width: 50px;
-    position: absolute;
-    top: 0;
-    right: 0;
-}
-
-.maplist-item__corner-badge--external {
-    background-image: url('/static/images/badge_external_link.png');
-}
-
-.maplist-item__corner-badge--private {
-    background-image: url('/static/images/badge_priva_projekt.png');
 }

--- a/meinberlin/assets/scss/components/_participation_tile.scss
+++ b/meinberlin/assets/scss/components/_participation_tile.scss
@@ -1,3 +1,34 @@
+.participation-tile__wrapper {
+    display: flex;
+    flex-direction: row;
+    position: relative;
+}
+
+.participation-tile__list-container {
+    flex: 0 1 44vh;
+
+    @media (min-width: $breakpoint-xs) {
+        flex-grow: 2;
+        overflow-y: visible;
+    }
+}
+
+.participation-tile__list {
+    max-width: calc(100% + 2rem); //this is all to fit within the frame to be inline with above items
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+
+    @media screen and (min-width: $breakpoint-md) {
+        margin-left: -1rem !important;
+        margin-right: -1rem !important;
+    }
+}
+
+.participation-tile__content {
+    padding: 1.5*$padding;
+}
+
 .participation-tile__horizontal,
 .participation-tile__vertical {
     border: 1px solid $border-color;
@@ -13,13 +44,23 @@
     @media screen and (min-width: $breakpoint-md) {
         margin: 0 $r-spacer $r-spacer 5*$r-spacer;
     }
+
+    .participation-tile__body { // statusbar position
+        height: 250px;
+    }
+
+    .participation-tile__content { // for status bar flex for image
+        height: inherit;
+        position: relative;
+        flex: 1;
+    }
 }
 
 .participation-tile__vertical {
     width: 100%;
     margin: $r-spacer;
     flex-grow: 1 0 100%;
-    min-height: 250px;
+    min-height: 350px;
 
     @media screen and (min-width: $breakpoint-xs) {
         flex-basis: auto;
@@ -40,43 +81,37 @@
     }
 }
 
-// .maplist-item__proj-count,
-// .maplist-item-popup__proj-count,
-// .maplist-item__status,
-// .maplist-item-popup__status {
-//     color: $text-color;
-//     font-size: $font-size-xs;
-//
-//     i {
-//         padding-right: $padding;
-//         color: $brand-secondary;
-//     }
-// }
-//
-// .participation-tile__proj-count,
-// .participation-tile__status {
-//     color: $text-color;
-//     font-size: $font-size-xs;
-//
-//     i {
-//         padding-right: $padding;
-//         color: $brand-secondary;
-//     }
-// }
-//
-// .participation-tile__content
-// .maplist-item__plan,
-// .maplist-item__content {
-//     padding: 1.5*$padding;
-// }
-//
-// .participation-tile
-// .maplist-item__proj-count {
-//     width: 100%;
-//     margin: $r-spacer;
-//     flex-grow: 1 0 100%;
-//     min-height: 250px;
-//
-//     .maplist-item__proj { // for image
-//         flex-direction: column;
-// }
+.participation-tile__title {
+    margin-top: 0;
+}
+
+.participation-tile__btn {
+    position: absolute;
+    left: 3*$r-spacer;
+    right: 3*$r-spacer;
+    bottom: 3.5*$r-spacer;
+}
+
+.participation-tile__spacer {
+    height: 6.5*$r-spacer;
+}
+
+.participation-tile__item-count,
+.participation-tile__proj-count,
+.participation-tile__status {
+    color: $text-color;
+    font-size: $font-size-xs;
+
+    i {
+        padding-right: $padding;
+        color: $brand-secondary;
+    }
+}
+
+.participation-tile__status-active {
+    color: $brand-primary;
+}
+
+.participation-tile__status-inactive {
+    color: $gray;
+}

--- a/meinberlin/assets/scss/components/_participation_tile.scss
+++ b/meinberlin/assets/scss/components/_participation_tile.scss
@@ -1,0 +1,82 @@
+.participation-tile__horizontal,
+.participation-tile__vertical {
+    border: 1px solid $border-color;
+    position: relative;
+    overflow-wrap: break-word;
+    background-color: $body-bg;
+}
+
+.participation-tile__horizontal {
+    width: 100%;
+    margin: 0 $r-spacer $r-spacer $r-spacer;
+
+    @media screen and (min-width: $breakpoint-md) {
+        margin: 0 $r-spacer $r-spacer 5*$r-spacer;
+    }
+}
+
+.participation-tile__vertical {
+    width: 100%;
+    margin: $r-spacer;
+    flex-grow: 1 0 100%;
+    min-height: 250px;
+
+    @media screen and (min-width: $breakpoint-xs) {
+        flex-basis: auto;
+        flex-grow: 1;
+        max-width: calc(100% * (1 / 2) - 2rem - 1px);
+    }
+
+    @media screen and (min-width: $breakpoint) {
+        flex-basis: auto;
+        flex-grow: 1;
+        max-width: calc(100% * (1 / 3) - 2rem - 1px);
+    }
+
+    @media screen and (min-width: $breakpoint-lg) {
+        flex-basis: auto;
+        flex-grow: 1;
+        max-width: calc(100% * (1 / 4) - 2rem - 1px);
+    }
+}
+
+// .maplist-item__proj-count,
+// .maplist-item-popup__proj-count,
+// .maplist-item__status,
+// .maplist-item-popup__status {
+//     color: $text-color;
+//     font-size: $font-size-xs;
+//
+//     i {
+//         padding-right: $padding;
+//         color: $brand-secondary;
+//     }
+// }
+//
+// .participation-tile__proj-count,
+// .participation-tile__status {
+//     color: $text-color;
+//     font-size: $font-size-xs;
+//
+//     i {
+//         padding-right: $padding;
+//         color: $brand-secondary;
+//     }
+// }
+//
+// .participation-tile__content
+// .maplist-item__plan,
+// .maplist-item__content {
+//     padding: 1.5*$padding;
+// }
+//
+// .participation-tile
+// .maplist-item__proj-count {
+//     width: 100%;
+//     margin: $r-spacer;
+//     flex-grow: 1 0 100%;
+//     min-height: 250px;
+//
+//     .maplist-item__proj { // for image
+//         flex-direction: column;
+// }

--- a/meinberlin/assets/scss/components/_status_bar.scss
+++ b/meinberlin/assets/scss/components/_status_bar.scss
@@ -41,6 +41,10 @@
     left: 0;
 }
 
+.status-bar__past--sm {
+    padding: 0.5*$padding;
+}
+
 .status-bar__status {
     color: $text-color;
 

--- a/meinberlin/assets/scss/style.scss
+++ b/meinberlin/assets/scss/style.scss
@@ -62,6 +62,7 @@
 @import 'components/timeline';
 @import 'components/poll';
 @import 'components/idea_remark';
+@import 'components/participation_tile';
 @import 'components/portal_header';
 @import 'components/progress';
 @import 'components/project_header';


### PR DESCRIPTION
To whoever reviews: Firstly sorry about lack of commits, I wanted to do one for each change of class name but then I forgot that was what I was going to do and just did most of it in one because they kind of bled into each other. 
I ended up swapping out quite a few class names to be used across the 3 different tile types that we use, basic, maplist and popup, ideally I would like 'participation-tile' to be the basic tile that we base all the rest off, however as a class name i wonder if it is too long? also it does not entirely relate to the other tile types that are based off of it. 