### PR TITLE
Revert "webpack: Use optimized static files for dsgvo-embed"

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -98,7 +98,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: /node_modules\/(?!(adhocracy4)\/).*/, // exclude most dependencies
+        exclude: /node_modules\/(?!(adhocracy4|dsgvo-video-embed)\/).*/, // exclude most dependencies
         loader: 'babel-loader',
         options: {
           presets: ['@babel/preset-env', '@babel/preset-react'].map(require.resolve),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -41,8 +41,8 @@ module.exports = {
       './meinberlin/assets/js/unload_warning.js'
     ],
     dsgvo_video_embed: [
-      'dsgvo-video-embed/dist/dsgvo-video-embed.min.css',
-      'dsgvo-video-embed/dist/dsgvo-video-embed.min.js'
+      'dsgvo-video-embed/css/dsgvo-video-embed.css',
+      'dsgvo-video-embed/js/dsgvo-video-embed.js'
     ],
     // A4 dependencies - we want all of them to go through webpack
     mb_plans_map: [


### PR DESCRIPTION
As we use our own fork and there's no clear way to rebuild the optimized files, don't use them. Instead, lets optimize it in webpack for now.