### PR TITLE
WIP bplan/signals: add in update if statement so triggered on draft save

### DIFF
--- a/meinberlin/apps/bplan/signals.py
+++ b/meinberlin/apps/bplan/signals.py
@@ -25,5 +25,8 @@ def send_notification(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=Bplan)
 def send_update(sender, instance, update_fields, **kwargs):
+    if update_fields:
+        emails.OfficeWorkerUpdateConfirmation.send(instance)
+
     if not update_fields or 'point' not in update_fields:
         emails.OfficeWorkerUpdateConfirmation.send(instance)


### PR DESCRIPTION
@fuzzylogic2000 I just added the update if statement back as that was working with the save in dashboard but apparently not with the publication.
I was wondering if we could use anything from the serializer but I don't understand enough to know, I was just reading what python signals are so thats where i'm at 