### PR TITLE
apps/bplans: save start and end date to bplan as well as correspondin…

### DIFF
--- a/meinberlin/apps/bplan/serializers.py
+++ b/meinberlin/apps/bplan/serializers.py
@@ -66,8 +66,8 @@ class BplanSerializer(serializers.ModelSerializer):
         orga = orga_model.objects.get(pk=orga_pk)
         validated_data['organisation'] = orga
 
-        start_date = validated_data.pop('start_date')
-        end_date = validated_data.pop('end_date')
+        start_date = validated_data['start_date']
+        end_date = validated_data['end_date']
 
         image_url = validated_data.pop('image_url', None)
         if image_url:
@@ -97,8 +97,8 @@ class BplanSerializer(serializers.ModelSerializer):
         )
 
     def update(self, instance, validated_data):
-        start_date = validated_data.pop('start_date', None)
-        end_date = validated_data.pop('end_date', None)
+        start_date = validated_data.get('start_date', None)
+        end_date = validated_data.get('end_date', None)
         if start_date or end_date:
             self._update_phase(instance, start_date, end_date)
             if end_date and end_date > timezone.localtime(timezone.now()):

--- a/tests/bplan/test_bplan_api.py
+++ b/tests/bplan/test_bplan_api.py
@@ -52,6 +52,8 @@ def test_initiator_add_bplan(apiclient, organisation):
     assert bplan.is_draft is False
     assert bplan.information == ''
     assert bplan.result == ''
+    assert bplan.start_date == parse("2013-01-01 17:00:00 UTC")
+    assert bplan.end_date == parse("2021-01-01 17:00:00 UTC")
     module = module_models.Module.objects.get(project=bplan)
     assert module is not None
     phase = phase_models.Phase.objects.get(module=module)
@@ -88,6 +90,14 @@ def test_initiator_update_bplan(apiclient, bplan, phase):
     bplan = bplan_models.Bplan.objects.first()
     assert bplan.is_draft is True
     assert bplan.tile_image_copyright == data.get('image_copyright')
+    assert bplan.start_date == parse("2013-01-01 17:00:00 UTC")
+    assert bplan.end_date == parse("2021-01-01 17:00:00 UTC")
+    module = module_models.Module.objects.get(project=bplan)
+    assert module is not None
+    phase = phase_models.Phase.objects.get(module=module)
+    assert phase is not None
+    assert phase.start_date == parse("2013-01-01 17:00:00 UTC")
+    assert phase.end_date == parse("2021-01-01 17:00:00 UTC")
 
 
 @pytest.mark.django_db
@@ -167,6 +177,9 @@ def test_initiator_update_bplan_phase(apiclient, bplan_factory, phase):
     apiclient.force_authenticate(user=user)
     response = apiclient.patch(url, data, format='json')
     assert response.status_code == status.HTTP_200_OK
+    bplan = bplan_models.Bplan.objects.first()
+    assert bplan.start_date == parse("2013-01-01 17:00:00 UTC")
+    assert bplan.end_date == parse("2021-01-01 17:00:00 UTC")
     phase = phase_models.Phase.objects.get(module=phase.module)
     assert phase.start_date == parse("2013-01-01 17:00:00 UTC")
     assert phase.end_date == parse("2021-01-01 17:00:00 UTC")


### PR DESCRIPTION
…g phase - fixes #2528

Ok, this fixes it, but the whole issue was introduced when we added a start and end_date to the external project (the bplan inherits from). I don't know why we did that and if it's not a better idea to remove that again and only and always use the dates of the corresponding phases. 
Right, no, we talked about that: https://github.com/liqd/a4-meinberlin/pull/2264
I still think, we might be able to use the dashboard to show and change the phase in the corresponding module instead of in the project. But I am not supersure that's possible and would have to get into the whole concept of the dashboard and the extra projects added in mB again.
@rmader What do you think?