### PR TITLE
apps/contrib: Add option to disable Matomo cookies

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/matomo/tracking_code.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/matomo/tracking_code.html
@@ -1,15 +1,19 @@
+{% load contrib_tags %}
 <!-- Matomo -->
 <script type="text/javascript">
-  var _paq = _paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+{% if cookie_disabled %}
+  _paq.push(['disableCookies']);
+{% endif %}
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
     var u="{{ url }}";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '{{ id }}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Matomo Code -->

--- a/meinberlin/apps/contrib/templatetags/contrib_tags.py
+++ b/meinberlin/apps/contrib/templatetags/contrib_tags.py
@@ -101,4 +101,9 @@ def tracking_code():
         url = settings.MATOMO_URL
     except AttributeError:
         raise ImproperlyConfigured('MATOMO_URL does not exist.')
-    return {'id': id, 'url': url}
+    cookie_disabled = False
+    try:
+        cookie_disabled = settings.TRACKING_COOKIE_DISABLED
+    except AttributeError:
+        pass
+    return {'id': id, 'url': url, 'cookie_disabled': cookie_disabled}


### PR DESCRIPTION
In order to avoid having to show a cookie banner.

---

This is actually for a+, but as meinberlin-dev is already set up on matomo, lets test the code here first.