### PR TITLE
apps/projects: make sure serializers only take phases of published mo…

### DIFF
--- a/meinberlin/apps/projects/filters.py
+++ b/meinberlin/apps/projects/filters.py
@@ -12,11 +12,13 @@ class StatusFilter(filters.BaseFilterBackend):
             active_projects = queryset \
                 .filter(
                     module__phase__start_date__lte=now,
-                    module__phase__end_date__gt=now) \
+                    module__phase__end_date__gt=now,
+                    module__is_draft=False) \
                 .distinct()
 
             future_projects = queryset.filter(
-                module__phase__start_date__gt=now
+                module__phase__start_date__gt=now,
+                module__is_draft=False
             ).distinct().exclude(
                 id__in=active_projects.values('id'))
 
@@ -28,7 +30,8 @@ class StatusFilter(filters.BaseFilterBackend):
 
             if statustype == 'pastParticipation':
                 past_projects = queryset.filter(
-                    module__phase__end_date__lt=now
+                    module__phase__end_date__lt=now,
+                    module__is_draft=False
                 ).distinct() \
                     .exclude(
                     id__in=active_projects.values('id')) \

--- a/meinberlin/apps/projects/serializers.py
+++ b/meinberlin/apps/projects/serializers.py
@@ -226,9 +226,9 @@ class ActiveProjectSerializer(ProjectSerializer):
         return unit_totals
 
     def get_active_phase(self, instance):
-        progress = instance.active_phase_progress
-        time_left = instance.time_left
-        end_date = str(instance.active_phase_ends_next.end_date)
+        progress = instance.module_running_progress
+        time_left = instance.module_running_time_left
+        end_date = str(instance.running_module_ends_next.module_end)
         return [progress, time_left, end_date]
 
     def get_status(self, instance):
@@ -252,7 +252,8 @@ class FutureProjectSerializer(ProjectSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._future_phases = Phase.objects\
-            .filter(start_date__gt=self.now)\
+            .filter(start_date__gt=self.now,
+                    module__is_draft=False)\
             .order_by('start_date')
 
     def get_active_phase(self, instance):
@@ -282,7 +283,8 @@ class PastProjectSerializer(ProjectSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._past_phases = Phase.objects\
-            .filter(end_date__lt=timezone.now())\
+            .filter(end_date__lt=timezone.now(),
+                    module__is_draft=False)\
             .order_by('start_date')
 
     def get_active_phase(self, instance):


### PR DESCRIPTION
…dules into account

fixes https://sentry.liqd.net/sentry/meinberlin-prod/issues/1207/
This occurs when a published project has a published (added to the project) past module and an unpublished (not added to the project) running module. That project ended up in the wrong serializer then because of the filters not filtering for published modules.