### PR TITLE
assets: Replace jQuery 'a4.embed.ready' listeners with vanilla js

### DIFF
--- a/meinberlin/apps/embed/assets/embed.js
+++ b/meinberlin/apps/embed/assets/embed.js
@@ -95,8 +95,9 @@ $(document).ready(function () {
     $main.empty()
     $main.append($top)
     $main.append($root.find('main').children())
-    $(document).trigger('a4.embed.ready')
-    $(window.init_widgets)
+
+    document.dispatchEvent(new Event('a4.embed.ready'))
+
     // jump to top after navigation, but not on inital load
     if (!isInitial) {
       $top.focus()

--- a/meinberlin/apps/maps/assets/map-address.js
+++ b/meinberlin/apps/maps/assets/map-address.js
@@ -106,7 +106,7 @@ var renderPoints = function (points) {
   }
 }
 
-var init = function () {
+function init () {
   var $ = window.jQuery
 
   $('[data-map="address"]').each(function (i, e) {
@@ -155,5 +155,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js
+++ b/meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js
@@ -18,7 +18,7 @@ function getBaseBounds (L, polygon, bbox) {
   }
 }
 
-var init = function () {
+function init () {
   const $ = window.jQuery
   const L = window.L
 
@@ -290,5 +290,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -40,7 +40,7 @@ var getCurrentPath = function () {
   return location.pathname
 }
 
-var initialiseWidget = function (namespace, name, fn) {
+function initialiseWidget (namespace, name, fn) {
   var key = 'data-' + namespace + '-widget'
   var selector = '[' + key + '=' + name + ']'
   $(selector).each(function (i, el) {
@@ -51,7 +51,7 @@ var initialiseWidget = function (namespace, name, fn) {
   })
 }
 
-var init = function () {
+function init () {
   var shariffs = $('.shariff')
   if (shariffs.length > 0) {
     new Shariff(shariffs, {
@@ -94,8 +94,8 @@ var init = function () {
   })
 }
 
-$(init)
-window.init_widgets = init
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)
 
 module.exports = {
   getCurrentPath: getCurrentPath

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.9.4",
     "@fortawesome/fontawesome-free": "5.13.0",
     "acorn": "7.1.1",
-    "adhocracy4": "liqd/adhocracy4#4db7933583650520fbf02ae1913a4eae9cc523bb",
+    "adhocracy4": "liqd/adhocracy4#d21a787094685c48151f211ca3ad7cade0a3c229",
     "autoprefixer": "9.7.6",
     "axios": "0.19.2",
     "babel-loader": "8.1.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@4db7933583650520fbf02ae1913a4eae9cc523bb#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@d21a787094685c48151f211ca3ad7cade0a3c229#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.1.7


### PR DESCRIPTION
When using multple webpack endpoints we do not get a global jQuery
object but instead one for each endpoint. These do not see each others
signals, thus do not fire.

Use standard js events instead - they don't suffer from that problem and
we should get rid of jQuery anyway over time.

Also use the chance to clean up the init syntax.

Depends on https://github.com/liqd/adhocracy4/pull/519

Fixes https://github.com/liqd/a4-meinberlin/issues/2781

**Needs to get tested with IE11** :(