### PR TITLE
Ka 2019 06 add status bar info to modules

### DIFF
--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -11,21 +11,25 @@
                     {% get_num_entries module as num_entries %}
                     {% blocktrans with num_entries=num_entries %}{{ num_entries }} Contributions{% endblocktrans %}
                 </span>
-                {% if module.active_phase %}
+                {% if module.module_running_time_left %}
                 <div class="status-item status__active">
                     <div class="status-bar__active">
-                        <span class="status-bar__active-fill" style="width: {{ project.active_phase_progress }}%"></span>
+                        <span class="status-bar__active-fill" style="width: {{ module.module_running_progress }}%"></span>
                     </div>
                     <span class="participation-tile__status">
                         <i class="fas fa-clock" aria-hidden="true"></i>
-                    {% blocktrans with time_left=project.time_left %}remaining {{ time_left }}{% endblocktrans %}
+                    {% blocktrans with time_left=module.module_running_time_left %}remaining {{ time_left }}{% endblocktrans %}
                     </span>
                 </div>
-                {% elif module.future_phases %}
+                {% elif not module.module_has_started %}
                 <div class="status-item status__future">
-                    <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date project.future_phases.first.start_date 'd.m.Y' as start_date %}
+                    <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date module.module_start 'd.m.Y' as start_date %}
                     {% blocktrans with date=start_date %}Participation: starts on {{ date }}{% endblocktrans %}
                     </span>
+                </div>
+                {% elif module.module_has_finished %}
+                <div class="status-item status-bar__past">
+                {% blocktrans %}Participation ended. Read result{% endblocktrans %}
                 </div>
                 {% endif %}
                 <div class="participation-tile__spacer"></div>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.0.0",
     "@fortawesome/fontawesome-free": "5.9.0",
     "acorn": "6.1.1",
-    "adhocracy4": "liqd/adhocracy4#django2-v1.0",
+    "adhocracy4": "liqd/adhocracy4#3376387474983c979ce4f5e27d8e9c763e95aa2e",
     "autoprefixer": "9.6.0",
     "babel-loader": "8.0.6",
     "bootstrap": "4.3.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@django2-v1.0#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@3376387474983c979ce4f5e27d8e9c763e95aa2e#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.1.7


### PR DESCRIPTION
depends on https://github.com/liqd/adhocracy4/pull/355
It's currently using that branch, but should not be merged like that. Merge the a4-PR first, then update the last commit to the new hash and then merge. 

While doing this stuff, I noticed our all the inconsitencies how we use the phases again. I think we should update the stuff that is used in the mB projects to use the new running module logic.