### PR TITLE
Revert "Update dependency jquery to v3.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "file-loader": "6.0.0",
     "file-saver": "2.0.2",
     "immutability-helper": "3.0.2",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "leaflet": "1.6.0",
     "leaflet-draw": "1.0.4",
     "leaflet.markercluster": "github:liqd/Leaflet.markercluster#5ed89b26922c51083fc9632a2c01425b9261a0f5",


### PR DESCRIPTION
Reverts liqd/a4-meinberlin#2913 until jquery or bootstrap release a fix we will stay at 