### PR TITLE
assets/js: Move onload_warning out of global assets again

### DIFF
--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -32,7 +32,6 @@ require('../../apps/maps/assets/map-address.js')
 require('../../apps/moderatorremark/assets/idea_remarks.js')
 require('../../apps/newsletters/assets/dynamic_fields.js')
 require('../../apps/dashboard/assets/ajax_modal.js')
-require('../../assets/js/unload_warning.js')
 require('../../apps/dashboard/assets/init_accordeons_cookie.js')
 
 // This function is overwritten with custom behavior in embed.js.

--- a/meinberlin/templates/a4dashboard/base_dashboard_project.html
+++ b/meinberlin/templates/a4dashboard/base_dashboard_project.html
@@ -55,3 +55,7 @@
         </div>
     </div>
 {% endblock %}
+
+{% block extra_js %}
+    <script src="{% static 'unload_warning.js' %}"></script>
+{% endblock %}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -34,6 +34,9 @@ module.exports = {
       'bootstrap/js/dist/modal.js',
       './meinberlin/apps/embed/assets/embed.js'
     ],
+    unload_warning: [
+      './meinberlin/assets/js/unload_warning.js'
+    ],
     // A4 dependencies - we want all of them to go through webpack
     mb_plans_map: [
       'leaflet/dist/leaflet.css',


### PR DESCRIPTION
This reverts parts of 80fe4e69d996f360025751535af06b40dfbf6d6f as it caused
us to warn e.g. when having filters set in the project overview.

Closes #2910