### PR TITLE
templates: Remove hacks to force german language

### DIFF
--- a/meinberlin/templates/a4reports/emails/report_moderators.en.email
+++ b/meinberlin/templates/a4reports/emails/report_moderators.en.email
@@ -1,8 +1,3 @@
-{# Hack to ensure german mails are sent regardless of the current users browser language setting #}
-{% extends 'a4reports/emails/report_moderators.de.email' %}
-
-{% comment %}
-
 {% extends 'email_base.'|add:part_type %}
 {% load reports_tags i18n %}
 
@@ -29,5 +24,3 @@ As a moderator* you can delete the post if it does not comply with our <a href="
 {% block cta_label %}Check contribution{% endblock %}
 
 {% block reason %}This e-mail was sent to {{ receiver.email }}. You have received the e-mail because you are registered as moderator for the project.{% endblock %}
-
-{% endcomment %}

--- a/meinberlin/templates/email_base.html
+++ b/meinberlin/templates/email_base.html
@@ -1,4 +1,4 @@
-{% load i18n %}{# Hack to ensure german mails are sent regardless of the current users browser language setting #}{% language 'de' %}
+{% load i18n %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
@@ -87,4 +87,3 @@
         </div>
     </body>
 </html>
-{% endlanguage %}

--- a/meinberlin/templates/email_base.txt
+++ b/meinberlin/templates/email_base.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{# Hack to ensure german mails are sent regardless of the current users browser language setting #}{% language 'de' %}
+{% load i18n %}
 {% block headline %}{% endblock %}
 {% block sub-headline %}{% endblock %}
 
@@ -15,4 +15,3 @@ Liquid Democracy e.V., Am Sudhaus 2, D-12053 Berlin
 
 {% trans 'Contact' %}: {{ site.domain }}/impressum/
 {% trans 'Terms of use' %}: {{ site.domain }}/terms-of-use/
-{% endlanguage %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-sites==0.10
 django_csp==3.6
 raven==6.10.0
 requests==2.23.0
-wagtail==2.7.1 # pyup: <2.8
+wagtail==2.7.2 # pyup: <2.8
 whitenoise==5.0.1
 zeep==3.4.0
 


### PR DESCRIPTION
Closes https://github.com/liqd/a4-meinberlin/issues/2860

Context: we now force a `de` browser header in our nginx settings