### PR TITLE
notification issues: use right links to events and modules

### DIFF
--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.de.email
@@ -17,4 +17,4 @@ Möchten Sie antworten?{% endblock %}
 {% block cta_url %}{% if action.target.get_absolute_url %}{{ email.get_host }}{{ action.target.get_absolute_url }}{% else %}{{ email.get_host }}{{ action.project.get_absolute_url }}{% endif %}{% endblock %}
 {% block cta_label %}{% if action.target.get_absolute_url %}Beitrag anzeigen{% else %}Projekt anzeigen{% endif %}{% endblock %}
 
-{% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie oben genanntem Projekt folgen. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, entfolgen Sie dem <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">Projekt</a> oder ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Account</a>.{% endblock %}
+{% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie einen Beitrag in einem Projekt erstellt haben. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.en.email
@@ -17,4 +17,4 @@ Would you like to answer?{% endblock %}
 {% block cta_url %}{% if action.target.get_absolute_url %}{{ email.get_host }}{{ action.target.get_absolute_url }}{% else %}{{ email.get_host }}{{ action.project.get_absolute_url }}{% endif %}{% endblock %}
 {% block cta_label %}{% if action.target.get_absolute_url %}View Post{% else %}Visit the project{% endif %}{% endblock %}
 
-{% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you are following the above project. If you no longer want to receive notifications, unsubscribe from the <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">project</a> or change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}
+{% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you added a contribution to the above project. If you no longer want to receive notifications, change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator_on_moderator_feedback.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator_on_moderator_feedback.de.email
@@ -23,4 +23,4 @@ Möchten Sie antworten?
 {% block cta_url %}{% if object.get_absolute_url %}{{ email.get_host }}{{ object.get_absolute_url }}{% else %}{{ email.get_host }}{{ object.project.get_absolute_url }}{% endif %}{% endblock %}
 {% block cta_label %}{% if object.get_absolute_url %}Beitrag anzeigen{% else %}Projekt anzeigen{% endif %}{% endblock %}
 
-{% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie oben genanntem Projekt folgen. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, entfolgen Sie dem <a href="{{ email.get_host }}{{ object.project.get_absolute_url }}">Projekt</a> oder ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Account</a>.{% endblock %}
+{% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie einen Beitrag in einem Projekt erstellt haben. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator_on_moderator_feedback.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator_on_moderator_feedback.en.email
@@ -23,4 +23,4 @@ Do you want to answer?
 {% if object.get_absolute_url %}{{ email.get_host }}{{ object.get_absolute_url }}{% else %}{{ email.get_host }}{{ object.project.get_absolute_url }}{% endif %}{% endblock %}
 {% block cta_label %}{% if object.get_absolute_url %}Check your contribution{% else %}Visit the project{% endif %}{% endblock %}
 
-{% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you are following the above project. If you no longer want to receive notifications, unsubscribe from the <a href="{{ email.get_host }}{{ object.project.get_absolute_url }}">project</a> or change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}
+{% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you added a contribution to the above project. If you no longer want to receive notifications, change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.de.email
@@ -13,7 +13,7 @@
 
 Weitere Informationen zu der Veranstaltung finden Sie im Projekt.{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.event.get_absolute_url }}{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.get_absolute_url }}{% endblock %}
 {% block cta_label %}Veranstaltung anzeigen{% endblock %}
 
 {% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie oben genanntem Projekt folgen. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, entfolgen Sie dem <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">Projekt</a> oder ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.de.email
@@ -1,14 +1,16 @@
 {% extends 'email_base.'|add:part_type %}
 
-{% block subject %}{{ action.project.name }} startet jetzt!{% endblock %}
+{% block subject %}Einladung zu einer Veranstaltung im Projekt {{ action.project.name }}{% endblock %}
 
-{% block headline %}Verstaltung{% endblock %}
+{% block headline %}Veranstaltung{% endblock %}
 {% block sub-headline %}{{ action.project.name }}{% endblock %}
 
 {% block greeting %}Hallo {{ receiver.username }},{% endblock %}
 
-{% block content %}am {{ action.obj.date }} findet die folgende Veranstaltung statt:
+{% block content %}am {{ action.obj.date }} Uhr findet die folgende Veranstaltung statt:
+
 <b>{{ action.obj.name }}</b>
+
 Weitere Informationen zu der Veranstaltung finden Sie im Projekt.{% endblock %}
 
 {% block cta_url %}{{ email.get_host }}{{ action.obj.module.event.get_absolute_url }}{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.en.email
@@ -1,6 +1,6 @@
 {% extends 'email_base.'|add:part_type %}
 
-{% block subject %}{{ action.project.name }} new event!{% endblock %}
+{% block subject %}Invitation to an event in project {{ action.project.name }}{% endblock %}
 
 {% block headline %}Event{% endblock %}
 {% block sub-headline %}{{ action.project.name }}{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_event_upcomming.en.email
@@ -11,7 +11,7 @@
 <b>{{ action.obj.name }}</b>
 Further information about the event can be found in the project.{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.event.get_absolute_url }}{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.get_absolute_url }}{% endblock %}
 {% block cta_label %}Show Event{% endblock %}
 
 {% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you are following the above project. If you no longer want to receive notifications, unsubscribe from the <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">project</a> or change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_over_soon.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_over_soon.de.email
@@ -8,9 +8,10 @@
 {% block greeting %}Hallo {{ receiver.username }},{% endblock %}
 
 {% block content %}die Online-Beteiligung im oben genannten Projekt endet bald.
+
 <b>Sie können noch bis zum {{ action.obj.end_date }} Uhr daran teilnehmen.</b>{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_absolute_url }}{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_detail_url }}{% endblock %}
 {% block cta_label %}Jetzt mitmachen{% endblock %}
 
 {% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie oben genanntem Projekt folgen. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, entfolgen Sie dem <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">Projekt</a> oder ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_over_soon.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_over_soon.en.email
@@ -8,9 +8,10 @@
 {% block greeting %}Hello {{ receiver.username }},{% endblock %}
 
 {% block content %}the online participation in the above mentioned project will end soon.
+
 <b>You can still participate until {{ action.obj.end_date }}.</b>{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_absolute_url }}{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_detail_url }}{% endblock %}
 {% block cta_label %}Join now{% endblock %}
 
 {% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you are following the above project. If you no longer want to receive notifications, unsubscribe from the <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">project</a> or change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_started.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_started.de.email
@@ -1,6 +1,6 @@
 {% extends 'email_base.'|add:part_type %}
 
-{% block subject %}{{ action.project.name }} startet jetzt!{% endblock %}
+{% block subject %}Los geht's: {{ action.project.name }} startet jetzt!{% endblock %}
 
 {% block headline %}Los geht’s!{% endblock %}
 {% block sub-headline %}{{ action.project.name }}{% endblock %}
@@ -8,9 +8,10 @@
 {% block greeting %}Hallo {{ receiver.username }},{% endblock %}
 
 {% block content %}die Online-Beteiligung im oben genannten Projekt hat begonnen.
+
 <b>Sie können bis zum {{ action.obj.end_date }} Uhr daran teilnehmen.</b>{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_absolute_url }}{% endblock %}
-{% block cta_label %}Join now{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_detail_url }}{% endblock %}
+{% block cta_label %}Jetzt mitmachen{% endblock %}
 
 {% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie oben genanntem Projekt folgen. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, entfolgen Sie dem <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">Projekt</a> oder ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Account</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_started.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_followers_phase_started.en.email
@@ -1,6 +1,6 @@
 {% extends 'email_base.'|add:part_type %}
 
-{% block subject %}{{ action.project.name }} startet jetzt!{% endblock %}
+{% block subject %}Here we go: {{ action.project.name }} starts now!{% endblock %}
 
 {% block headline %}Here we go!{% endblock %}
 {% block sub-headline %}{{ action.project.name }}{% endblock %}
@@ -8,9 +8,10 @@
 {% block greeting %}Hello {{ receiver.username }},{% endblock %}
 
 {% block content %}Online participation for the above project has started.
+
 <b>You can participate untill {{ action.obj.end_date }}.</b>{% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_absolute_url }}{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ action.obj.module.get_detail_url }}{% endblock %}
 {% block cta_label %}Join now{% endblock %}
 
 {% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you are following the above project. If you no longer want to receive notifications, unsubscribe from the <a href="{{ email.get_host }}{{ action.project.get_absolute_url }}">project</a> or change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}

--- a/meinberlin/templates/email_base.html
+++ b/meinberlin/templates/email_base.html
@@ -52,12 +52,6 @@
                     <td style="color: #818181; font-size: x-small; padding-top: 20px;">
                         <hr />
                         {% block reason %}
-                        <a href="{% block account_url %}{% endblock %}">
-                            {% block account_label %}{% endblock %}
-                        </a>
-                        <a href="{% block project_url %}{% endblock %}">
-                            {% block project_label %}{% endblock %}
-                        </a>
                         {% endblock %}
                     </td>
                 </tr>

--- a/tests/offlineevents/test_views_integration.py
+++ b/tests/offlineevents/test_views_integration.py
@@ -8,4 +8,4 @@ def test_detail_view(client, offline_event):
     url = offline_event.get_absolute_url()
     response = client.get(url)
     assert_template_response(
-        response, 'meinberlin_offlineevents/offlineevent_detail.html')
+        response, 'meinberlin_projects/project_detail.html')


### PR DESCRIPTION
- templates: remove unused blocks from email base
- use right wording in reason of notify creator emails
- fixes #2546 
- fixes #2548 
- fixes #2547 