### PR TITLE
dashboard: make separate lists for participation projects, external projects, and bplans

### DIFF
--- a/meinberlin/apps/bplan/phases.py
+++ b/meinberlin/apps/bplan/phases.py
@@ -1,16 +1,44 @@
+from django.http.response import HttpResponseRedirect
+from django.urls import reverse
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
+from django.views import generic
 
 from adhocracy4 import phases
+from adhocracy4.projects.mixins import ProjectMixin
+from adhocracy4.rules import mixins as rules_mixins
 
 from . import apps
+from . import forms
 from . import models
-from . import views
+
+
+class BplanStatementFormView(ProjectMixin,
+                             rules_mixins.PermissionRequiredMixin,
+                             generic.CreateView):
+    model = models.Statement
+    form_class = forms.StatementForm
+    permission_required = 'meinberlin_bplan.add_statement'
+    template_name = 'meinberlin_bplan/statement_create_form.html'
+    success_url = reverse_lazy('meinberlin_bplan:statement-sent')
+
+    def dispatch(self, request, *args, **kwargs):
+        if self.project.has_finished:
+            return HttpResponseRedirect(reverse('meinberlin_bplan:finished'))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_permission_object(self, *args, **kwargs):
+        return self.module
+
+    def form_valid(self, form):
+        form.instance.module = self.module
+        return super().form_valid(form)
 
 
 class StatementPhase(phases.PhaseContent):
     app = apps.Config.label
     phase = 'statement'
-    view = views.BplanStatementFormView
+    view = BplanStatementFormView
 
     name = _('Statement phase')
     description = _('Send statement to the office workers per mail.')

--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/dashboard_bplan_list.html
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/dashboard_bplan_list.html
@@ -1,0 +1,34 @@
+{% extends "a4dashboard/base_project_list.html" %}
+{% load i18n rules %}
+
+{% block title %}{% trans "Development plans" %} &mdash; {{ block.super }}{% endblock%}
+
+{% block project_list %}
+    <div class="lr-bar lr-bar--with-margin">
+        <h1 class="lr-bar__left">
+            {% trans 'Development plans' %}
+        </h1>
+        <div class="lr-bar__right">
+            <a href="{% url 'a4dashboard:bplan-project-create' organisation_slug=view.organisation.slug %}" class="btn">
+                {% trans 'New Development plan' %}
+            </a>
+        </div>
+    </div>
+
+    {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
+
+    {% if bplan_list|length > 0 %}
+        <ul class="u-list-reset">
+            {% for bplan in bplan_list %}
+                {% has_perm 'a4projects.change_project' request.user bplan as can_change_project %}
+                {% if can_change_project %}
+                {% include "a4dashboard/includes/project_list_item.html" with project=bplan %}
+                {% endif %}
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>{% trans 'We could not find any development plans.' %}</p>
+    {% endif %}
+
+    {% include "meinberlin_contrib/includes/pagination.html" %}
+{% endblock %}

--- a/meinberlin/apps/bplan/views.py
+++ b/meinberlin/apps/bplan/views.py
@@ -6,6 +6,7 @@ from django.views.generic import TemplateView
 
 from adhocracy4.dashboard.components.forms.views import \
     ProjectComponentFormView
+from adhocracy4.dashboard.mixins import DashboardBaseMixin
 from adhocracy4.projects.mixins import ProjectMixin
 from adhocracy4.rules import mixins as rules_mixins
 from meinberlin.apps.extprojects.views import ExternalProjectCreateView
@@ -64,3 +65,20 @@ class BplanProjectUpdateView(ProjectComponentFormView):
 
     def get_object(self, queryset=None):
         return self.project
+
+
+class BplanProjectListView(DashboardBaseMixin,
+                           generic.ListView):
+    model = models.Bplan
+    paginate_by = 12
+    template_name = 'meinberlin_bplan/dashboard_bplan_list.html'
+    permission_required = 'a4projects.add_project'
+    menu_item = 'project'
+
+    def get_queryset(self):
+        return super().get_queryset().filter(
+            organisation=self.organisation
+        )
+
+    def get_permission_object(self):
+        return self.organisation

--- a/meinberlin/apps/bplan/views.py
+++ b/meinberlin/apps/bplan/views.py
@@ -1,40 +1,16 @@
-from django.http.response import HttpResponseRedirect
-from django.urls import reverse
-from django.urls import reverse_lazy
+from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from django.views.generic import TemplateView
 
+from adhocracy4.dashboard.blueprints import ProjectBlueprint
 from adhocracy4.dashboard.components.forms.views import \
     ProjectComponentFormView
 from adhocracy4.dashboard.mixins import DashboardBaseMixin
-from adhocracy4.projects.mixins import ProjectMixin
-from adhocracy4.rules import mixins as rules_mixins
+from meinberlin.apps.bplan import phases as bplan_phases
 from meinberlin.apps.extprojects.views import ExternalProjectCreateView
 
 from . import forms
 from . import models
-
-
-class BplanStatementFormView(ProjectMixin,
-                             rules_mixins.PermissionRequiredMixin,
-                             generic.CreateView):
-    model = models.Statement
-    form_class = forms.StatementForm
-    permission_required = 'meinberlin_bplan.add_statement'
-    template_name = 'meinberlin_bplan/statement_create_form.html'
-    success_url = reverse_lazy('meinberlin_bplan:statement-sent')
-
-    def dispatch(self, request, *args, **kwargs):
-        if self.project.has_finished:
-            return HttpResponseRedirect(reverse('meinberlin_bplan:finished'))
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_permission_object(self, *args, **kwargs):
-        return self.module
-
-    def form_valid(self, form):
-        form.instance.module = self.module
-        return super().form_valid(form)
 
 
 class BplanStatementSentView(TemplateView):
@@ -49,9 +25,20 @@ class BplanProjectCreateView(ExternalProjectCreateView):
 
     model = models.Bplan
     slug_url_kwarg = 'project_slug'
-    blueprint_key = 'bplan'
     form_class = forms.BplanProjectCreateForm
     template_name = 'meinberlin_extprojects/external_project_create_form.html'
+    success_message = _('Development plan successfully created.')
+
+    blueprint = ProjectBlueprint(
+        title=_('Development Plan'),
+        description=_('Create a statement formular for development plans'
+                      ' to be embedded on external sites.'),
+        content=[
+            bplan_phases.StatementPhase(),
+        ],
+        image='',
+        settings_model=None,
+    )
 
 
 class BplanProjectUpdateView(ProjectComponentFormView):

--- a/meinberlin/apps/dashboard/blueprints.py
+++ b/meinberlin/apps/dashboard/blueprints.py
@@ -1,10 +1,8 @@
 from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.dashboard.blueprints import ProjectBlueprint
-from meinberlin.apps.bplan import phases as bplan_phases
 from meinberlin.apps.budgeting import phases as budgeting_phases
 from meinberlin.apps.documents import phases as documents_phases
-from meinberlin.apps.extprojects import phases as extprojects_phases
 from meinberlin.apps.ideas import phases as ideas_phases
 from meinberlin.apps.kiezkasse import phases as kiezkasse_phases
 from meinberlin.apps.mapideas import phases as mapideas_phases
@@ -90,18 +88,6 @@ blueprints = [
          image='images/participatory-budgeting.svg',
          settings_model=('a4maps', 'AreaSettings'),
      )),
-    ('external-project',
-     ProjectBlueprint(
-         title=_('External project'),
-         description=_(
-             'External projects are handled on a different platform.'
-         ),
-         content=[
-             extprojects_phases.ExternalPhase(),
-         ],
-         image='images/external-project.svg',
-         settings_model=None,
-     )),
     ('poll',
      ProjectBlueprint(
          title=_('Poll'),
@@ -138,17 +124,6 @@ blueprints = [
          ],
          image='images/place-priotization.svg',
          settings_model=('a4maps', 'AreaSettings'),
-     )),
-    ('bplan',
-     ProjectBlueprint(
-         title=_('Development Plan'),
-         description=_('Create a statement formular for development plans'
-                       ' to be embedded on external sites.'),
-         content=[
-             bplan_phases.StatementPhase(),
-         ],
-         image='images/bplan.svg',
-         settings_model=None,
      )),
     ('kiezkasse',
      ProjectBlueprint(

--- a/meinberlin/apps/dashboard/urls.py
+++ b/meinberlin/apps/dashboard/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import url
 
 from adhocracy4.dashboard.urls import urlpatterns as a4dashboard_urlpatterns
-from meinberlin.apps.bplan.views import BplanProjectCreateView
-from meinberlin.apps.extprojects.views import ExternalProjectCreateView
+from meinberlin.apps.bplan import views as bplan_views
+from meinberlin.apps.extprojects import views as extproject_views
 from meinberlin.apps.newsletters import views as newsletter_views
 from meinberlin.apps.organisations import views as organisation_views
 from meinberlin.apps.plans import views as plan_views
@@ -22,6 +22,12 @@ urlpatterns = [
     url(r'^organisations/(?P<organisation_slug>[-\w_]+)/containers/$',
         container_views.ContainerListView.as_view(),
         name='container-list'),
+    url(r'^organisations/(?P<organisation_slug>[-\w_]+)/bplans/$',
+        bplan_views.BplanProjectListView.as_view(),
+        name='bplan-list'),
+    url(r'^organisations/(?P<organisation_slug>[-\w_]+)/external-projects/$',
+        extproject_views.ExternalProjectListView.as_view(),
+        name='extproject-list'),
     url(r'^organisations/(?P<organisation_slug>[-\w_]+)/plans/$',
         plan_views.DashboardPlanListView.as_view(),
         name='plan-list'),
@@ -56,11 +62,11 @@ urlpatterns = [
     # Overwrite adhocracy4 core urls with meinBerlin urls
     url(r'^organisations/(?P<organisation_slug>[-\w_]+)/blueprints/'
         r'external-project/$',
-        ExternalProjectCreateView.as_view(),
+        extproject_views.ExternalProjectCreateView.as_view(),
         name='external-project-create'),
     url(r'^organisations/(?P<organisation_slug>[-\w_]+)/blueprints/'
         r'bplan/$',
-        BplanProjectCreateView.as_view(),
+        bplan_views.BplanProjectCreateView.as_view(),
         name='bplan-project-create'),
     url(r'^organisations/(?P<organisation_slug>[-\w_]+)/blueprints/'
         r'container/$',

--- a/meinberlin/apps/dashboard/views.py
+++ b/meinberlin/apps/dashboard/views.py
@@ -188,7 +188,10 @@ class ModuleDeleteView(generic.DeleteView):
 
 class DashboardProjectListView(a4dashboard_views.ProjectListView):
     def get_queryset(self):
-        return super().get_queryset().filter(projectcontainer=None)
+        return super().get_queryset().filter(
+            projectcontainer=None,
+            externalproject=None
+        )
 
 
 class ProjectCreateView(mixins.DashboardBaseMixin,

--- a/meinberlin/apps/extprojects/phases.py
+++ b/meinberlin/apps/extprojects/phases.py
@@ -1,15 +1,28 @@
+from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
+from django.views import generic
 
 from adhocracy4 import phases
+from adhocracy4.projects.mixins import ProjectMixin
 
 from . import apps
-from . import views
+from . import models
+
+
+class ExternalProjectRedirectView(ProjectMixin,
+                                  generic.RedirectView):
+    permanent = True
+
+    def get_redirect_url(self, *args, **kwargs):
+        extproject = get_object_or_404(models.ExternalProject,
+                                       module=self.module)
+        return extproject.url
 
 
 class ExternalPhase(phases.PhaseContent):
     app = apps.Config.label
     phase = 'external'
-    view = views.ExternalProjectRedirectView
+    view = ExternalProjectRedirectView
 
     name = _('External phase')
     description = _('External phase.')

--- a/meinberlin/apps/extprojects/templates/meinberlin_extprojects/dashboard_extproject_list.html
+++ b/meinberlin/apps/extprojects/templates/meinberlin_extprojects/dashboard_extproject_list.html
@@ -1,0 +1,34 @@
+{% extends "a4dashboard/base_project_list.html" %}
+{% load i18n rules %}
+
+{% block title %}{% trans "Linkages" %} &mdash; {{ block.super }}{% endblock%}
+
+{% block project_list %}
+    <div class="lr-bar lr-bar--with-margin">
+        <h1 class="lr-bar__left">
+            {% trans 'Linkages' %}
+        </h1>
+        <div class="lr-bar__right">
+            <a href="{% url 'a4dashboard:external-project-create' organisation_slug=view.organisation.slug %}" class="btn">
+                {% trans 'New Linkage' %}
+            </a>
+        </div>
+    </div>
+
+    {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
+
+    {% if externalproject_list|length > 0 %}
+        <ul class="u-list-reset">
+            {% for linkage in externalproject_list %}
+                {% has_perm 'a4projects.change_project' request.user linkage as can_change_project %}
+                {% if can_change_project %}
+                {% include "a4dashboard/includes/project_list_item.html" with project=linkage %}
+                {% endif %}
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>{% trans 'We could not find any linkages.' %}</p>
+    {% endif %}
+
+    {% include "meinberlin_contrib/includes/pagination.html" %}
+{% endblock %}

--- a/meinberlin/apps/extprojects/templates/meinberlin_extprojects/external_project_create_form.html
+++ b/meinberlin/apps/extprojects/templates/meinberlin_extprojects/external_project_create_form.html
@@ -1,12 +1,12 @@
 {% extends "a4dashboard/base_dashboard.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Create project based on" %} {{ view.blueprint.title }} &mdash; {{ block.super }}{% endblock %}
+{% block title %}{% blocktrans with blueprint_title=view.blueprint.title %}Create {{ blueprint_title }}{% endblocktrans %} &mdash; {{ block.super }}{% endblock %}
 
 {% block dashboard_content %}
     <div class="l-menu">
         <div class="l-menu__content l-menu__content--aside">
-            <h1 class="u-first-heading">{% trans "Create project based on" %} {{ view.blueprint.title }}</h1>
+            <h1 class="u-first-heading">{% blocktrans with blueprint_title=view.blueprint.title %}Create {{ blueprint_title }}{% endblocktrans %}</h1>
 
             {% for error in form.non_field_errors %}
                 <span>{{ error }}</span>
@@ -26,7 +26,7 @@
 
                 <div class="u-spacer-bottom">
                     <input type="submit" class="btn btn--primary" name="send" value="{% trans 'Send' %}"/>
-                    <a href="{% url 'a4dashboard:blueprint-list' organisation_slug=view.organisation.slug %}"
+                    <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}"
                        class="btn btn--light">{% trans 'Cancel' %}</a>
                 </div>
             </form>

--- a/meinberlin/apps/extprojects/views.py
+++ b/meinberlin/apps/extprojects/views.py
@@ -1,36 +1,37 @@
-from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
+from adhocracy4.dashboard.blueprints import ProjectBlueprint
 from adhocracy4.dashboard.components.forms.views import \
     ProjectComponentFormView
 from adhocracy4.dashboard.mixins import DashboardBaseMixin
 from adhocracy4.dashboard.views import ProjectCreateView
-from adhocracy4.projects.mixins import ProjectMixin
+from meinberlin.apps.extprojects import phases as extprojects_phases
 
 from . import apps
 from . import forms
 from . import models
 
 
-class ExternalProjectRedirectView(ProjectMixin,
-                                  generic.RedirectView):
-    permanent = True
-
-    def get_redirect_url(self, *args, **kwargs):
-        extproject = get_object_or_404(models.ExternalProject,
-                                       module=self.module)
-        return extproject.url
-
-
 class ExternalProjectCreateView(ProjectCreateView):
 
     model = models.ExternalProject
     slug_url_kwarg = 'project_slug'
-    blueprint_key = 'external-project'
     form_class = forms.ExternalProjectCreateForm
     template_name = 'meinberlin_extprojects/external_project_create_form.html'
     success_message = _('External project successfully created.')
+
+    blueprint = ProjectBlueprint(
+        title=_('Linkage'),
+        description=_(
+            'Linkages are handled on a different platform.'
+        ),
+        content=[
+            extprojects_phases.ExternalPhase(),
+        ],
+        image='',
+        settings_model=None,
+    )
 
 
 class ExternalProjectUpdateView(ProjectComponentFormView):

--- a/meinberlin/apps/extprojects/views.py
+++ b/meinberlin/apps/extprojects/views.py
@@ -1,11 +1,14 @@
 from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
 from adhocracy4.dashboard.components.forms.views import \
     ProjectComponentFormView
+from adhocracy4.dashboard.mixins import DashboardBaseMixin
 from adhocracy4.dashboard.views import ProjectCreateView
 from adhocracy4.projects.mixins import ProjectMixin
 
+from . import apps
 from . import forms
 from . import models
 
@@ -27,6 +30,7 @@ class ExternalProjectCreateView(ProjectCreateView):
     blueprint_key = 'external-project'
     form_class = forms.ExternalProjectCreateForm
     template_name = 'meinberlin_extprojects/external_project_create_form.html'
+    success_message = _('External project successfully created.')
 
 
 class ExternalProjectUpdateView(ProjectComponentFormView):
@@ -40,3 +44,25 @@ class ExternalProjectUpdateView(ProjectComponentFormView):
 
     def get_object(self, queryset=None):
         return self.project
+
+
+class ExternalProjectListView(DashboardBaseMixin,
+                              generic.ListView):
+    model = models.ExternalProject
+    paginate_by = 12
+    template_name = 'meinberlin_extprojects/dashboard_extproject_list.html'
+    permission_required = 'a4projects.add_project'
+    menu_item = 'project'
+
+    def get_queryset(self):
+        project_type = '{}.{}'.format(
+            apps.Config.label,
+            'ExternalProject'
+        )
+        return super().get_queryset().filter(
+            organisation=self.organisation,
+            project_type=project_type
+        )
+
+    def get_permission_object(self):
+        return self.organisation

--- a/meinberlin/templates/a4dashboard/base_project_list.html
+++ b/meinberlin/templates/a4dashboard/base_project_list.html
@@ -7,13 +7,19 @@
     <nav class="l-menu__menu" aria-label="{% trans 'Participation projects' %}">
         <div class="dashboard-nav">
             <div class="dashboard-nav__dropdown">
-                <div class="dashboard-nav__item">{% trans "Overview" %}</div>
+                <div class="dashboard-nav__item">{% trans "Projects" %}</div>
             </div>
             <ul class="dashboard-nav__pages">
                 <li class="dashboard-nav__page">
                     <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}"
                         class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == 'project-list' %}is-active{% endif %}">
                         {% trans "Participation projects" %}
+                    </a>
+                </li>
+                <li class="dashboard-nav__page">
+                    <a href="{% url 'a4dashboard:bplan-list' organisation_slug=view.organisation.slug %}"
+                        class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == 'bplan-list' %}is-active{% endif %}">
+                        {% trans "Development plans" %}
                     </a>
                 </li>
                 <li class="dashboard-nav__page">
@@ -24,8 +30,14 @@
                 </li>
                 <li class="dashboard-nav__page">
                     <a href="{% url 'a4dashboard:plan-list' organisation_slug=view.organisation.slug %}"
-                       class="dashboard-nav__item dashboard-nav__item--interactive {% if 'plan-' in request.resolver_match.url_name %}is-active{% endif %}">
+                       class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == 'plan-list' %}is-active{% endif %}">
                         {% trans "Plans" %}
+                    </a>
+                </li>
+                <li class="dashboard-nav__page">
+                    <a href="{% url 'a4dashboard:extproject-list' organisation_slug=view.organisation.slug %}"
+                        class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == 'extproject-list' %}is-active{% endif %}">
+                        {% trans "Linkages" %}
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
Alright, while there is still much more to do, this is good point to review and merge, I think. 
This adds separate lists for the projects, bplans, and external projects. The individual create-buttons work and make it possible to add bpland and external projects again.