### PR TITLE
 ci: Some linting improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,11 @@ lint:
 	$(VIRTUAL_ENV)/bin/isort --diff -rc -c $(SOURCE_DIRS) ||  EXIT_STATUS=$$?; \
 	$(VIRTUAL_ENV)/bin/flake8 $(SOURCE_DIRS) --exclude migrations,settings ||  EXIT_STATUS=$$?; \
 	npm run lint ||  EXIT_STATUS=$$?; \
+	exit $${EXIT_STATUS}
+
+.PHONY: check-migrations
+check-migrations:
+	EXIT_STATUS=0; \
 	$(VIRTUAL_ENV)/bin/python manage.py makemigrations --dry-run --check --noinput || EXIT_STATUS=$$?; \
 	exit $${EXIT_STATUS}
 

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -12,7 +12,7 @@ var Shariff = window.Shariff
 require('bootstrap')
 
 require('slick-carousel')
-require("slick-carousel/slick/slick.css")
+require('slick-carousel/slick/slick.css')
 
 var django = require('django')
 
@@ -83,14 +83,13 @@ $(document).on('click', function () {
   $('.collapse').collapse('hide')
 })
 
-//carousel
-$(document).ready(function(){
-
-  function getInitialSlide() {
-    return parseInt($("#timeline-carousel").attr("data-initial-slide"))
+// carousel
+$(document).ready(function () {
+  function getInitialSlide () {
+    return parseInt($('#timeline-carousel').attr('data-initial-slide'))
   }
 
-  $(".timeline-carousel__item").slick({
+  $('.timeline-carousel__item').slick({
     initialSlide: getInitialSlide(),
     focusOnSelect: false,
     centerMode: true,
@@ -102,5 +101,5 @@ $(document).ready(function(){
     variableWidth: true,
     slidesToShow: 1,
     slidesToScroll: 1
-    })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -82,12 +82,12 @@
     "build:prod": "webpack --config webpack.prod.js --mode production",
     "build": "webpack --config webpack.dev.js --mode development",
     "watch": "webpack --config webpack.dev.js --watch --mode development",
-    "lint": "eslint 'meinberlin/apps/**/*.{js,jsx}' && stylelint 'meinberlin/assets/scss/**/*.scss' --syntax scss"
+    "lint": "eslint meinberlin/apps meinberlin/assets --ext .js,.jsx && stylelint 'meinberlin/assets/scss/**/*.scss' --syntax scss"
   },
   "browserslist": "last 3 versions, ie >= 11",
   "husky": {
     "hooks": {
-      "pre-commit": "make lint"
+      "pre-commit": "make lint && make check-migrations"
     }
   }
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,5 @@
 const webpack = require('webpack')
 const path = require('path')
-const autoprefixer = require('autoprefixer')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 


### PR DESCRIPTION
Lets also lint `meinberlin/assets`. And make `make lint` not check for migrations.