### PR TITLE
apps/projects: Do not print errors on valid data

### DIFF
--- a/meinberlin/apps/projects/serializers.py
+++ b/meinberlin/apps/projects/serializers.py
@@ -99,8 +99,7 @@ class ProjectSerializer(serializers.ModelSerializer, CommonFields):
                             (project_phases.future_phases().first().
                              start_date.strftime('%d.%m.%Y')),
                             True)
-                except AttributeError as e:
-                    print(e)
+                except AttributeError:
                     return (_('starts in the future'),
                             True)
             else:


### PR DESCRIPTION
We treat this case as valid, so lets not print messages, they are distracting.