### PR TITLE
Ka 2019 08 make sure project list not used anymore

### DIFF
--- a/meinberlin/apps/contrib/sitemaps/static_sitemap.py
+++ b/meinberlin/apps/contrib/sitemaps/static_sitemap.py
@@ -7,7 +7,7 @@ class StaticSitemap(Sitemap):
     priority = 0.8
 
     def items(self):
-        return ["project-list"]
+        return ["plan-list"]
 
     def location(self, obj):
         return reverse(obj)

--- a/meinberlin/apps/organisations/models.py
+++ b/meinberlin/apps/organisations/models.py
@@ -43,8 +43,4 @@ class Organisation(models.Model):
         return user in self.initiators.all()
 
     def get_absolute_url(self):
-        from django.utils.http import urlencode
-        return '%s?%s' % (
-            reverse('project-list'),
-            urlencode({'organisation': self.pk})
-        )
+        return reverse('plan-list')

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -33,7 +33,7 @@
                 </div>
                 {% endif %}
                 <div class="participation-tile__spacer"></div>
-                {% if not module.module_has_finished %}
+                {% if module.module_running_time_left %}
                 <div class="participation-tile__btn">
                     <a class="btn btn--full btn--small" href="{% url 'module-detail' module.slug %}">{% trans 'Join now' %}</a>
                 </div>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.0.0",
     "@fortawesome/fontawesome-free": "5.10.1",
     "acorn": "6.2.1",
-    "adhocracy4": "liqd/adhocracy4#mB-v2.2",
+    "adhocracy4": "liqd/adhocracy4#mB-v2.2.2",
     "autoprefixer": "9.6.1",
     "babel-loader": "8.0.6",
     "bootstrap": "4.3.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@mB-v2.2#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@mB-v2.2.2#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.1.7


### PR DESCRIPTION
Should fix this: https://sentry.liqd.net/sentry/meinberlin-prod/issues/815/
And the issue with the index @MagdaN found yesterday: https://github.com/liqd/adhocracy4/pull/373