### PR TITLE
apps/embed: Speed up login by not loading landing page

### DIFF
--- a/meinberlin/apps/embed/templates/meinberlin_embed/embed.html
+++ b/meinberlin/apps/embed/templates/meinberlin_embed/embed.html
@@ -22,7 +22,7 @@
     <header class="embed-header">
         {% if not object|is_external %}
             {% if request.user.is_anonymous %}
-                <a href="{% url 'account_login' %}" class="btn btn--light">{% trans 'Login' %}</a>
+                <a href="{% url 'account_login' %}?next={% url 'embed-login-success' %}" class="btn btn--light">{% trans 'Login' %}</a>
             {% else %}
                 {% trans 'You are logged in as ' %} {{ request.user.username }}
                 <form class="u-inline">

--- a/meinberlin/apps/embed/templates/meinberlin_embed/login_popup_close.html
+++ b/meinberlin/apps/embed/templates/meinberlin_embed/login_popup_close.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block extra_js %}
+    {% if request.user.is_authenticated %}
+        <script src="{% static 'popup-close.js' %}"></script>
+    {% endif %}
+{% endblock %}
+

--- a/meinberlin/apps/embed/urls.py
+++ b/meinberlin/apps/embed/urls.py
@@ -5,4 +5,6 @@ from . import views
 urlpatterns = [
     url(r'^projects/(?P<slug>[-\w_]+)/$', views.EmbedProjectView.as_view(),
         name='embed-project'),
+    url('login_success', views.EmbedLoginClose.as_view(),
+        name='embed-login-success'),
 ]

--- a/meinberlin/apps/embed/views.py
+++ b/meinberlin/apps/embed/views.py
@@ -13,3 +13,7 @@ class EmbedView(generic.View):
 class EmbedProjectView(generic.DetailView, EmbedView):
     model = project_models.Project
     template_name = "meinberlin_embed/embed.html"
+
+
+class EmbedLoginClose(generic.base.TemplateView):
+    template_name = "meinberlin_embed/login_popup_close.html"

--- a/meinberlin/templates/base.html
+++ b/meinberlin/templates/base.html
@@ -16,9 +16,6 @@
     <script src="{% static 'vendor.js' %}"></script>
     <script src="{% static 'adhocracy4.js' %}"></script>
     <meta name="viewport" content="width=device-width" />
-    {% if request.user.is_authenticated %}
-        <script src="{% static 'popup-close.js' %}"></script>
-    {% endif %}
     {% block header %}{% endblock %}
 
     {% block extra_js %}


### PR DESCRIPTION
This moves the popup close handling out of the base template into an
own simplistic view. While this one could still be smaller (it inherits
the base view), it is much faster than the landing page.