### PR TITLE
plans/assets: Update state of LazyBackground when props change

### DIFF
--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -13,10 +13,11 @@ class LazyBackground extends React.Component {
 
   componentDidMount () {
     window.addEventListener('scroll', this.handleScroll.bind(this))
-    const isInViewpoort = this.isInViewport()
-    if (isInViewpoort) {
-      this.loadImage()
-    }
+    this.checkLoadImage()
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('scroll', this.handleScroll.bind(this))
   }
 
   componentDidUpdate (prevProps, prevState, snapshot) {
@@ -27,17 +28,14 @@ class LazyBackground extends React.Component {
     }
   }
 
-  componentWillUnmount () {
-    window.removeEventListener('scroll', this.handleScroll.bind(this))
+  handleScroll () {
+    this.checkLoadImage()
   }
 
-  loadImage () {
-    const src = this.props.item.tile_image
-    const imageLoader = new Image()
-    imageLoader.src = src
-    imageLoader.onload = () => {
+  checkLoadImage () {
+    if (this.isInViewport() && !this.state.source) {
       this.setState({
-        source: src
+        source: this.props.item.tile_image
       })
     }
   }
@@ -51,12 +49,6 @@ class LazyBackground extends React.Component {
       Math.floor(100 - ((rect.bottom - windowHeight) / rect.height) * 100) < 1
     )
     return res
-  }
-
-  handleScroll () {
-    if (this.isInViewport() && !this.state.source) {
-      this.loadImage()
-    }
   }
 
   render () {

--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -60,7 +60,7 @@ class LazyBackground extends React.Component {
         className={this.props.isHorizontal ? 'u-lg-only-display maplist-item__img' : 'maplist-item__img'} style={{
           backgroundPosition: 'center',
           backgroundRepeat: 'no-repeat',
-          backgroundImage: `url(${this.state.source})`
+          backgroundImage: this.state.source ? `url(${this.state.source})` : 'none'
         }} alt=""
       >
         {!this.props.isHorizontal && this.props.renderTopics(this.props.item)}

--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -7,8 +7,7 @@ class LazyBackground extends React.Component {
     super(props)
 
     this.state = {
-      source: null,
-      isVisible: false
+      source: null
     }
   }
 
@@ -17,6 +16,14 @@ class LazyBackground extends React.Component {
     const isInViewpoort = this.isInViewport()
     if (isInViewpoort) {
       this.loadImage()
+    }
+  }
+
+  componentDidUpdate (prevProps, prevState, snapshot) {
+    if (this.props.item.tile_image !== prevProps.item.tile_image) {
+      this.setState({
+        source: this.isInViewport() ? this.props.item.tile_image : null
+      })
     }
   }
 
@@ -30,8 +37,7 @@ class LazyBackground extends React.Component {
     imageLoader.src = src
     imageLoader.onload = () => {
       this.setState({
-        source: src,
-        isVisible: true
+        source: src
       })
     }
   }

--- a/meinberlin/apps/plans/assets/plans_map.jsx
+++ b/meinberlin/apps/plans/assets/plans_map.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import { CookiesProvider } from 'react-cookie'
 import ListMapBox from './ListMapBox'
 
-const init = function () {
+function init () {
   $('[data-map="plans"]').each(function (i, element) {
     const projectApiUrl = element.getAttribute('data-projects-url')
     const containersApiUrl = element.getAttribute('data-containers-url')
@@ -48,5 +48,5 @@ const init = function () {
   })
 }
 
-$(init)
-$(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)


### PR DESCRIPTION
From the main commit:
```
`LazyBackground` does not use the image url property directly but
instead has an internal state - to not directly load images when the
property appears, but only when they first become visible.
Thus, we must listen on property changes and update the state accordingly.

Also, remove an unused variable.
```

Closes #2911