### PR TITLE
Revert "fix(deps): update dependency jquery to v3.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "file-loader": "6.0.0",
     "file-saver": "2.0.2",
     "immutability-helper": "3.0.2",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "leaflet": "1.6.0",
     "leaflet-draw": "1.0.4",
     "leaflet.markercluster": "1.4.1",


### PR DESCRIPTION
Reverts liqd/a4-meinberlin#2894

above update breaks header dropdown on mobile, seems to be a bootstrap issue