### PR TITLE
apps/bplans: don't trigger get_location or send_update on automatic b…

### DIFF
--- a/meinberlin/apps/bplan/management/commands/bplan_auto_archive.py
+++ b/meinberlin/apps/bplan/management/commands/bplan_auto_archive.py
@@ -14,7 +14,9 @@ class Command(BaseCommand):
         for bplan in bplans:
             if bplan.has_finished and not bplan.is_archived:
                 bplan.is_archived = True
-                bplan.save()
+                bplan.save(
+                    update_fields=['is_archived']
+                )
                 self.stdout.write('Archived bplan {}.'.format(bplan.name))
 
         # Delete statements of archived projects

--- a/meinberlin/apps/bplan/signals.py
+++ b/meinberlin/apps/bplan/signals.py
@@ -10,7 +10,8 @@ from .models import Statement
 @receiver(post_save, sender=Bplan)
 def get_location(sender, instance, update_fields, **kwargs):
     if instance.identifier and (not update_fields or
-                                'point' not in update_fields):
+                                ('point' not in update_fields and
+                                 'is_archived' not in update_fields)):
         tasks.get_location_information(instance.pk)
 
 
@@ -25,5 +26,6 @@ def send_notification(sender, instance, created, **kwargs):
 
 @receiver(post_save, sender=Bplan)
 def send_update(sender, instance, update_fields, **kwargs):
-    if not update_fields or 'point' not in update_fields:
+    if (not update_fields or ('point' not in update_fields and
+                              'is_archived' not in update_fields)):
         emails.OfficeWorkerUpdateConfirmation.send(instance)


### PR DESCRIPTION
…plan archiving - fixes #3061

Can be tested by adding a bplan that is already finished and then triggering the auto archive by
`python manage.py bplan_auto_archive`
In this branch there is nothing in the tasks, while on master there are still the ones for get_location and send_update.