### PR TITLE
apps/projects: Move and fix accordeon cookie

### DIFF
--- a/meinberlin/apps/dashboard/assets/init_accordeons_cookie.js
+++ b/meinberlin/apps/dashboard/assets/init_accordeons_cookie.js
@@ -1,0 +1,27 @@
+import Cookies from 'js-cookie'
+
+$(function () {
+  const cookieName = 'dashboard_projects_closed_accordeons'
+
+  if (Cookies.get(cookieName) === undefined) {
+    Cookies.set(cookieName, '[]')
+  }
+
+  $('.dashboard-nav__checkbox').change(function (e) {
+    const currentId = parseInt(this.id.split('--')[1])
+    const cookie = Cookies.get(cookieName)
+    let currentList = []
+
+    if (cookie) {
+      currentList = JSON.parse(cookie)
+    }
+
+    if (!this.checked && !currentList.includes(currentId)) {
+      currentList.push(currentId)
+      Cookies.set(cookieName, JSON.stringify(currentList))
+    } else if (this.checked && currentList.includes(currentId)) {
+      currentList.splice(currentList.indexOf(currentId), 1)
+      Cookies.set(cookieName, JSON.stringify(currentList))
+    }
+  })
+})

--- a/meinberlin/apps/dashboard/templatetags/meinberlin_dashboard_tags.py
+++ b/meinberlin/apps/dashboard/templatetags/meinberlin_dashboard_tags.py
@@ -1,0 +1,16 @@
+import json
+from urllib.parse import unquote
+
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def closed_accordeons(context, project_id):
+    request = context['request']
+    cookie = request.COOKIES.get('dashboard_projects_closed_accordeons', '[]')
+    ids = json.loads(unquote(cookie))
+    if project_id in ids:
+        ids.append(-1)
+    return ids

--- a/meinberlin/apps/dashboard/views.py
+++ b/meinberlin/apps/dashboard/views.py
@@ -1,3 +1,6 @@
+import json
+from urllib import parse
+
 from django.apps import apps
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
@@ -67,13 +70,16 @@ class ModuleCreateView(ProjectMixin,
         self._create_module_settings(module)
         self._create_phases(module, self.blueprint.content)
 
-        closed = request.COOKIES.get('closed_accordeons', '')
-        closed_project_accordeon = \
-            'dashboard-nav__project--{}'.format(str(self.project.id))
-        if closed_project_accordeon not in closed:
-            closed = closed_project_accordeon + closed
+        cookie = request.COOKIES.get('dashboard_projects_closed_accordeons',
+                                     '[]')
+        ids = json.loads(parse.unquote(cookie))
+        if self.project.id not in ids:
+            ids.append(self.project.id)
+
+        cookie = parse.quote(json.dumps(ids))
+
         response = HttpResponseRedirect(self.get_next(module))
-        response.set_cookie('closed_accordeons', closed)
+        response.set_cookie('dashboard_projects_closed_accordeons', cookie)
         return response
 
     def _create_module_settings(self, module):

--- a/meinberlin/apps/projects/templatetags/meinberlin_project_tags.py
+++ b/meinberlin/apps/projects/templatetags/meinberlin_project_tags.py
@@ -57,16 +57,3 @@ def get_num_entries(module):
         + Comment.objects.filter(poll__module=module).count() \
         + Vote.objects.filter(choice__question__poll__module=module).count()
     return item_count
-
-
-@register.simple_tag(takes_context=True)
-def closed_accordeons(context, project_id):
-    request = context['request']
-    closed = request.COOKIES.get('closed_accordeons', '')
-    closed_list = closed.split('%')
-    ids = [int(entry.split('--')[1])
-           for entry in closed_list
-           if '--' in entry]
-    if 'project--{}'.format(project_id) in closed:
-        ids.append(-1)
-    return ids

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -1,7 +1,5 @@
 /* eslint no-unused-vars: "off", no-new: "off" */
 
-import Cookies from 'js-cookie'
-
 // make jquery available for non-webpack js
 var $ = window.jQuery = window.$ = require('jquery')
 window.Tether = require('tether/dist/js/tether.js')
@@ -31,6 +29,8 @@ var relativeTimestamps = require('../../apps/actions/assets/timestamps.js')
 var mapAddress = require('./map-address.js')
 var remarkpopover = require('../../apps/moderatorremark/assets/idea_remarks.js')
 var dynamicFields = require('../../apps/contrib/assets/dynamic_fields.js')
+
+var initAccordeonsCookie = require('../../apps/dashboard/assets/init_accordeons_cookie.js')
 
 // This function is overwritten with custom behavior in embed.js.
 var getCurrentPath = function () {
@@ -88,26 +88,6 @@ var init = function () {
     variableWidth: true,
     slidesToShow: 1,
     slidesToScroll: 1
-  })
-
-  if (Cookies.get('closed_accordeons') === undefined) {
-    Cookies.set('closed_accordeons', '')
-  }
-
-  $('.dashboard-nav__checkbox').change(function (e) {
-    var currentId = this.id
-    var currentList = Cookies.get('closed_accordeons')
-    if (!this.checked) {
-      if (!currentList.includes(currentId)) {
-        currentList = currentList + ',' + currentId
-        Cookies.set('closed_accordeons', currentList)
-      }
-    } else {
-      if (currentList.includes(currentId)) {
-        var newList = currentList.replace(',' + currentId, '').replace(currentId, '')
-        Cookies.set('closed_accordeons', newList)
-      }
-    }
   })
 }
 

--- a/meinberlin/templates/a4dashboard/base_dashboard_project.html
+++ b/meinberlin/templates/a4dashboard/base_dashboard_project.html
@@ -1,5 +1,5 @@
 {% extends "a4dashboard/base_dashboard.html" %}
-{% load i18n static meinberlin_project_tags rules %}
+{% load i18n static meinberlin_dashboard_tags meinberlin_project_tags rules %}
 
 {% block dashboard_nav %}
 <div class="u--bg-secondary u-spacer-bottom-double">


### PR DESCRIPTION
Properly save the list as JSON, fixing a bug with the previous
splitting and making it much easier to work with. Also use the
chance to move the js code into its own file, into the same app
where the template tag using it resides.