### PR TITLE
templates/base: Add a block for deferred js and use it for plans_list

### DIFF
--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_list.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_list.html
@@ -5,7 +5,6 @@
 
 {% block extra_js %}
     {{ block.super }}
-    <script src="{% static 'mb_plans_map.js' %}"></script>
 {% endblock %}
 
 {% block extra_css %}
@@ -28,4 +27,8 @@
          data-use_vector_map="{{ use_vector_map }}"
          data-baseurl="{{ baseurl }}"
          data-bounds="{{ bounds }}"></div>
+{% endblock %}
+
+{% block extra_js_deferred %}
+    <script src="{% static 'mb_plans_map.js' %}"></script>
 {% endblock %}

--- a/meinberlin/templates/base.html
+++ b/meinberlin/templates/base.html
@@ -57,5 +57,8 @@
     </main>
 
     {% include 'footer.html' %}
+    {% block extra_js_deferred %}
+        {# Override this in templates to add extra javascript #}
+    {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
If some JS code is not needed for page rendering, lets defer it so
initial rendering gets faster. Add a block in the base template for
that.

This gets dev from the 2Xs to 4Xs on pagespeed, helps with https://github.com/liqd/a4-meinberlin/issues/2030