### PR TITLE
apps/projects/modules: move module/timeline logic to mixin

### DIFF
--- a/meinberlin/apps/contrib/mixins.py
+++ b/meinberlin/apps/contrib/mixins.py
@@ -3,10 +3,10 @@ from django.db.models import Max
 from django.db.models import Min
 from django.db.models import Q
 from django.urls import resolve
+from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
-
-from adhocracy4.modules.models import Module
 
 RIGHT_OF_USE_LABEL = _('I hereby confirm that the copyrights for this '
                        'photo are with me or that I have received '
@@ -71,6 +71,8 @@ class ModuleClusterMixin:
 
     def _get_module_dict(self, count, start_date, end_date):
         return {
+            'title': _('{}. Online Participation').format(str(count)),
+            'type': 'module',
             'count': count,
             'date': start_date,
             'end_date': end_date,
@@ -116,32 +118,93 @@ class ModuleClusterMixin:
 class DisplayProjectOrModuleMixin(generic.base.ContextMixin,
                                   ModuleClusterMixin):
 
-    def module_clusters(self, modules):
-        return super().get_module_clusters(modules)
+    @cached_property
+    def module_clusters(self):
+        return super().get_module_clusters(self.modules)
 
-    @property
+    @cached_property
     def url_name(self):
         return resolve(self.request.path_info).url_name
 
-    @property
-    def other_modules(self):
-        modules = Module.objects.filter(project=self.project)\
+    @cached_property
+    def modules(self):
+        return self.project.modules\
             .annotate(start_date=Min('phase__start_date'))\
             .annotate(end_date=Max('phase__end_date'))\
+            .exclude(Q(start_date=None) | Q(end_date=None))\
             .order_by('start_date')
 
-        for cluster in self.module_clusters(modules):
+    @cached_property
+    def events(self):
+        return self.project.offlineevent_set.all()
+
+    @cached_property
+    def full_list(self):
+        module_cluster = self.module_clusters
+        event_list = self.get_events_list()
+        full_list = module_cluster + list(event_list)
+        return sorted(full_list, key=lambda k: k['date'])
+
+    @cached_property
+    def other_modules(self):
+        for cluster in self.module_clusters(self.modules):
             if self.module in cluster['modules']:
                 idx = cluster['modules'].index(self.module)
                 modules = cluster['modules']
                 return modules, idx
         return []
 
-    @property
+    @cached_property
     def extends(self):
         if self.url_name == 'module-detail':
             return 'a4modules/module_detail.html'
         return 'meinberlin_projects/project_detail.html'
+
+    @cached_property
+    def display_timeline(self):
+        return len(self.full_list) > 1
+
+    @cached_property
+    def initial_slide(self):
+        initial_slide = self.request.GET.get('initialSlide')
+        if initial_slide:
+            return int(initial_slide)
+        else:
+            now = timezone.now()
+            for idx, val in enumerate(self.full_list):
+                if 'type' in val and val['type'] == 'module':
+                    start_date = val['date']
+                    end_date = val['end_date']
+                    if start_date and end_date:
+                        if now >= start_date and now <= end_date:
+                            return idx
+        return 0
+
+    def get_current_event(self):
+        fl = self.full_list
+        idx = self.initial_slide
+        try:
+            current_dict = fl[idx]
+            if 'type' not in current_dict:
+                return self.full_list[self.initial_slide]
+        except (IndexError, KeyError):
+            return []
+        return []
+
+    def get_current_modules(self):
+        fl = self.full_list
+        idx = self.initial_slide
+        try:
+            current_dict = fl[idx]
+            if current_dict['type'] == 'module':
+                return self.full_list[self.initial_slide]['modules']
+        except (IndexError, KeyError):
+            return []
+
+    def get_events_list(self):
+        return self.events.values('date', 'name',
+                                  'event_type',
+                                  'slug', 'description')
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -163,4 +226,9 @@ class DisplayProjectOrModuleMixin(generic.base.ContextMixin,
             context['index'] = idx + 1
             context['next'] = next_module
             context['previous'] = previous_module
+        else:
+            context['event'] = self.get_current_event()
+            context['modules'] = self.get_current_modules()
+            context['participation_dates'] = self.full_list
+            context['initial_slide'] = self.initial_slide
         return context

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -154,7 +154,6 @@
     role="tabpanel"
     aria-labelledby="tab-project-{{ project.pk }}-participation"
     aria-expanded="true">
-
         <div class="l-wrapper">
             <div class="timeline-carousel__wrapper">
             {% if view.display_timeline %}


### PR DESCRIPTION
The offlineevent-check is still missing, but we can add that before moving it to a4.

fixes #2349 