### PR TITLE
deps: update a4 and adapt to project access enum

### DIFF
--- a/meinberlin/apps/cms/blocks.py
+++ b/meinberlin/apps/cms/blocks.py
@@ -3,6 +3,7 @@ from django.utils.functional import cached_property
 from wagtail.core import blocks
 from wagtail.images.blocks import ImageChooserBlock
 
+from adhocracy4.projects.models import Access
 from adhocracy4.projects.models import Project
 
 
@@ -16,7 +17,7 @@ class ProjectSelectionBlock(blocks.ChooserBlock):
             queryset=self.target_model.objects.filter(
                 is_draft=False,
                 is_archived=False,
-                is_public=True),
+                access=Access.PUBLIC),
             widget=self.widget,
             required=self._required,
             help_text=self._help_text)

--- a/meinberlin/apps/cms/blocks.py
+++ b/meinberlin/apps/cms/blocks.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db.models import Q
 from django.utils.functional import cached_property
 from wagtail.core import blocks
 from wagtail.images.blocks import ImageChooserBlock
@@ -15,9 +16,10 @@ class ProjectSelectionBlock(blocks.ChooserBlock):
     def field(self):
         return forms.ModelChoiceField(
             queryset=self.target_model.objects.filter(
+                Q(access=Access.PUBLIC) |
+                Q(access=Access.SEMIPUBLIC),
                 is_draft=False,
-                is_archived=False,
-                access=Access.PUBLIC),
+                is_archived=False),
             widget=self.widget,
             required=self._required,
             help_text=self._help_text)

--- a/meinberlin/apps/cms/models/storefronts.py
+++ b/meinberlin/apps/cms/models/storefronts.py
@@ -11,6 +11,7 @@ from wagtail.snippets.models import register_snippet
 
 from adhocracy4.comments.models import Comment
 from adhocracy4.modules.models import Item
+from adhocracy4.projects.enums import Access
 from adhocracy4.projects.models import Project
 from meinberlin.apps.plans.models import Plan
 from meinberlin.apps.projects import get_project_type
@@ -56,7 +57,7 @@ class StorefrontItem(models.Model):
         projects = Project.objects\
             .filter(administrative_district=self.district,
                     is_draft=False,
-                    is_public=True,
+                    access=Access.PUBLIC,
                     is_archived=False
                     )
         plans = Plan.objects\
@@ -100,7 +101,7 @@ class Storefront(ClusterableModel):
     @cached_property
     def num_projects(self):
         projects = Project.objects.all()\
-            .filter(is_draft=False, is_archived=False, is_public=True)
+            .filter(is_draft=False, is_archived=False, access=Access.PUBLIC)
         active_project_count = 0
         for project in projects:
             if project.active_phase or project.future_phases:

--- a/meinberlin/apps/cms/models/storefronts.py
+++ b/meinberlin/apps/cms/models/storefronts.py
@@ -1,6 +1,7 @@
 import random
 
 from django.db import models
+from django.db.models import Q
 from django.utils.functional import cached_property
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
@@ -55,9 +56,9 @@ class StorefrontItem(models.Model):
     @cached_property
     def district_project_count(self):
         projects = Project.objects\
-            .filter(administrative_district=self.district,
+            .filter(Q(access=Access.PUBLIC) | Q(access=Access.SEMIPUBLIC),
+                    administrative_district=self.district,
                     is_draft=False,
-                    access=Access.PUBLIC,
                     is_archived=False
                     )
         plans = Plan.objects\
@@ -100,8 +101,9 @@ class Storefront(ClusterableModel):
 
     @cached_property
     def num_projects(self):
-        projects = Project.objects.all()\
-            .filter(is_draft=False, is_archived=False, access=Access.PUBLIC)
+        projects = Project.objects.all().filter(
+            Q(access=Access.PUBLIC) | Q(access=Access.SEMIPUBLIC),
+            is_draft=False, is_archived=False)
         active_project_count = 0
         for project in projects:
             if project.active_phase or project.future_phases:

--- a/meinberlin/apps/cms/templates/meinberlin_cms/blocks/projects_block.html
+++ b/meinberlin/apps/cms/templates/meinberlin_cms/blocks/projects_block.html
@@ -3,7 +3,7 @@
     <h2>{{ value.title }}</h2>
     <ul class="l-tiles-4">
         {% for project in value.projects %}
-            {% if project and project.is_public and not project.is_draft %}
+            {% if project and not project.is_private and not project.is_draft %}
                 {% include "meinberlin_projects/includes/project_tile.html" with project=project %}
             {% endif %}
         {% endfor %}

--- a/meinberlin/apps/contrib/sitemaps/adhocracy4_sitemap.py
+++ b/meinberlin/apps/contrib/sitemaps/adhocracy4_sitemap.py
@@ -1,5 +1,6 @@
 from django.contrib.sitemaps import Sitemap
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.projects.models import Project
 
 
@@ -8,4 +9,4 @@ class Adhocracy4Sitemap(Sitemap):
     priority = 0.8
 
     def items(self):
-        return Project.objects.filter(is_draft=False, is_public=True)
+        return Project.objects.filter(is_draft=False, access=Access.PUBLIC)

--- a/meinberlin/apps/contrib/sitemaps/adhocracy4_sitemap.py
+++ b/meinberlin/apps/contrib/sitemaps/adhocracy4_sitemap.py
@@ -1,4 +1,5 @@
 from django.contrib.sitemaps import Sitemap
+from django.db.models import Q
 
 from adhocracy4.projects.enums import Access
 from adhocracy4.projects.models import Project
@@ -9,4 +10,6 @@ class Adhocracy4Sitemap(Sitemap):
     priority = 0.8
 
     def items(self):
-        return Project.objects.filter(is_draft=False, access=Access.PUBLIC)
+        return Project.objects.filter(
+            Q(access=Access.PUBLIC) | Q(access=Access.SEMIPUBLIC),
+            is_draft=False)

--- a/meinberlin/apps/dashboard/forms.py
+++ b/meinberlin/apps/dashboard/forms.py
@@ -29,12 +29,19 @@ class DashboardProjectCreateForm(ProjectCreateForm):
 
     class Meta:
         model = project_models.Project
-        fields = ['name', 'description', 'is_public']
+        fields = ['name', 'description', 'access']
         widgets = {
-            'is_public': forms.RadioSelect(
+            'access': forms.RadioSelect(
                 choices=[
-                    (True, _('All users can participate (public).')),
-                    (False, _('Only invited users can participate (private).'))
+                    (project_models.Access.PUBLIC.value,
+                     _('All users can see project tile and content and can '
+                       'participate (public).')),
+                    (project_models.Access.SEMIPUBLIC.value,
+                     _('All users can see project tile and content, only '
+                       'invited users can participate (semi-public).')),
+                    (project_models.Access.PRIVATE.value,
+                     _('Only invited users can see project tile and content '
+                       'and can participate (private).'))
                 ]
             )
         }

--- a/meinberlin/apps/dashboard/forms.py
+++ b/meinberlin/apps/dashboard/forms.py
@@ -32,6 +32,8 @@ class DashboardProjectCreateForm(ProjectCreateForm):
         fields = ['name', 'description', 'access']
         widgets = {
             'access': forms.RadioSelect(
+                # FIXME: these choices are currently ignored by djangos widget
+                # machinery - we work around that in apps/projects/overwrites
                 choices=[
                     (project_models.Access.PUBLIC.value,
                      _('All users can see project tile and content and can '

--- a/meinberlin/apps/extprojects/api.py
+++ b/meinberlin/apps/extprojects/api.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 from rest_framework import viewsets
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.extprojects.models import ExternalProject
 from meinberlin.apps.extprojects.serializers import ExternalProjectSerializer
 
@@ -11,7 +12,7 @@ class ExternalProjectListViewSet(viewsets.ReadOnlyModelViewSet):
         return ExternalProject.objects.filter(
             project_type='meinberlin_extprojects.ExternalProject',
             is_draft=False,
-            is_public=True,
+            access=Access.PUBLIC,
             is_archived=False
         )
 

--- a/meinberlin/apps/extprojects/serializers.py
+++ b/meinberlin/apps/extprojects/serializers.py
@@ -10,7 +10,7 @@ class ExternalProjectSerializer(ProjectSerializer):
                   'organisation', 'tile_image',
                   'tile_image_copyright',
                   'point', 'point_label', 'cost',
-                  'district', 'topics', 'is_public',
+                  'district', 'topics', 'access',
                   'status',
                   'participation_string',
                   'participation_active',

--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -224,7 +224,7 @@ class PlansList extends React.Component {
             </div>}
           {item.subtype === 'external' &&
             <div className="maplist-item__corner-badge maplist-item__corner-badge--external" />}
-          {!item.is_public && item.type === 'project' &&
+          {item.access === 3 && item.type === 'project' &&
             <div className="maplist-item__corner-badge maplist-item__corner-badge--private" />}
         </a>
       </li>

--- a/meinberlin/apps/plans/models.py
+++ b/meinberlin/apps/plans/models.py
@@ -13,6 +13,7 @@ from adhocracy4.maps import fields as map_fields
 from adhocracy4.models.base import UserGeneratedContentModel
 from adhocracy4.phases.models import Phase
 from adhocracy4.projects import models as project_models
+from adhocracy4.projects.enums import Access
 from adhocracy4.projects.fields import TopicField
 
 
@@ -127,7 +128,7 @@ class Plan(UserGeneratedContentModel):
     @cached_property
     def published_projects(self):
         return self.projects.filter(
-            is_draft=False, is_public=True, is_archived=False)
+            is_draft=False, access=Access.PUBLIC, is_archived=False)
 
     @cached_property
     def participation_string(self):

--- a/meinberlin/apps/plans/models.py
+++ b/meinberlin/apps/plans/models.py
@@ -2,6 +2,7 @@ from ckeditor.fields import RichTextField
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db import models
+from django.db.models import Q
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
@@ -128,7 +129,8 @@ class Plan(UserGeneratedContentModel):
     @cached_property
     def published_projects(self):
         return self.projects.filter(
-            is_draft=False, access=Access.PUBLIC, is_archived=False)
+            Q(access=Access.PUBLIC) | Q(access=Access.SEMIPUBLIC),
+            is_draft=False, is_archived=False)
 
     @cached_property
     def participation_string(self):

--- a/meinberlin/apps/projectcontainers/api.py
+++ b/meinberlin/apps/projectcontainers/api.py
@@ -1,6 +1,7 @@
 from django.utils import timezone
 from rest_framework import viewsets
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.projectcontainers.models import ProjectContainer
 from meinberlin.apps.projectcontainers.serializers import \
     ProjectContainerSerializer
@@ -11,7 +12,7 @@ class ProjectContainerListViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         containers = ProjectContainer.objects.filter(
             is_draft=False,
-            is_public=True,
+            access=Access.PUBLIC,
             is_archived=False
         )
         return containers

--- a/meinberlin/apps/projectcontainers/forms.py
+++ b/meinberlin/apps/projectcontainers/forms.py
@@ -81,7 +81,8 @@ class ContainerProjectsForm(ProjectDashboardForm):
             .filter(Q(containers=self.instance) |
                     (Q(containers=None) &
                      Q(is_archived=False) &
-                     Q(access=Access.PUBLIC)))\
+                     Q(access=Access.PUBLIC) |
+                     Q(access=Access.SEMIPUBLIC)))\
             .order_by('name')
 
     class Meta:

--- a/meinberlin/apps/projectcontainers/forms.py
+++ b/meinberlin/apps/projectcontainers/forms.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.dashboard.forms import ProjectCreateForm
 from adhocracy4.dashboard.forms import ProjectDashboardForm
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.contrib.widgets import Select2MultipleWidget
 
 from . import models
@@ -80,7 +81,7 @@ class ContainerProjectsForm(ProjectDashboardForm):
             .filter(Q(containers=self.instance) |
                     (Q(containers=None) &
                      Q(is_archived=False) &
-                     Q(is_public=True)))\
+                     Q(access=Access.PUBLIC)))\
             .order_by('name')
 
     class Meta:

--- a/meinberlin/apps/projectcontainers/models.py
+++ b/meinberlin/apps/projectcontainers/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
@@ -23,12 +24,13 @@ class ProjectContainer(project_models.Project):
     def active_project_count(self):
         """Return the number of active projects within the container.
 
-        If a container is public (default) only public projects are counted.
-        For future private containers all projects should be counted.
+        A container is public by default, only public and semipublic
+        projects are counted.
         """
         now = timezone.now()
         return self.projects\
-            .filter(access=Access.PUBLIC, is_draft=False, is_archived=False)\
+            .filter(Q(access=Access.PUBLIC) | Q(access=Access.SEMIPUBLIC),
+                    is_draft=False, is_archived=False)\
             .filter(module__phase__start_date__lte=now,
                     module__phase__end_date__gt=now)\
             .distinct()\
@@ -38,12 +40,13 @@ class ProjectContainer(project_models.Project):
     def future_project_count(self):
         """Return the number of future projects within the container.
 
-        If a container is public (default) only public projects are counted.
-        For future private containers all projects should be counted.
+        A container is public by default, only public and semipublic
+        projects are counted.
         """
         now = timezone.now()
         return self.projects\
-            .filter(access=Access.PUBLIC, is_draft=False, is_archived=False)\
+            .filter(Q(access=Access.PUBLIC) | Q(access=Access.SEMIPUBLIC),
+                    is_draft=False, is_archived=False)\
             .filter(module__phase__start_date__gt=now)\
             .distinct()\
             .count()
@@ -52,11 +55,12 @@ class ProjectContainer(project_models.Project):
     def total_project_count(self):
         """Return the number of total projects within the container.
 
-        If a container is public (default) only public projects are counted.
-        For future private containers all projects should be counted.
+        A container is public by default, only public and semipublic
+        projects are counted.
         """
         return self.projects \
-            .filter(access=Access.PUBLIC, is_draft=False, is_archived=False)\
+            .filter(Q(access=Access.PUBLIC) | Q(access=Access.SEMIPUBLIC),
+                    is_draft=False, is_archived=False)\
             .count()
 
     @property

--- a/meinberlin/apps/projectcontainers/models.py
+++ b/meinberlin/apps/projectcontainers/models.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.projects import models as project_models
+from adhocracy4.projects.enums import Access
 
 
 class ProjectContainer(project_models.Project):
@@ -27,7 +28,7 @@ class ProjectContainer(project_models.Project):
         """
         now = timezone.now()
         return self.projects\
-            .filter(is_public=True, is_draft=False, is_archived=False)\
+            .filter(access=Access.PUBLIC, is_draft=False, is_archived=False)\
             .filter(module__phase__start_date__lte=now,
                     module__phase__end_date__gt=now)\
             .distinct()\
@@ -42,7 +43,7 @@ class ProjectContainer(project_models.Project):
         """
         now = timezone.now()
         return self.projects\
-            .filter(is_public=True, is_draft=False, is_archived=False)\
+            .filter(access=Access.PUBLIC, is_draft=False, is_archived=False)\
             .filter(module__phase__start_date__gt=now)\
             .distinct()\
             .count()
@@ -55,7 +56,7 @@ class ProjectContainer(project_models.Project):
         For future private containers all projects should be counted.
         """
         return self.projects \
-            .filter(is_public=True, is_draft=False, is_archived=False)\
+            .filter(access=Access.PUBLIC, is_draft=False, is_archived=False)\
             .count()
 
     @property

--- a/meinberlin/apps/projectcontainers/serializers.py
+++ b/meinberlin/apps/projectcontainers/serializers.py
@@ -14,7 +14,7 @@ class ProjectContainerSerializer(ProjectSerializer):
                   'organisation', 'tile_image',
                   'tile_image_copyright',
                   'point', 'point_label', 'cost',
-                  'district', 'topics', 'is_public',
+                  'district', 'topics', 'access',
                   'status',
                   'participation_string',
                   'participation_active',

--- a/meinberlin/apps/projects/admin.py
+++ b/meinberlin/apps/projects/admin.py
@@ -45,7 +45,7 @@ class ProjectAdmin(admin.ModelAdmin):
         }),
         (_('Settings'), {
             'classes': ('collapse',),
-            'fields': ('is_public', 'is_draft', 'is_archived',
+            'fields': ('access', 'is_draft', 'is_archived',
                        'moderators', 'participants', 'project_type')
         }),
         (_('Images'), {

--- a/meinberlin/apps/projects/api.py
+++ b/meinberlin/apps/projects/api.py
@@ -21,9 +21,10 @@ class ProjectListViewSet(viewsets.ReadOnlyModelViewSet):
         projects = Project.objects \
             .filter(Q(project_type='a4projects.Project') |
                     Q(project_type='meinberlin_bplan.Bplan')) \
-            .filter(is_draft=False,
-                    is_archived=False,
-                    access=Access.PUBLIC)\
+            .filter(Q(access=Access.PUBLIC) |
+                    Q(access=Access.SEMIPUBLIC),
+                    is_draft=False,
+                    is_archived=False)\
             .order_by('created') \
             .select_related('administrative_district',
                             'organisation') \

--- a/meinberlin/apps/projects/api.py
+++ b/meinberlin/apps/projects/api.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.projects.models import Project
 from meinberlin.apps.projects import serializers as project_serializers
 from meinberlin.apps.projects.filters import StatusFilter
@@ -22,7 +23,7 @@ class ProjectListViewSet(viewsets.ReadOnlyModelViewSet):
                     Q(project_type='meinberlin_bplan.Bplan')) \
             .filter(is_draft=False,
                     is_archived=False,
-                    is_public=True)\
+                    access=Access.PUBLIC)\
             .order_by('created') \
             .select_related('administrative_district',
                             'organisation') \
@@ -59,7 +60,7 @@ class PrivateProjectListViewSet(viewsets.ReadOnlyModelViewSet):
         private_projects = Project.objects.filter(
             is_draft=False,
             is_archived=False,
-            is_public=False)
+            access=Access.PRIVATE)
         if private_projects:
             not_allowed_projects = \
                 [project.id for project in private_projects if

--- a/meinberlin/apps/projects/apps.py
+++ b/meinberlin/apps/projects/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = 'meinberlin.apps.projects'
     label = 'meinberlin_projects'
+
+    def ready(self):
+        from . import overwrites
+        overwrites.overwrite_access_enum_label()

--- a/meinberlin/apps/projects/dashboard.py
+++ b/meinberlin/apps/projects/dashboard.py
@@ -15,7 +15,7 @@ class ParticipantsComponent(DashboardComponent):
     label = _('Participants')
 
     def is_effective(self, project):
-        return not project.is_draft and project.is_private
+        return not project.is_draft and not project.is_public
 
     def get_base_url(self, project):
         return reverse('a4dashboard:dashboard-participants-edit', kwargs={

--- a/meinberlin/apps/projects/overwrites.py
+++ b/meinberlin/apps/projects/overwrites.py
@@ -1,0 +1,15 @@
+from django.utils.translation import ugettext_lazy as _
+
+from adhocracy4.projects.enums import Access
+
+
+def overwrite_access_enum_label():
+    Access.__labels__ = {
+        Access.PRIVATE: _('Only invited users can see project tile and '
+                          'content and can participate (private).'),
+        Access.PUBLIC: _('All users can see project tile and content and can '
+                         'participate (public).'),
+        Access.SEMIPUBLIC: _('All users can see project tile and content, '
+                             'only invited users can participate '
+                             '(semi-public).')
+    }

--- a/meinberlin/apps/projects/rules.py
+++ b/meinberlin/apps/projects/rules.py
@@ -3,10 +3,11 @@ from rules.predicates import is_superuser
 
 from adhocracy4.organisations.predicates import is_initiator
 from adhocracy4.projects.predicates import is_live
-from adhocracy4.projects.predicates import is_member
 from adhocracy4.projects.predicates import is_moderator
 from adhocracy4.projects.predicates import is_prj_group_member
+from adhocracy4.projects.predicates import is_project_member
 from adhocracy4.projects.predicates import is_public
+from adhocracy4.projects.predicates import is_semipublic
 
 rules.remove_perm('a4projects.change_project')
 rules.add_perm('a4projects.change_project',
@@ -17,4 +18,9 @@ rules.remove_perm('a4projects.view_project')
 rules.add_perm('a4projects.view_project',
                is_superuser | is_initiator |
                is_moderator | is_prj_group_member |
-               ((is_public | is_member) & is_live))
+               ((is_public | is_semipublic | is_project_member)
+                & is_live))
+
+rules.set_perm('a4projects.participate_in_project',
+               is_superuser | is_initiator | is_moderator |
+               ((is_public | is_project_member) & is_live))

--- a/meinberlin/apps/projects/serializers.py
+++ b/meinberlin/apps/projects/serializers.py
@@ -69,7 +69,7 @@ class ProjectSerializer(serializers.ModelSerializer, CommonFields):
                   'organisation', 'tile_image',
                   'tile_image_copyright',
                   'point', 'point_label', 'cost',
-                  'district', 'topics', 'is_public',
+                  'district', 'topics', 'access',
                   'status',
                   'participation_string',
                   'participation_active',

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -1,4 +1,4 @@
-{% load i18n project_tags meinberlin_project_tags contrib_tags thumbnail static %}
+{% load i18n project_tags meinberlin_project_tags contrib_tags thumbnail static rules %}
 {% project_tile_image project as project_image %}
 {% project_tile_image_copyright project as project_image_copyright %}
 <li class="participation-tile__vertical">
@@ -35,7 +35,8 @@
                 <div class="participation-tile__spacer"></div>
                 {% if module.module_running_time_left %}
                 <div class="participation-tile__btn">
-                    <a class="btn btn--full u-spacer-bottom btn--small" href="{% url 'module-detail' module.slug %}">{% trans 'Join now' %}</a>
+                    {% has_perm 'a4projects.participate_in_project' request.user project as user_may_participate_in_project %}
+                    <a class="btn btn--full u-spacer-bottom btn--small" href="{% url 'module-detail' module.slug %}">{% if user_may_participate_in_project %}{% trans 'Join now' %}{% else %}{% trans 'Read now' %}{% endif %}</a>
                 </div>
                 {% endif %}
             </div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
@@ -87,7 +87,7 @@
         </div>
         {% if project|is_external %}
         <div class="maplist-item__corner-badge maplist-item__corner-badge--external"></div>
-        {% elif not project.is_public %}
+        {% elif project.is_private %}
         <div class="maplist-item__corner-badge maplist-item__corner-badge--private"></div>
         {% endif %}
     </a>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -235,6 +235,21 @@
                 {% endwith %}
             {% endif %}
         </div>
+        {% if not view.is_project_view %}
+        <div class="l-wrapper">
+            <div class="l-center-6 u-spacer-bottom-double">
+            {% if project.is_private %}
+                <div class="">
+                    <i class="fas fa-lock u-spacer-right" aria-hidden="true"></i>{% trans 'This project is not publicly visible. Only invited users can see content and actively participate.' %}
+                </div>
+            {% elif project.is_semipublic %}
+                <div class="">
+                    <i class="fas fa-eye u-spacer-right" aria-hidden="true"></i>{% trans 'This project is publicly visible. Invited users can actively participate.' %}
+                </div>
+            {% endif %}
+            </div>
+        </div>
+        {% endif %}
         <!-- these blocks are only filled when in phase view -->
         <div class="l-wrapper">
             <div class="l-center-6">

--- a/meinberlin/templates/a4dashboard/includes/project_basic_form.html
+++ b/meinberlin/templates/a4dashboard/includes/project_basic_form.html
@@ -8,7 +8,7 @@
 
 {% include 'a4dashboard/includes/form_field.html' with field=form.description %}
 
-{% include 'a4dashboard/includes/form_field.html' with field=form.is_public %}
+{% include 'a4dashboard/includes/form_field.html' with field=form.access %}
 
 {% include 'meinberlin_embed/includes/project_embed_code.html' with project=project %}
 

--- a/meinberlin/templates/a4dashboard/includes/project_list_item.html
+++ b/meinberlin/templates/a4dashboard/includes/project_list_item.html
@@ -17,7 +17,9 @@
                         {% if project.has_finished %}
                             <span class="label label--primary">{% trans "Finished" %}</span>
                         {% endif %}
-                        {% if not project.is_public %}
+                        {% if project.is_semipublic %}
+                            <span class="label label--secondary">{% trans 'Semipublic' %}</span>
+                        {% elif project.is_private %}
                             <span class="label label--secondary">{% trans 'Private' %}</span>
                         {% endif %}
                     {% endif %}

--- a/meinberlin/templates/a4dashboard/project_create_form.html
+++ b/meinberlin/templates/a4dashboard/project_create_form.html
@@ -36,7 +36,7 @@
 
                 {% include 'a4forms/includes/form_field.html' with field=form.description %}
 
-                {% include 'a4dashboard/includes/form_field.html' with field=form.is_public %}
+                {% include 'a4dashboard/includes/form_field.html' with field=form.access %}
 
                 <div class="u-spacer-bottom">
                     <input type="submit" class="btn btn--primary" name="send" value="{% trans 'Save' %}"/>

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -116,6 +116,19 @@
     </div>
 
     <div class="l-wrapper">
+        <div class="l-center-6 u-spacer-bottom-double">
+        {% if project.is_private %}
+            <div class="">
+                <i class="fas fa-lock u-spacer-right" aria-hidden="true"></i>{% trans 'This project is not publicly visible. Only invited users can see content and actively participate.' %}
+            </div>
+        {% elif project.is_semipublic %}
+            <div class="">
+                <i class="fas fa-eye u-spacer-right" aria-hidden="true"></i>{% trans 'This project is publicly visible. Invited users can actively participate.' %}
+            </div>
+        {% endif %}
+        </div>
+    </div>
+    <div class="l-wrapper">
         <div class="l-center-6">
         {% block project_action %}{% endblock %}
         </div>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.12.1",
     "@fortawesome/fontawesome-free": "5.15.1",
     "acorn": "8.0.4",
-    "adhocracy4": "liqd/adhocracy4#mB-v2.6.2",
+    "adhocracy4": "liqd/adhocracy4#f9a7efc50cd7d1242fa99c540d349528efb18654",
     "autoprefixer": "10.0.1",
     "axios": "0.21.0",
     "babel-loader": "8.1.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@mB-v2.6.2#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@f9a7efc50cd7d1242fa99c540d349528efb18654#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0
@@ -21,6 +21,7 @@ django-allauth==0.42.0
 django-autoslug==1.9.8
 django-background-tasks==1.2.5
 django-ckeditor==6.0.0
+django-enumfield==2.0.2
 django-filter==2.4.0
 django-multiselectfield==0.1.12
 django-widget-tweaks==1.4.8

--- a/tests/budgeting/rules/test_rules_add.py
+++ b/tests/budgeting/rules/test_rules_add.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.budgeting import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.RequestPhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.RequestPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)

--- a/tests/budgeting/rules/test_rules_view.py
+++ b/tests/budgeting/rules/test_rules_view.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.budgeting import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, proposal_factory, user):
                                           phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, proposal_factory, user):
                                           phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -46,14 +47,14 @@ def test_phase_active(phase_factory, proposal_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, proposal_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, proposal_factory,
-                                          phases.RequestPhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, proposal_factory, phases.RequestPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)

--- a/tests/dashboard/test_dashboard_views.py
+++ b/tests/dashboard/test_dashboard_views.py
@@ -20,7 +20,8 @@ def test_project_create(client, organisation, user_factory, group_factory):
 
     data = {
         'name': 'project name',
-        'description': 'project description'
+        'description': 'project description',
+        'access': 1
     }
 
     response = client.post(project_create_url, data)

--- a/tests/documents/rules/test_rules_add_chapter.py
+++ b/tests/documents/rules/test_rules_add_chapter.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.documents import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.CommentPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.CommentPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.CommentPhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.CommentPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)

--- a/tests/documents/rules/test_rules_comment_paragraph.py
+++ b/tests/documents/rules/test_rules_comment_paragraph.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.documents import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -22,7 +23,7 @@ def test_pre_phase(phase_factory, chapter_factory, paragraph_factory, user):
     anonymous, moderator, initiator = setup_users(project)
     paragraph = paragraph_factory(chapter=item)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
@@ -37,7 +38,7 @@ def test_phase_active(phase_factory, chapter_factory, paragraph_factory, user):
     anonymous, moderator, initiator = setup_users(project)
     paragraph = paragraph_factory(chapter=item)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
@@ -48,15 +49,15 @@ def test_phase_active(phase_factory, chapter_factory, paragraph_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, chapter_factory,
                                       paragraph_factory, user, user2):
-    phase, _, project, item = setup_phase(phase_factory, chapter_factory,
-                                          phases.CommentPhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, chapter_factory, phases.CommentPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
     paragraph = paragraph_factory(chapter=item)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
@@ -68,9 +69,9 @@ def test_phase_active_project_private(phase_factory, chapter_factory,
 @pytest.mark.django_db
 def test_phase_active_project_draft(phase_factory, chapter_factory,
                                     paragraph_factory, user):
-    phase, _, project, item = setup_phase(phase_factory, chapter_factory,
-                                          phases.CommentPhase,
-                                          module__project__is_draft=True)
+    phase, _, project, item = setup_phase(
+        phase_factory, chapter_factory, phases.CommentPhase,
+        module__project__is_draft=True)
     anonymous, moderator, initiator = setup_users(project)
     paragraph = paragraph_factory(chapter=item)
 

--- a/tests/documents/rules/test_rules_view_chapter.py
+++ b/tests/documents/rules/test_rules_view_chapter.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.documents import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, chapter_factory, user):
                                           phases.CommentPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, chapter_factory, user):
                                           phases.CommentPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -46,14 +47,14 @@ def test_phase_active(phase_factory, chapter_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, chapter_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, chapter_factory,
-                                          phases.CommentPhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, chapter_factory, phases.CommentPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)

--- a/tests/documents/rules/test_rules_view_paragraph.py
+++ b/tests/documents/rules/test_rules_view_paragraph.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.documents import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -22,7 +23,7 @@ def test_pre_phase(phase_factory, chapter_factory, paragraph_factory, user):
     anonymous, moderator, initiator = setup_users(project)
     paragraph = paragraph_factory(chapter=item)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
@@ -37,7 +38,7 @@ def test_phase_active(phase_factory, chapter_factory, paragraph_factory, user):
     anonymous, moderator, initiator = setup_users(project)
     paragraph = paragraph_factory(chapter=item)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
@@ -48,15 +49,15 @@ def test_phase_active(phase_factory, chapter_factory, paragraph_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, chapter_factory,
                                       paragraph_factory, user, user2):
-    phase, _, project, item = setup_phase(phase_factory, chapter_factory,
-                                          phases.CommentPhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, chapter_factory, phases.CommentPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
     paragraph = paragraph_factory(chapter=item)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)

--- a/tests/ideas/rules/test_rules_add.py
+++ b/tests/ideas/rules/test_rules_add.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.ideas import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.CollectPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.CollectPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.CollectPhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.CollectPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)

--- a/tests/ideas/rules/test_rules_view.py
+++ b/tests/ideas/rules/test_rules_view.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.ideas import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, idea_factory, user):
                                           phases.CollectPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, idea_factory, user):
                                           phases.CollectPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -46,14 +47,14 @@ def test_phase_active(phase_factory, idea_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, idea_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, idea_factory,
-                                          phases.CollectPhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, idea_factory, phases.CollectPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)

--- a/tests/ideas/views/test_idea_detail.py
+++ b/tests/ideas/views/test_idea_detail.py
@@ -1,5 +1,6 @@
 import pytest
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.test.helpers import redirect_target
 from meinberlin.apps.ideas import phases
 from meinberlin.test.helpers import assert_template_response
@@ -20,13 +21,12 @@ def test_detail_view(client, phase_factory, idea_factory):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('idea__module__project__is_public', [False])
 def test_detail_view_private_not_visible_anonymous(client,
                                                    phase_factory,
                                                    idea_factory):
     phase, module, project, idea = setup_phase(
         phase_factory, idea_factory, phases.FeedbackPhase)
-    idea.module.project.is_public = False
+    idea.module.project.access = Access.PRIVATE
     idea.module.project.save()
     url = idea.get_absolute_url()
     response = client.get(url)
@@ -35,14 +35,13 @@ def test_detail_view_private_not_visible_anonymous(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('idea__module__project__is_public', [False])
 def test_detail_view_private_not_visible_normal_user(client,
                                                      user,
                                                      phase_factory,
                                                      idea_factory):
     phase, module, project, idea = setup_phase(
         phase_factory, idea_factory, phases.FeedbackPhase)
-    idea.module.project.is_public = False
+    idea.module.project.access = Access.PRIVATE
     idea.module.project.save()
     assert user not in idea.module.project.participants.all()
     client.login(username=user.email,
@@ -53,14 +52,13 @@ def test_detail_view_private_not_visible_normal_user(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('idea__module__project__is_public', [False])
 def test_detail_view_private_visible_to_participant(client,
                                                     user,
                                                     phase_factory,
                                                     idea_factory):
     phase, module, project, idea = setup_phase(
         phase_factory, idea_factory, phases.FeedbackPhase)
-    idea.module.project.is_public = False
+    idea.module.project.access = Access.PRIVATE
     idea.module.project.save()
     url = idea.get_absolute_url()
     assert user not in idea.module.project.participants.all()
@@ -72,13 +70,12 @@ def test_detail_view_private_visible_to_participant(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('idea__module__project__is_public', [False])
 def test_detail_view_private_visible_to_moderator(client,
                                                   phase_factory,
                                                   idea_factory):
     phase, module, project, idea = setup_phase(
         phase_factory, idea_factory, phases.FeedbackPhase)
-    idea.module.project.is_public = False
+    idea.module.project.access = Access.PRIVATE
     idea.module.project.save()
     url = idea.get_absolute_url()
     user = idea.project.moderators.first()
@@ -89,13 +86,12 @@ def test_detail_view_private_visible_to_moderator(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('idea__module__project__is_public', [False])
 def test_detail_view_private_visible_to_initiator(client,
                                                   phase_factory,
                                                   idea_factory):
     phase, module, project, idea = setup_phase(
         phase_factory, idea_factory, phases.FeedbackPhase)
-    idea.module.project.is_public = False
+    idea.module.project.access = Access.PRIVATE
     idea.module.project.save()
     url = idea.get_absolute_url()
     user = idea.project.organisation.initiators.first()

--- a/tests/kiezkasse/rules/test_rules_add.py
+++ b/tests/kiezkasse/rules/test_rules_add.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.kiezkasse import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.RequestPhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.RequestPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)

--- a/tests/kiezkasse/rules/test_rules_view.py
+++ b/tests/kiezkasse/rules/test_rules_view.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.kiezkasse import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, proposal_factory, user):
                                           phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, proposal_factory, user):
                                           phases.RequestPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -46,14 +47,14 @@ def test_phase_active(phase_factory, proposal_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, proposal_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, proposal_factory,
-                                          phases.RequestPhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, proposal_factory, phases.RequestPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)

--- a/tests/livequestions/rules/test_rules_propose.py
+++ b/tests/livequestions/rules/test_rules_propose.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.livequestions import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.IssuePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.IssuePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, module)
         assert rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.IssuePhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.IssuePhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, module)
         assert rules.has_perm(perm_name, user, module)

--- a/tests/livequestions/rules/test_rules_view.py
+++ b/tests/livequestions/rules/test_rules_view.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.livequestions import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, live_question_factory, user):
                                           phases.IssuePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, live_question_factory, user):
                                           phases.IssuePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -46,14 +47,14 @@ def test_phase_active(phase_factory, live_question_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, live_question_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, live_question_factory,
-                                          phases.IssuePhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, live_question_factory, phases.IssuePhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)

--- a/tests/mapideas/rules/test_rules_add.py
+++ b/tests/mapideas/rules/test_rules_add.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.mapideas import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.CollectPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.CollectPhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.CollectPhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.CollectPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)

--- a/tests/mapideas/rules/test_rules_view.py
+++ b/tests/mapideas/rules/test_rules_view.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.mapideas import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -46,9 +47,9 @@ def test_phase_active(phase_factory, map_idea_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, map_idea_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, map_idea_factory,
-                                          phases.CollectPhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, map_idea_factory, phases.CollectPhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)

--- a/tests/mapideas/views/test_mapidea_detail.py
+++ b/tests/mapideas/views/test_mapidea_detail.py
@@ -1,5 +1,6 @@
 import pytest
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.test.helpers import redirect_target
 from meinberlin.apps.mapideas import phases
 from meinberlin.test.helpers import assert_template_response
@@ -20,13 +21,12 @@ def test_detail_view(client, phase_factory, map_idea_factory):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('mapidea__module__project__is_public', [False])
 def test_detail_view_private_not_visible_anonymous(client,
                                                    phase_factory,
                                                    map_idea_factory):
     phase, module, project, mapidea = setup_phase(
         phase_factory, map_idea_factory, phases.FeedbackPhase)
-    mapidea.module.project.is_public = False
+    mapidea.module.project.access = Access.PRIVATE
     mapidea.module.project.save()
     url = mapidea.get_absolute_url()
     response = client.get(url)
@@ -35,14 +35,13 @@ def test_detail_view_private_not_visible_anonymous(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('mapidea__module__project__is_public', [False])
 def test_detail_view_private_not_visible_normal_user(client,
                                                      user,
                                                      phase_factory,
                                                      map_idea_factory):
     phase, module, project, mapidea = setup_phase(
         phase_factory, map_idea_factory, phases.FeedbackPhase)
-    mapidea.module.project.is_public = False
+    mapidea.module.project.access = Access.PRIVATE
     mapidea.module.project.save()
     assert user not in mapidea.module.project.participants.all()
     client.login(username=user.email,
@@ -53,14 +52,13 @@ def test_detail_view_private_not_visible_normal_user(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('mapidea__module__project__is_public', [False])
 def test_detail_view_private_visible_to_participant(client,
                                                     user,
                                                     phase_factory,
                                                     map_idea_factory):
     phase, module, project, mapidea = setup_phase(
         phase_factory, map_idea_factory, phases.FeedbackPhase)
-    mapidea.module.project.is_public = False
+    mapidea.module.project.access = Access.PRIVATE
     mapidea.module.project.save()
     url = mapidea.get_absolute_url()
     assert user not in mapidea.module.project.participants.all()
@@ -72,13 +70,12 @@ def test_detail_view_private_visible_to_participant(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('mapidea__module__project__is_public', [False])
 def test_detail_view_private_visible_to_moderator(client,
                                                   phase_factory,
                                                   map_idea_factory):
     phase, module, project, mapidea = setup_phase(
         phase_factory, map_idea_factory, phases.FeedbackPhase)
-    mapidea.module.project.is_public = False
+    mapidea.module.project.access = Access.PRIVATE
     mapidea.module.project.save()
     url = mapidea.get_absolute_url()
     user = mapidea.project.moderators.first()
@@ -89,13 +86,12 @@ def test_detail_view_private_visible_to_moderator(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('mapidea__module__project__is_public', [False])
 def test_detail_view_private_visible_to_initiator(client,
                                                   phase_factory,
                                                   map_idea_factory):
     phase, module, project, mapidea = setup_phase(
         phase_factory, map_idea_factory, phases.FeedbackPhase)
-    mapidea.module.project.is_public = False
+    mapidea.module.project.access = Access.PRIVATE
     mapidea.module.project.save()
     url = mapidea.get_absolute_url()
     user = mapidea.project.organisation.initiators.first()

--- a/tests/maptopicprio/rules/test_rules_add.py
+++ b/tests/maptopicprio/rules/test_rules_add.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.maptopicprio import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.PrioritizePhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.PrioritizePhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)

--- a/tests/maptopicprio/rules/test_rules_view.py
+++ b/tests/maptopicprio/rules/test_rules_view.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.maptopicprio import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, maptopic_factory, user):
                                           phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, maptopic_factory, user):
                                           phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -46,14 +47,14 @@ def test_phase_active(phase_factory, maptopic_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, maptopic_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, maptopic_factory,
-                                          phases.PrioritizePhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, maptopic_factory, phases.PrioritizePhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)

--- a/tests/maptopicprio/views/test_maptopic_detail.py
+++ b/tests/maptopicprio/views/test_maptopic_detail.py
@@ -1,5 +1,6 @@
 import pytest
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.test.helpers import redirect_target
 from meinberlin.apps.maptopicprio import phases
 from meinberlin.test.helpers import assert_template_response
@@ -20,13 +21,12 @@ def test_detail_view(client, phase_factory, maptopic_factory):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('maptopic__module__project__is_public', [False])
 def test_detail_view_private_not_visible_anonymous(client,
                                                    phase_factory,
                                                    maptopic_factory):
     phase, module, project, maptopic = setup_phase(
         phase_factory, maptopic_factory, phases.PrioritizePhase)
-    maptopic.module.project.is_public = False
+    maptopic.module.project.access = Access.PRIVATE
     maptopic.module.project.save()
     url = maptopic.get_absolute_url()
     response = client.get(url)
@@ -35,14 +35,13 @@ def test_detail_view_private_not_visible_anonymous(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('maptopic__module__project__is_public', [False])
 def test_detail_view_private_not_visible_normal_user(client,
                                                      user,
                                                      phase_factory,
                                                      maptopic_factory):
     phase, module, project, maptopic = setup_phase(
         phase_factory, maptopic_factory, phases.PrioritizePhase)
-    maptopic.module.project.is_public = False
+    maptopic.module.project.access = Access.PRIVATE
     maptopic.module.project.save()
     assert user not in maptopic.module.project.participants.all()
     client.login(username=user.email,
@@ -53,14 +52,13 @@ def test_detail_view_private_not_visible_normal_user(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('maptopic__module__project__is_public', [False])
 def test_detail_view_private_visible_to_participant(client,
                                                     user,
                                                     phase_factory,
                                                     maptopic_factory):
     phase, module, project, maptopic = setup_phase(
         phase_factory, maptopic_factory, phases.PrioritizePhase)
-    maptopic.module.project.is_public = False
+    maptopic.module.project.access = Access.PRIVATE
     maptopic.module.project.save()
     url = maptopic.get_absolute_url()
     assert user not in maptopic.module.project.participants.all()
@@ -72,13 +70,12 @@ def test_detail_view_private_visible_to_participant(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('maptopic__module__project__is_public', [False])
 def test_detail_view_private_visible_to_moderator(client,
                                                   phase_factory,
                                                   maptopic_factory):
     phase, module, project, maptopic = setup_phase(
         phase_factory, maptopic_factory, phases.PrioritizePhase)
-    maptopic.module.project.is_public = False
+    maptopic.module.project.access = Access.PRIVATE
     maptopic.module.project.save()
     url = maptopic.get_absolute_url()
     user = maptopic.project.moderators.first()
@@ -89,13 +86,12 @@ def test_detail_view_private_visible_to_moderator(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('maptopic__module__project__is_public', [False])
 def test_detail_view_private_visible_to_initiator(client,
                                                   phase_factory,
                                                   maptopic_factory):
     phase, module, project, maptopic = setup_phase(
         phase_factory, maptopic_factory, phases.PrioritizePhase)
-    maptopic.module.project.is_public = False
+    maptopic.module.project.access = Access.PRIVATE
     maptopic.module.project.save()
     url = maptopic.get_absolute_url()
     user = maptopic.project.organisation.initiators.first()

--- a/tests/plans/test_views_integration.py
+++ b/tests/plans/test_views_integration.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.projects.models import Project
 from meinberlin.apps.plans.models import Plan
 from meinberlin.test.helpers import assert_template_response
@@ -17,7 +18,7 @@ def test_list_view(client, plan_factory, project_factory,
                    phase_factory, user, apiclient):
 
     project_active = project_factory(name='active')
-    project_private = project_factory(name='private', is_public=False)
+    project_private = project_factory(name='private', access=Access.PRIVATE)
     project_private.participants.add(user)
     project_private.save()
     project_future = project_factory(name='future')

--- a/tests/projectcontainers/dashboard_components/test_views_container_projects.py
+++ b/tests/projectcontainers/dashboard_components/test_views_container_projects.py
@@ -1,6 +1,7 @@
 import pytest
 
 from adhocracy4.dashboard import components
+from adhocracy4.projects.enums import Access
 from adhocracy4.test.helpers import redirect_target
 from meinberlin.test.helpers import assert_dashboard_form_component_response
 
@@ -11,7 +12,7 @@ component = components.projects.get('container-projects')
 def test_edit_view(client, project_factory, project_container):
     initiator = project_container.organisation.initiators.first()
     organisation = project_container.organisation
-    project = project_factory(is_public=True, organisation=organisation)
+    project = project_factory(access=Access.PUBLIC, organisation=organisation)
     url = component.get_base_url(project_container)
     client.login(username=initiator.email, password='password')
     response = client.get(url)

--- a/tests/topicprio/rules/test_rules_add.py
+++ b/tests/topicprio/rules/test_rules_add.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.topicprio import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, user):
                                             phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, user):
                                             phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
@@ -45,15 +46,15 @@ def test_phase_active(phase_factory, user):
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, user, user2):
-    phase, module, project, _ = setup_phase(phase_factory, None,
-                                            phases.PrioritizePhase,
-                                            module__project__is_public=False)
+    phase, module, project, _ = setup_phase(
+        phase_factory, None, phases.PrioritizePhase,
+        module__project__access=Access.PRIVATE)
     anonymous, moderator, initiator = setup_users(project)
 
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)

--- a/tests/topicprio/rules/test_rules_view.py
+++ b/tests/topicprio/rules/test_rules_view.py
@@ -1,6 +1,7 @@
 import pytest
 import rules
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.topicprio import phases
 from meinberlin.test.helpers import freeze_phase
 from meinberlin.test.helpers import freeze_post_phase
@@ -21,7 +22,7 @@ def test_pre_phase(phase_factory, topic_factory, user):
                                           phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -35,7 +36,7 @@ def test_phase_active(phase_factory, topic_factory, user):
                                           phases.PrioritizePhase)
     anonymous, moderator, initiator = setup_users(project)
 
-    assert project.is_public
+    assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
@@ -46,14 +47,15 @@ def test_phase_active(phase_factory, topic_factory, user):
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, topic_factory,
                                       user, user2):
-    phase, _, project, item = setup_phase(phase_factory, topic_factory,
-                                          phases.PrioritizePhase,
-                                          module__project__is_public=False)
+    phase, _, project, item = setup_phase(
+        phase_factory, topic_factory, phases.PrioritizePhase,
+        module__project__access=Access.PRIVATE
+    )
     anonymous, moderator, initiator = setup_users(project)
     participant = user2
     project.participants.add(participant)
 
-    assert not project.is_public
+    assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)

--- a/tests/topicprio/views/test_topic_detail.py
+++ b/tests/topicprio/views/test_topic_detail.py
@@ -1,5 +1,6 @@
 import pytest
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.test.helpers import redirect_target
 from meinberlin.apps.topicprio import phases
 from meinberlin.test.helpers import assert_template_response
@@ -20,13 +21,12 @@ def test_detail_view(client, phase_factory, topic_factory):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('topic__module__project__is_public', [False])
 def test_detail_view_private_not_visible_anonymous(client,
                                                    phase_factory,
                                                    topic_factory):
     phase, module, project, topic = setup_phase(
         phase_factory, topic_factory, phases.PrioritizePhase)
-    topic.module.project.is_public = False
+    topic.module.project.access = Access.PRIVATE
     topic.module.project.save()
     url = topic.get_absolute_url()
     response = client.get(url)
@@ -35,14 +35,13 @@ def test_detail_view_private_not_visible_anonymous(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('topic__module__project__is_public', [False])
 def test_detail_view_private_not_visible_normal_user(client,
                                                      user,
                                                      phase_factory,
                                                      topic_factory):
     phase, module, project, topic = setup_phase(
         phase_factory, topic_factory, phases.PrioritizePhase)
-    topic.module.project.is_public = False
+    topic.module.project.access = Access.PRIVATE
     topic.module.project.save()
     assert user not in topic.module.project.participants.all()
     client.login(username=user.email,
@@ -53,14 +52,13 @@ def test_detail_view_private_not_visible_normal_user(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('topic__module__project__is_public', [False])
 def test_detail_view_private_visible_to_participant(client,
                                                     user,
                                                     phase_factory,
                                                     topic_factory):
     phase, module, project, topic = setup_phase(
         phase_factory, topic_factory, phases.PrioritizePhase)
-    topic.module.project.is_public = False
+    topic.module.project.access = Access.PRIVATE
     topic.module.project.save()
     url = topic.get_absolute_url()
     assert user not in topic.module.project.participants.all()
@@ -72,13 +70,12 @@ def test_detail_view_private_visible_to_participant(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('topic__module__project__is_public', [False])
 def test_detail_view_private_visible_to_moderator(client,
                                                   phase_factory,
                                                   topic_factory):
     phase, module, project, topic = setup_phase(
         phase_factory, topic_factory, phases.PrioritizePhase)
-    topic.module.project.is_public = False
+    topic.module.project.access = Access.PRIVATE
     topic.module.project.save()
     url = topic.get_absolute_url()
     user = topic.project.moderators.first()
@@ -89,13 +86,12 @@ def test_detail_view_private_visible_to_moderator(client,
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('topic__module__project__is_public', [False])
 def test_detail_view_private_visible_to_initiator(client,
                                                   phase_factory,
                                                   topic_factory):
     phase, module, project, topic = setup_phase(
         phase_factory, topic_factory, phases.PrioritizePhase)
-    topic.module.project.is_public = False
+    topic.module.project.access = Access.PRIVATE
     topic.module.project.save()
     url = topic.get_absolute_url()
     user = topic.project.organisation.initiators.first()


### PR DESCRIPTION
What I didn't do here is in the story now. 
So, when this is fine, please merge!

- [x] update a4
- [x] replace is_public in forms
- [x] cheange serialzer
- [x] fix project list
- [x] add new icon for semi-public (to projects list and projecttiles)
- [x] display "join in" or "read" on project tiles
- [x] fix in dashboard
- [ ] check external projects, bplans and containers
- [x] check tests
- [ ] copy tests over
- [x] think about interactive events
- [x] fix sitemap(s)
- [x] add info sentence to project detail when private or semi-private