### PR TITLE
config/urls: Use 'projekte' instead 'projects' in project urls

### DIFF
--- a/meinberlin/config/urls.py
+++ b/meinberlin/config/urls.py
@@ -86,7 +86,7 @@ urlpatterns = [
     url(r'^admin/', include('wagtail.admin.urls')),
     url(r'^accounts/', include('allauth.urls')),
     url(r'^documents/', include('wagtail.documents.urls')),
-    url(r'^projects/', include('meinberlin.apps.projects.urls')),
+    url(r'^projekte/', include('meinberlin.apps.projects.urls')),
 
     url(r'^ideas/', include(('meinberlin.apps.ideas.urls',
                              'meinberlin_ideas'),

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -106,7 +106,7 @@ def test_register_with_next(client, signup_url):
             'password1': 'password',
             'password2': 'password',
             'terms_of_use': 'on',
-            'next': '/projects/pppp/',
+            'next': '/projekte/pppp/',
             'captcha': 'testpass:0'
         }
     )
@@ -116,7 +116,7 @@ def test_register_with_next(client, signup_url):
     ).count() == 1
     assert len(mail.outbox) == 1
     confirmation_url = re.search(
-        r'(http://testserver/.*/?next=/projects/pppp/)',
+        r'(http://testserver/.*/?next=/projekte/pppp/)',
         str(mail.outbox[0].body)
     ).group(0)
     confirm_email_response = client.get(confirmation_url)


### PR DESCRIPTION
Note: in order to keep old urls working we need to adapt our nginx config.