### PR TITLE
apps/bplan: use new sub-headline from email_base and make content lef…

### DIFF
--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/submitter_confirmation.de.email
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/submitter_confirmation.de.email
@@ -1,11 +1,14 @@
 {% extends 'email_base.'|add:part_type %}
+
 {% load wagtailcore_tags %}
 
 {% block subject %}Ihre Stellungnahme zum Bebauungsplan "{{ project.name }}" von {{ module.active_phase.start_date|date:'d.m.Y' }} - {{ module.active_phase.end_date|date:'d.m.Y' }}{% endblock %}
 
-{% block headline %}Ihre Stellungnahme zum Bebauungsplan "{{ project.name }}" von {{ module.active_phase.start_date|date:'d.m.Y' }} - {{ module.active_phase.end_date|date:'d.m.Y' }}{% endblock %}
+{% block headline %}Ihre Stellungnahme{% endblock %}
 
-{% block content %}vielen Dank für Ihre Stellungnahme. Sie ist an die zuständige Stelle weitergeleitet worden und geht in die Abwägung der öffentlichen und privaten Belange ein. Wenn Sie sich an einer öffentlichen Auslegung beteiligt haben, werden Sie außerdem nach Festsetzung des Bebauungsplans von der verantwortlichen Stelle schriftlich (per E-Mail oder postalisch) über das Ergebnis informiert, sofern Sie Ihre Adresse angegeben haben.
+{% block sub-headline %} "{{ project.name }}" {% endblock %}
+
+{% block content_left_aligned %}vielen Dank für Ihre Stellungnahme. Sie ist an die zuständige Stelle weitergeleitet worden und geht in die Abwägung der öffentlichen und privaten Belange ein. Wenn Sie sich an einer öffentlichen Auslegung beteiligt haben, werden Sie außerdem nach Festsetzung des Bebauungsplans von der verantwortlichen Stelle schriftlich (per E-Mail oder postalisch) über das Ergebnis informiert, sofern Sie Ihre Adresse angegeben haben.
 
 Ihre Angaben in der Übersicht:
 

--- a/meinberlin/templates/email_base.html
+++ b/meinberlin/templates/email_base.html
@@ -37,6 +37,8 @@
                                 {% load capture_tags %}
                                 {% capture as content silent %}{% block content %}{% endblock %}{% endcapture %}
                                 {{ content|linebreaks }}
+                                {% capture as content_left_aligned silent %}{% block content_left_aligned %}{% endblock %}{% endcapture %}
+                                <div style="text-align: left;">{{ content_left_aligned|linebreaks }}</div>
                             {% endblock %}
                         </p>
                     </td>


### PR DESCRIPTION
…t-aligned

I am not super happy to add yet another content block, but didn't know how to make it left-aligned AND keep the newlines otherwise :woman_shrugging: 