### PR TITLE
remove user profile

### DIFF
--- a/meinberlin/apps/users/models.py
+++ b/meinberlin/apps/users/models.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import models as auth_models
 from django.core import validators
 from django.db import models
-from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
@@ -99,6 +98,3 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
         self.email = email
         if commit:
             self.save()
-
-    def get_absolute_url(self):
-        return reverse('profile', args=[str(self.username)])

--- a/meinberlin/apps/users/urls.py
+++ b/meinberlin/apps/users/urls.py
@@ -1,8 +1,0 @@
-from django.conf.urls import url
-
-from . import views
-
-urlpatterns = [
-    url(r'^(?P<slug>[-\w _.@+-]+)/$', views.ProfileView.as_view(),
-        name='profile'),
-]

--- a/meinberlin/apps/users/views.py
+++ b/meinberlin/apps/users/views.py
@@ -1,8 +1,0 @@
-from django.views.generic.detail import DetailView
-
-from . import models
-
-
-class ProfileView(DetailView):
-    model = models.User
-    slug_field = 'username'

--- a/meinberlin/config/urls.py
+++ b/meinberlin/config/urls.py
@@ -79,7 +79,6 @@ urlpatterns = [
     url(r'^dashboard/', include('meinberlin.apps.dashboard.urls')),
     url(r'^account/', include('meinberlin.apps.account.urls')),
     url(r'^embed/', include('meinberlin.apps.embed.urls')),
-    url(r'^profile/', include('meinberlin.apps.users.urls')),
     url(r'^initiators/', include(('meinberlin.apps.initiators.urls',
                                   'meinberlin_initiators'),
                                  'meinberlin_initiators')),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.7.4",
     "@fortawesome/fontawesome-free": "5.12.0",
     "acorn": "7.1.0",
-    "adhocracy4": "liqd/adhocracy4#105c06378b7195ba23950ca6caf1d722f4317239",
+    "adhocracy4": "liqd/adhocracy4#1a7dbe09b53c7c8b70264276b1d780c2e5d810fb",
     "autoprefixer": "9.7.3",
     "babel-loader": "8.0.6",
     "bootstrap": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "acorn": "7.1.0",
     "adhocracy4": "liqd/adhocracy4#1a7dbe09b53c7c8b70264276b1d780c2e5d810fb",
     "autoprefixer": "9.7.3",
+    "axios": "^0.19.1",
     "babel-loader": "8.0.6",
     "bootstrap": "4.4.1",
     "copy-webpack-plugin": "5.1.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@105c06378b7195ba23950ca6caf1d722f4317239#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@1a7dbe09b53c7c8b70264276b1d780c2e5d810fb#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.1.7

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -7,11 +7,9 @@ User = auth.get_user_model()
 
 
 @pytest.mark.django_db
-def test_absolute_url(client, user):
-    url = user.get_absolute_url()
-    response = client.get(url)
-    assert response.status_code == 200
-    assert response.context['user'] == user
+def test_absolute_url(user):
+    with pytest.raises(AttributeError):
+        user.get_absolute_url()
 
 
 @pytest.mark.django_db

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -5,6 +5,7 @@ from allauth.account.models import EmailAddress
 from django.contrib import auth
 from django.core import mail
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 
 from adhocracy4.test.helpers import redirect_target
 from meinberlin.apps.users import models
@@ -214,10 +215,8 @@ def test_reset_password_error(client):
 
 @pytest.mark.django_db
 def test_profile(client, user):
-    url = reverse('profile', kwargs={'slug': user.username})
-    response = client.get(url)
-    assert response.status_code == 200
-    assert response.context['user'] == user
+    with pytest.raises(NoReverseMatch):
+        reverse('profile', kwargs={'slug': user.username})
 
 
 @pytest.mark.django_db
@@ -233,9 +232,5 @@ def test_profile_edit(client, user):
 
     assert response.status_code == 302
 
-    profile_url = reverse('profile', kwargs={'slug': user.username})
-    profile_response = client.get(profile_url)
-
-    assert profile_response.status_code == 200
-    assert profile_response.context['user'] == user
-    assert profile_response.context['user'].get_newsletters
+    with pytest.raises(NoReverseMatch):
+        reverse('profile', kwargs={'slug': user.username})


### PR DESCRIPTION
depends on this PR: https://github.com/liqd/adhocracy4/pull/457

With this there won't be a link to the users profile (which does not exist anymore also) near a comment. Only the username is shown.
