### PR TITLE
Ks 2020 05 redesign blan new statement mail

### DIFF
--- a/meinberlin/apps/bplan/emails.py
+++ b/meinberlin/apps/bplan/emails.py
@@ -11,6 +11,11 @@ class OfficeWorkerNotification(Email):
         project = self.object.module.project
         return project.externalproject.bplan.office_worker_email
 
+    @property
+    def bplan_identifier(self):
+        project = self.object.module.project
+        return project.externalproject.bplan.identifier
+
     def get_receivers(self):
         return [self.office_worker_email]
 
@@ -19,6 +24,7 @@ class OfficeWorkerNotification(Email):
         context['module'] = self.object.module
         context['project'] = self.object.module.project
         context['contact_email'] = settings.CONTACT_EMAIL
+        context['identifier'] = self.bplan_identifier
         return context
 
 

--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/office_worker_notification.de.email
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/office_worker_notification.de.email
@@ -1,33 +1,33 @@
 {% extends 'email_base.'|add:part_type %}
 {% load wagtailcore_tags %}
 
-{% block subject %}Neue Stellungnahme zum Bebauungsplan "{{ project.name }}" von {{ module.active_phase.start_date|date:'d.m.Y' }} - {{ module.active_phase.end_date|date:'d.m.Y' }}{% endblock %}
+{% block subject %}Neue Stellungnahme zu {{ identifier }}{% endblock %}
 
-{% block headline %}Neue Stellungnahme zum Bebauungsplan "{{ project.name }}" von {{ module.active_phase.start_date|date:'d.m.Y' }} - {{ module.active_phase.end_date|date:'d.m.Y' }}{% endblock %}
+{% block logo %}{% endblock %}
 
-{% block content %}es wurde eine neue Stellungnahme für den Bebauungsplan "{{ project.name }}" von {{ module.active_phase.start_date|date:'d.m.Y' }} - {{ module.active_phase.end_date|date:'d.m.Y' }} abgegeben.
+{% block headline %}Neue Stellungnahme{% endblock %}
 
-Angaben in der Übersicht:
+{% block sub-headline %}{{ identifier }}: {{ project.name }}{% endblock %}
 
-Name
+{% block greeting %}{% endblock %}
+
+{% block content_left_aligned %}
+Name:
 {{ statement.name }}
 
-Straße, Hausnummer
+Straße, Hausnummer:
 {{ statement.street_number }}
 
-PLZ, Ort
+PLZ, Ort:
 {{ statement.postal_code_city }}
 
-E-Mail-Adresse
+E-Mail Adresse:
 {{ statement.email }}
 
-Stellungnahme
-
+Stellungnahme:
 {{ statement.statement }}
-
 {% endblock %}
 
-{% block cta_label %}Bebauungsplan anzeigen{% endblock %}
-{% block cta_url %}{{ project.externalproject.url }}{% endblock %}
+{% block cta %}{% endblock %}
 
-{% block reason %}Diese E-Mail wurde an {{ receiver }} gesendet, da Sie als Sachbearbeiter*in des Projekts angegeben sind. Bei Fragen können Sie sich gerne unter {{ contact_email }} an uns wenden.{% endblock %}
+{% block reason %}Diese E-Mail wurde an {{ receiver }} gesendet. Sie haben die E-Mail erhalten, weil Sie als Sachbearbeiter*in für eine digitale Öffentlichkeitsbeteiligung zu einem Bebauungsplan eingetragen wurden.{% endblock %}

--- a/meinberlin/templates/email_base.html
+++ b/meinberlin/templates/email_base.html
@@ -9,6 +9,7 @@
         <div style="margin: 20px auto; padding: 20px; width: 100%; max-width: 650px; background-color: #fff; box-shadow: 0 0 10px 0 rgba(0,0,0,0.2);">
             <table width="100%" border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse;">
                 <tr>
+                    {% block logo %}
                     <td style="padding-top: 20px; text-align: center;" align="center">
                         {% if organisation.logo %}
                             <img width="15%" src="cid:organisation_logo" style="width: 15%;" alt="Logo" >
@@ -16,6 +17,7 @@
                             <img width="15%" src="cid:logo" style="width: 15%;" alt="Logo" >
                         {% endif %}
                     </td>
+                    {% endblock %}
                 </tr>
                 <tr>
                     <td style="padding-top: 20px; text-align: center;" align="center">


### PR DESCRIPTION
In the mail template, that @CarolingerSeilchenspringer gave us, the headline and subheadline were also left aligned, but this would mean 2 more extra left aligned blocks.. thats why I left it centered for now, bc I dont think it makes a difference for the length of the printouts.. do you think this is ok? 