### PR TITLE
Pm 2019 06 ally timeline

### DIFF
--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -90,32 +90,35 @@ $(document).ready(function(){
     return parseInt($("#timeline-carousel").attr("data-initial-slide"))
   }
 
-
   $(".timeline-carousel__item").slick({
-  	dots: false,
-    arrows: true,
-    slidesToScroll: 2,
-    infinite: false,
-    slidesToShow: 2,
     initialSlide: getInitialSlide(),
     focusOnSelect: false,
-    centerMode: true,
-    variableWidth: true,
+    centerMode: false,
+    dots: false,
+    arrows: true,
+    centerPadding: 30,
+    mobileFirst: true,
+    infinite: false,
     responsive: [
       {
-          breakpoint: 800,
-          settings: {
-            slidesToShow: 2,
-            slidesToScroll: 1
-          }
+        breakpoint: 0,
+        settings: {
+          slidesToShow: 1,
+          slidesToScroll: 1,
+        }
       },
       {
-          breakpoint: 512,
-          settings: {
-            slidesToShow: 1,
-            slidesToScroll: 1
-          }
-      }
+        breakpoint: 512,
+        settings: {
+          slidesToShow: 2,
+        }
+      },
+      {
+        breakpoint: 800,
+        settings: {
+          slidesToShow: 3,
+        }
+      },
     ]
-  });
-});
+    })
+})

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -93,12 +93,13 @@ $(document).ready(function(){
   $(".timeline-carousel__item").slick({
     initialSlide: getInitialSlide(),
     focusOnSelect: false,
-    centerMode: false,
+    centerMode: true,
     dots: false,
     arrows: true,
     centerPadding: 30,
     mobileFirst: true,
     infinite: false,
+    variableWidth: true,
     responsive: [
       {
         breakpoint: 0,

--- a/meinberlin/assets/scss/components/_tabs.scss
+++ b/meinberlin/assets/scss/components/_tabs.scss
@@ -1,6 +1,7 @@
 .tabpanel {
     display: none;
     overflow-wrap: break-word;
+    overflow-x: hidden;
 
     &.active {
         display: block;

--- a/meinberlin/assets/scss/components/_timeline-carousel.scss
+++ b/meinberlin/assets/scss/components/_timeline-carousel.scss
@@ -14,66 +14,21 @@ $timeline-carousel__top-space: 11px;
     text-align: center;
     margin: $spacer 0;
 
-    .timeline-carousel__dot {
-        display: inline-block;
-        background-color: $border-color;
-        padding: 0;
-        margin-bottom: 3px;
-        border-radius: 50%;
-        height: 17px;
-        width: 17px;
-        vertical-align: middle;
-        transition: transform 0.2s;
-        transform-origin: 50% 50%;
-    }
-
-    .timeline-carousel__label {
-        padding: $padding;
-        margin-top: 2*$spacer;
-        color: $brand-secondary;
-        background-color: $blue-light;
-        text-align: left;
-    }
-
-    .timeline-carousel__dot:hover,
-    .timeline-carousel__dot:focus {
-        transform: scale(1.25);
-    }
-
-    .timeline-carousel__line {
-        position: absolute;
-        width: 200%;
-        left: -50%;
-        top: $timeline-carousel__top-space;
-        border-top: 2px dashed $border-color;
-    }
-
-    //slick overwrites
-    .slick-slide {
-        margin: 0 3*$spacer;
-        min-width: 275px;
-
-        :focus {
-            outline: none;
-        }
-    }
-
+    //slick overwrites - nested for specificity
     .slick-prev,
     .slick-next {
-        background: $body-bg;
         top: $timeline-carousel__top-space;
         text-align: center;
+        border-radius: 100%;
+        border: 1px solid $border-color;
+        background-color: $body-bg;
 
         &:before {
-            background: $body-bg;
-            border-radius: 100%;
-            border: 1px solid $border-color;
-            opacity: 1;
             color: $brand-secondary;
+            opacity: 1;
             font-family: "Font Awesome 5 Free", sans-serif;
             font-weight: 900;
             font-size: $font-size-lg;
-            padding: 0 6px;
         }
     }
 
@@ -84,27 +39,70 @@ $timeline-carousel__top-space: 11px;
     .slick-next:before {
         content: '\f105'; // angle-right
     }
+}
 
-    .initial {
-        background: $brand-secondary;
-        color: $text-color-inverted;
+.timeline-carousel__dot {
+    display: inline-block;
+    background-color: $border-color;
+    padding: 0;
+    margin-bottom: 3px;
+    border-radius: 50%;
+    height: 17px;
+    width: 17px;
+    vertical-align: middle;
+    transition: transform 0.2s;
+    transform-origin: 50% 50%;
+}
 
-        &.timeline-carousel__label {
-            padding: 1.5*$padding;
-        }
+.timeline-carousel__label {
+    padding: $padding;
+    margin-top: 2*$spacer;
+    color: $brand-secondary;
+    background-color: $blue-light;
+    text-align: left;
+}
 
-        &.timeline-carousel__dot {
-            transform: scale(1.25);
+.timeline-carousel__dot:hover,
+.timeline-carousel__dot:focus {
+    transform: scale(1.25);
+}
+
+.timeline-carousel__line {
+    position: absolute;
+    width: 200%;
+    left: -50%;
+    top: $timeline-carousel__top-space;
+    border-top: 2px dashed $border-color;
+}
+
+//slick overwrites
+.slick-slide {
+    margin: 0 3*$spacer;
+
+    :focus {
+        outline: none;
+
+        .timeline-carousel__label {
+            color: $link-color-btn;
         }
     }
 }
 
-//mobile
-@media screen and (max-width: $breakpoint-xs-down) {
-    .timeline-carousel__wrapper {
-        overflow: hidden;
+.initial {
+    background: $brand-secondary;
+    color: $text-color-inverted;
+
+    &.timeline-carousel__label {
+        padding: 1.5*$padding;
     }
 
+    &.timeline-carousel__dot {
+        transform: scale(1.25);
+    }
+}
+
+//mobile
+@media screen and (max-width: $breakpoint-md-down) {
     .slick-next {
         right: 0 !important;
     }

--- a/meinberlin/assets/scss/components/_timeline-carousel.scss
+++ b/meinberlin/assets/scss/components/_timeline-carousel.scss
@@ -22,6 +22,7 @@ $timeline-carousel__top-space: 11px;
         border-radius: 100%;
         border: 1px solid $border-color;
         background-color: $body-bg;
+        z-index: 1; //for when tile links overlap
 
         &:before {
             color: $brand-secondary;
@@ -29,6 +30,7 @@ $timeline-carousel__top-space: 11px;
             font-family: "Font Awesome 5 Free", sans-serif;
             font-weight: 900;
             font-size: $font-size-lg;
+            line-height: 0.8rem;
         }
     }
 
@@ -38,6 +40,11 @@ $timeline-carousel__top-space: 11px;
 
     .slick-next:before {
         content: '\f105'; // angle-right
+    }
+
+    .slick-prev:hover,
+    .slick-next:hover {
+        background-color: $body-bg;
     }
 }
 
@@ -78,6 +85,7 @@ $timeline-carousel__top-space: 11px;
 //slick overwrites
 .slick-slide {
     margin: 0 3*$spacer;
+    min-width: 275px;
 
     :focus {
         outline: none;
@@ -102,7 +110,7 @@ $timeline-carousel__top-space: 11px;
 }
 
 //mobile
-@media screen and (max-width: $breakpoint-md-down) {
+@media screen and (max-width: $breakpoint-lg-down) {
     .slick-next {
         right: 0 !important;
     }

--- a/meinberlin/assets/scss/components/_timeline-carousel.scss
+++ b/meinberlin/assets/scss/components/_timeline-carousel.scss
@@ -8,46 +8,6 @@ $timeline-carousel__top-space: 11px;
     }
 }
 
-.timeline-carousel {
-    position: relative;
-    color: $brand-secondary;
-    text-align: center;
-    margin: $spacer 0;
-
-    //slick overwrites - nested for specificity
-    .slick-prev,
-    .slick-next {
-        top: $timeline-carousel__top-space;
-        text-align: center;
-        border-radius: 100%;
-        border: 1px solid $border-color;
-        background-color: $body-bg;
-        z-index: 1; //for when tile links overlap
-
-        &:before {
-            color: $brand-secondary;
-            opacity: 1;
-            font-family: "Font Awesome 5 Free", sans-serif;
-            font-weight: 900;
-            font-size: $font-size-lg;
-            line-height: 0.8rem;
-        }
-    }
-
-    .slick-prev:before {
-        content: '\f104'; // angle-left
-    }
-
-    .slick-next:before {
-        content: '\f105'; // angle-right
-    }
-
-    .slick-prev:hover,
-    .slick-next:hover {
-        background-color: $body-bg;
-    }
-}
-
 .timeline-carousel__dot {
     display: inline-block;
     background-color: $border-color;
@@ -67,11 +27,8 @@ $timeline-carousel__top-space: 11px;
     color: $brand-secondary;
     background-color: $blue-light;
     text-align: left;
-}
-
-.timeline-carousel__dot:hover,
-.timeline-carousel__dot:focus {
-    transform: scale(1.25);
+    transition: transform 0.2s;
+    transform-origin: 50% 50%;
 }
 
 .timeline-carousel__line {
@@ -87,12 +44,57 @@ $timeline-carousel__top-space: 11px;
     margin: 0 3*$spacer;
     min-width: 275px;
 
-    :focus {
+    :focus,
+    :hover {
         outline: none;
 
-        .timeline-carousel__label {
-            color: $link-color-btn;
+        .timeline-carousel__dot {
+            transform: scale(1.25);
         }
+
+        .timeline-carousel__label {
+            transform: scale(1.05);
+        }
+    }
+}
+
+.timeline-carousel {
+    position: relative;
+    color: $brand-secondary;
+    text-align: center;
+    margin: $spacer 0;
+
+    //slick overwrites - nested for specificity
+    .slick-prev,
+    .slick-next {
+        top: $timeline-carousel__top-space;
+        text-align: center;
+        border-radius: 100%;
+        border: 1px solid $border-color;
+        background-color: $body-bg;
+        z-index: 1; //for when tile links overlap
+
+        &:hover,
+        :focus {
+            background-color: $body-bg;
+        }
+
+        &:before {
+            color: $brand-secondary;
+            opacity: 1;
+            font-family: "Font Awesome 5 Free", sans-serif;
+            font-weight: 900;
+            font-size: $font-size-lg;
+            line-height: 0.8rem;
+        }
+    }
+
+    .slick-prev:before {
+        content: '\f104'; // angle-left
+    }
+
+    .slick-next:before {
+        content: '\f105'; // angle-right
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "select2": "4.0.7",
     "shariff": "3.2.1",
     "shpjs": "3.4.3",
-    "slick-carousel": "1.8.1",
+    "slick-carousel": "github:liqd/slick#pm-2019-07-overwrites",
     "style-loader": "0.23.1",
     "terser-webpack-plugin": "1.3.0",
     "tether": "1.4.6",


### PR DESCRIPTION
can currently tab through all the slides, it's not perfect as previous slides remain off screen but I think it's fine as they will be read out, and arrow has a previous aria label on so should make sense.