### PR TITLE
locale/django.po:add missing translation for link to 'all participati…

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -3836,7 +3836,7 @@ msgstr "Organisationen"
 #: meinberlin/templates/a4dashboard/base_dashboard_project.html:28
 #: meinberlin/templates/a4dashboard/project_create_form.html:14
 msgid "All participation projects"
-msgstr ""
+msgstr "Alle Beteiligungsprojekte"
 
 #: meinberlin/templates/a4dashboard/base_dashboard_project.html:51
 msgid "Project ready for publication"


### PR DESCRIPTION
…on projects'

Just saw that  this was still in english..