### PR TITLE
Ka 2020 07 bplan update email

### DIFF
--- a/meinberlin/apps/bplan/signals.py
+++ b/meinberlin/apps/bplan/signals.py
@@ -25,5 +25,5 @@ def send_notification(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=Bplan)
 def send_update(sender, instance, update_fields, **kwargs):
-    if update_fields:
+    if not update_fields or 'point' not in update_fields:
         emails.OfficeWorkerUpdateConfirmation.send(instance)

--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/office_worker_update_confirmation.de.email
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/office_worker_update_confirmation.de.email
@@ -2,7 +2,7 @@
 
 {% load wagtailcore_tags %}
 
-{% block subject %}Betreff: Ihr Bebauungsplan auf {{ site.name }}: {{ identifier }}{% endblock %}
+{% block subject %}Ihr Bebauungsplan auf {{ site.name }}: {{ identifier }}{% endblock %}
 
 {% block headline %}Ihr Bebauungsplan auf {{ site.name }}{% endblock %}
 
@@ -13,13 +13,13 @@
 der oben genannte Bebauungsplan wurde auf {{ site.name }} veröffentlicht, geändert oder als Entwurf angelegt. Alle eingehenden Stellungnahmen werden an {{ bplan.office_worker_email }} weitergeleitet.
 
 Bebauungsplan-Nr.: {{ identifier }}
-Beteiligungszeitraum: {{ bplan.start_date }} – {{ bplan.end_date }}
+Beteiligungszeitraum: {{ bplan.start_date }} Uhr – {{ bplan.end_date }} Uhr
 
 Falls der Bebauungsplan nicht korrekt angezeigt wird, können Sie sich an support@mein.berlin.de wenden.
 
 {% endblock %}
 
-{% block cta_label %}Zur Projektünersicht{% endblock %}
+{% block cta_label %}Zur Projektübersicht{% endblock %}
 {% block cta_url %}{{ project.externalproject.url }}{% endblock %}
 
 {% block reason %}Diese E-Mail wurde an {{ receiver }} gesendet. Sie haben die E-Mail erhalten, weil Sie als Sachbearbeiter*in für eine digitale Öffentlichkeitsbeteiligung zu einem Bebauungsplan eingetragen wurden.{% endblock %}


### PR DESCRIPTION
Long explanation in the first commit!

To test locally, just start watch and backround and add or change a bplan via the dashboard like you are used to or via the terminal:
`curl -d '{"name":"Katharinenblock Ost - Bebauungsplan 4-83", "identifier": "4-83", "description": "Test", "url": "https://mein.berlin.de", "office_worker_email": "<YOUR EMAIL>", "start_date": "2020-01-01T00:00", "end_date": "2022-01-01T00:00"}' -H "Content-Type: application/json" -X POST "url": "http://localhost:8003/api/organisations/1/bplan/" --user 'admin@liqd.net':'password'`