### PR TITLE
apps/bplan: office worker confirmation links to project overview and …

### DIFF
--- a/meinberlin/apps/bplan/emails.py
+++ b/meinberlin/apps/bplan/emails.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.urls import reverse
 
 from meinberlin.apps.contrib.emails import Email
 
@@ -48,15 +49,11 @@ class SubmitterConfirmation(Email):
 class OfficeWorkerUpdateConfirmation(Email):
     template_name = 'meinberlin_bplan/emails/office_worker_update_confirmation'
 
-    @property
-    def bplan_identifier(self):
-        return self.object.identifier
-
     def get_receivers(self):
         return [self.object.office_worker_email]
 
     def get_context(self):
         context = super().get_context()
         context['contact_email'] = settings.CONTACT_EMAIL
-        context['identifier'] = self.bplan_identifier
+        context['project_list_url'] = reverse('meinberlin_plans:plan-list')
         return context

--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/office_worker_update_confirmation.de.email
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/emails/office_worker_update_confirmation.de.email
@@ -2,7 +2,7 @@
 
 {% load wagtailcore_tags %}
 
-{% block subject %}Ihr Bebauungsplan auf {{ site.name }}: {{ identifier }}{% endblock %}
+{% block subject %}Ihr Bebauungsplan auf {{ site.name }}: {{ bplan.identifier }}{% endblock %}
 
 {% block headline %}Ihr Bebauungsplan auf {{ site.name }}{% endblock %}
 
@@ -12,14 +12,14 @@
 
 der oben genannte Bebauungsplan wurde auf {{ site.name }} veröffentlicht, geändert oder als Entwurf angelegt. Alle eingehenden Stellungnahmen werden an {{ bplan.office_worker_email }} weitergeleitet.
 
-Bebauungsplan-Nr.: {{ identifier }}
+Bebauungsplan-Nr.: {{ bplan.identifier }}
 Beteiligungszeitraum: {{ bplan.start_date }} Uhr – {{ bplan.end_date }} Uhr
 
-Falls der Bebauungsplan nicht korrekt angezeigt wird, können Sie sich an support@mein.berlin.de wenden.
+Falls der Bebauungsplan nicht korrekt angezeigt wird, können Sie sich an {{ contact_email }} wenden.
 
 {% endblock %}
 
 {% block cta_label %}Zur Projektübersicht{% endblock %}
-{% block cta_url %}{{ bplan.externalproject.url }}{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ project_list_url }}{% endblock %}
 
 {% block reason %}Diese E-Mail wurde an {{ receiver }} gesendet. Sie haben die E-Mail erhalten, weil Sie als Sachbearbeiter*in für eine digitale Öffentlichkeitsbeteiligung zu einem Bebauungsplan eingetragen wurden.{% endblock %}


### PR DESCRIPTION
…cleanup

Locally the contact email will be another one (from the settings), but for our servers, that is overwritten and will be the right one.