### PR TITLE
cms/email_form: Remove captcha data from mail

### DIFF
--- a/meinberlin/apps/cms/models/email_form.py
+++ b/meinberlin/apps/cms/models/email_form.py
@@ -29,6 +29,11 @@ class WagtailCaptchaEmailForm(AbstractEmailForm):
 
     form_builder = WagtailCaptchaFormBuilder
 
+    def process_form_submission(self, form):
+        form.fields.pop('captcha', None)
+        form.cleaned_data.pop('captcha', None)
+        return super().process_form_submission(form)
+
     class Meta:
         abstract = True
 


### PR DESCRIPTION
This was accidentally removed during debugging, resulting in the captcha
data send along in the email.