### PR TITLE
apps/plans: Remember closing the infobox on sticky map - take two

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,10 @@
 {
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "jquery": true
+  },
   "extends": [
     "standard",
     "standard-jsx",

--- a/meinberlin/apps/contrib/static/js/ajax_modal.js
+++ b/meinberlin/apps/contrib/static/js/ajax_modal.js
@@ -1,4 +1,4 @@
-/* globals $ django */
+/* globals django */
 $(function () {
   var modalHTML = (
     '<div class="modal" tabindex="-1" role="dialog">' +

--- a/meinberlin/apps/contrib/static/js/unload_warning.js
+++ b/meinberlin/apps/contrib/static/js/unload_warning.js
@@ -1,4 +1,4 @@
-/* global $ CKEDITOR django */
+/* global CKEDITOR django */
 
 $(function () {
   var submitted = false

--- a/meinberlin/apps/plans/assets/ListMapBox.jsx
+++ b/meinberlin/apps/plans/assets/ListMapBox.jsx
@@ -1,11 +1,10 @@
-/* global history */
 /* global django */
 import StickyBox from 'react-sticky-box'
-const React = require('react')
-let PlansList = require('./PlansList')
-let PlansMap = require('./PlansMap')
-let FilterNav = require('./FilterNav')
-let Toggles = require('./Toggles')
+import React, { Component } from 'react'
+import PlansList from './PlansList'
+import PlansMap from './PlansMap'
+import FilterNav from './FilterNav'
+import Toggles from './Toggles'
 
 const breakpointXS = 512
 const breakpointMD = 1024
@@ -27,7 +26,7 @@ const statusNames = [
   django.gettext('done')
 ]
 
-class ListMapBox extends React.Component {
+class ListMapBox extends Component {
   constructor (props) {
     super(props)
 
@@ -402,4 +401,4 @@ class ListMapBox extends React.Component {
   }
 }
 
-module.exports = ListMapBox
+export default ListMapBox

--- a/meinberlin/apps/plans/assets/PlansMap.jsx
+++ b/meinberlin/apps/plans/assets/PlansMap.jsx
@@ -1,6 +1,7 @@
 /* global django */
 import { renderToString } from 'react-dom/server'
 import React, { Component } from 'react'
+import { withCookies } from 'react-cookie'
 import PopUp from './PopUp'
 import { createMap } from 'a4maps_common'
 import 'leaflet.markercluster'
@@ -42,14 +43,15 @@ class PlansMap extends Component {
   constructor (props) {
     super(props)
 
+    let showInfoBox = !this.props.cookies.get('plansMapHideInfoBox')
     this.state = {
       searchResults: null,
       address: null,
       selected: null,
       displayError: false,
       displayResults: false,
-      showInfoBox: true,
-      showInfoBoxUser: true,
+      showInfoBox: showInfoBox,
+      showInfoBoxUser: showInfoBox,
       filters: {
         status: -1,
         participation: -1,
@@ -236,6 +238,7 @@ class PlansMap extends Component {
       { 'showInfoBox': false,
         'showInfoBoxUser': false }
     )
+    this.props.cookies.set('plansMapHideInfoBox', 1, { path: '/' })
   }
 
   render () {
@@ -290,4 +293,4 @@ class PlansMap extends Component {
   }
 }
 
-module.exports = PlansMap
+export default withCookies(PlansMap)

--- a/meinberlin/apps/plans/assets/plans_map.jsx
+++ b/meinberlin/apps/plans/assets/plans_map.jsx
@@ -1,7 +1,7 @@
-const React = require('react')
-const ReactDOM = require('react-dom')
-const $ = require('jquery')
-var ListMapBox = require('./ListMapBox')
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { CookiesProvider } from 'react-cookie'
+import ListMapBox from './ListMapBox'
 
 const init = function () {
   $('[data-map="plans"]').each(function (i, element) {
@@ -18,20 +18,25 @@ const init = function () {
     let mapboxToken = element.getAttribute('data-mapbox-token')
     let omtToken = element.getAttribute('data-omt-token')
     let useVectorMap = element.getAttribute('data-use_vector_map')
-    ReactDOM.render(<ListMapBox
-      selectedDistrict={selectedDistrict}
-      selectedTopic={selectedTopic}
-      initialitems={items}
-      attribution={attribution}
-      baseurl={baseurl}
-      mapboxToken={mapboxToken}
-      omtToken={omtToken}
-      useVectorMap={useVectorMap}
-      bounds={bounds}
-      organisations={organisations}
-      districts={districts}
-      districtnames={districtnames}
-      topicChoices={topicChoices} />, element)
+    ReactDOM.render(
+      <CookiesProvider>
+        <ListMapBox
+          selectedDistrict={selectedDistrict}
+          selectedTopic={selectedTopic}
+          initialitems={items}
+          attribution={attribution}
+          baseurl={baseurl}
+          mapboxToken={mapboxToken}
+          omtToken={omtToken}
+          useVectorMap={useVectorMap}
+          bounds={bounds}
+          organisations={organisations}
+          districts={districts}
+          districtnames={districtnames}
+          topicChoices={topicChoices}
+        />
+      </CookiesProvider>,
+      element)
   })
 }
 

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -1,5 +1,4 @@
 /* eslint no-unused-vars: "off", no-new: "off" */
-/* global location */
 
 // make jquery available for non-webpack js
 var $ = window.jQuery = window.$ = require('jquery')

--- a/meinberlin/assets/js/embed.js
+++ b/meinberlin/assets/js/embed.js
@@ -1,4 +1,4 @@
-/* global $ location django */
+/* global django */
 
 $(document).ready(function () {
   var $main = $('main')

--- a/meinberlin/assets/js/map-address.js
+++ b/meinberlin/assets/js/map-address.js
@@ -1,4 +1,4 @@
-/* global $,django */
+/* global django */
 
 var apiUrl = 'https://bplan-prod.liqd.net/api/addresses/'
 

--- a/meinberlin/assets/js/popup-close.js
+++ b/meinberlin/assets/js/popup-close.js
@@ -1,5 +1,3 @@
-/* global location */
-
 // if this page was opened from an embed for login, notify it about success
 if (window.opener) {
   window.opener.postMessage(

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "postcss-loader": "3.0.0",
     "react": "16.8.6",
     "react-bootstrap-typeahead": "3.4.6",
+    "react-cookie": "4.0.0",
     "react-dom": "16.8.6",
     "react-flip-move": "3.0.3",
     "react-sticky-box": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "copy-webpack-plugin": "5.0.3",
     "css-loader": "3.0.0",
     "datepicker": "git+https://github.com/liqd/datePicker.git",
+    "es6-promise": "4.2.8",
     "feature-detect": "1.0.0",
     "file-loader": "4.0.0",
     "file-saver": "2.0.2",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -147,7 +147,8 @@ module.exports = {
     new webpack.ProvidePlugin({
       timeago: 'timeago.js',
       $: 'jquery',
-      jQuery: 'jquery'
+      jQuery: 'jquery',
+      Promise: ['es6-promise', 'Promise']
     }),
     new webpack.optimize.SplitChunksPlugin({
       name: 'vendor',


### PR DESCRIPTION
Revert the revert and fix what's broken. Apparently it was broken by a react update - they choose to require some ES6 functionality now. So add ES6 promise package (again?) and properly provide it via webpack.

Now works fine again on IE11