### PR TITLE
settings: Disable SESSION_COOKIE_SAMESITE to allow servicekonto connections

### DIFF
--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -276,6 +276,7 @@ SOCIALACCOUNT_AUTO_SIGNUP = False
 SOCIALACCOUNT_EMAIL_VERIFICATION = 'none'
 SOCIALACCOUNT_FORMS = {'signup': 'meinberlin.apps.users.forms.SocialTermsSignupForm'}
 SOCIALACCOUNT_QUERY_EMAIL = True
+SESSION_COOKIE_SAMESITE = None # This is currently needed for servicekonto account connection
 
 LOGIN_URL = 'account_login'
 LOGIN_REDIRECT_URL = '/'


### PR DESCRIPTION
It was introduced in django 2 and by default blocks cookies being send on
cross origin request. Unfortunately the servicekonto account connection,
when a user already has an account and is logged in and wants to connect
her account to the servicekonto, requires us to send the cookie on login
callback.

Note: This is not necessary for oauth2 and other more sophisticated
social login techniques. Further more the allauth `draugiem` provider, on
which the `servicekonto` provider is based on, is the only provider in allauth
requiring a `@csrf_exempt`. Using OAuth2 would be much saver and easier.