### PR TITLE
timeline arrows: reducing tiels shown to 1 so arrows always visible

### DIFF
--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -100,26 +100,7 @@ $(document).ready(function(){
     mobileFirst: true,
     infinite: false,
     variableWidth: true,
-    responsive: [
-      {
-        breakpoint: 0,
-        settings: {
-          slidesToShow: 1,
-          slidesToScroll: 1,
-        }
-      },
-      {
-        breakpoint: 512,
-        settings: {
-          slidesToShow: 2,
-        }
-      },
-      {
-        breakpoint: 800,
-        settings: {
-          slidesToShow: 3,
-        }
-      },
-    ]
+    slidesToShow: 1,
+    slidesToScroll: 1
     })
 })


### PR DESCRIPTION
tested on different browser sizes and seems to work