### PR TITLE
assets: js cleanups

### DIFF
--- a/meinberlin/apps/maps/assets/map-address.js
+++ b/meinberlin/apps/maps/assets/map-address.js
@@ -69,8 +69,6 @@ var setBusy = function ($group, busy) {
 }
 
 var getPoints = function (address, cb) {
-  var $ = window.jQuery
-
   $.ajax(apiUrl, {
     data: { address: address },
     success: function (geojson) {
@@ -107,8 +105,6 @@ var renderPoints = function (points) {
 }
 
 function init () {
-  var $ = window.jQuery
-
   $('[data-map="address"]').each(function (i, e) {
     var $group = $(e)
     var name = $group.data('name')

--- a/meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js
+++ b/meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js
@@ -1,7 +1,7 @@
 /* Adds extra select dropdown to choose predefined polygon instead of drawing one */
 
 /* global django */
-import { createMap } from 'a4maps_common'
+import { maps } from 'adhocracy4'
 import 'leaflet-draw'
 import './i18n-leaflet-draw'
 import FileSaver from 'file-saver'
@@ -19,7 +19,6 @@ function getBaseBounds (L, polygon, bbox) {
 }
 
 function init () {
-  const $ = window.jQuery
   const L = window.L
 
   const ImportControl = L.Control.extend({
@@ -180,7 +179,7 @@ function init () {
     const polygon = JSON.parse(e.getAttribute('data-polygon'))
     const bbox = JSON.parse(e.getAttribute('data-bbox'))
 
-    const map = createMap(L, e, {
+    const map = maps.createMap(L, e, {
       baseUrl: e.getAttribute('data-baseurl'),
       useVectorMap: e.getAttribute('data-usevectormap'),
       attribution: e.getAttribute('data-attribution'),

--- a/meinberlin/apps/plans/assets/PlansMap.jsx
+++ b/meinberlin/apps/plans/assets/PlansMap.jsx
@@ -3,7 +3,7 @@ import { renderToString } from 'react-dom/server'
 import React, { Component } from 'react'
 import { withCookies } from 'react-cookie'
 import PopUp from './PopUp'
-import { createMap } from 'a4maps_common'
+import { maps } from 'adhocracy4'
 import 'leaflet.markercluster'
 const L = window.L
 const $ = window.$
@@ -83,7 +83,7 @@ class PlansMap extends Component {
   }
 
   setupMap () {
-    const map = createMap(L, this.mapElement, {
+    const map = maps.createMap(L, this.mapElement, {
       baseUrl: this.props.baseurl,
       useVectorMap: this.props.useVectorMap,
       mapboxToken: this.props.mapboxToken,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.12.13",
     "@fortawesome/fontawesome-free": "5.15.2",
     "acorn": "8.0.5",
-    "adhocracy4": "liqd/adhocracy4#162a8722dfd378f3d804cc86e888767207059a8e",
+    "adhocracy4": "liqd/adhocracy4#81e60b4c386008df7cc8",
     "autoprefixer": "10.2.4",
     "axios": "0.21.1",
     "babel-loader": "8.2.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@162a8722dfd378f3d804cc86e888767207059a8e#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@81e60b4c386008df7cc8#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -151,7 +151,6 @@ module.exports = {
     fallback: { path: require.resolve('path-browserify') },
     extensions: ['*', '.js', '.jsx', '.scss', '.css'],
     alias: {
-      a4maps_common$: 'adhocracy4/adhocracy4/maps/static/a4maps/a4maps_common.js',
       bootstrap$: 'bootstrap/dist/js/bootstrap.bundle.min.js',
       jquery$: 'jquery/dist/jquery.min.js',
       select2$: 'select2/dist/js/select2.min.js',


### PR DESCRIPTION
Instead of relying on webpack to provide the common map file, properly
import it (requires new a4). Also rely less on global jQuery.

Depends on https://github.com/liqd/adhocracy4/pull/670