### PR TITLE
plans/assets: Properly pipe through the attribution

### DIFF
--- a/meinberlin/apps/plans/assets/ListMapBox.jsx
+++ b/meinberlin/apps/plans/assets/ListMapBox.jsx
@@ -305,6 +305,7 @@ class ListMapBox extends Component {
     return (
       <PlansMap
         key="content"
+        attribution={this.props.attribution}
         resize={this.state.resizeMap}
         items={this.state.items}
         bounds={this.props.bounds}

--- a/meinberlin/apps/plans/assets/PlansMap.jsx
+++ b/meinberlin/apps/plans/assets/PlansMap.jsx
@@ -84,6 +84,7 @@ class PlansMap extends Component {
 
   setupMap () {
     const map = maps.createMap(L, this.mapElement, {
+      attribution: this.props.attribution,
       baseUrl: this.props.baseurl,
       useVectorMap: this.props.useVectorMap,
       mapboxToken: this.props.mapboxToken,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.12.13",
     "@fortawesome/fontawesome-free": "5.15.2",
     "acorn": "8.0.5",
-    "adhocracy4": "liqd/adhocracy4#63d864a25413a3060a53edd52a4200f528239b2e",
+    "adhocracy4": "liqd/adhocracy4#0a066f3be27d61b641c6260a8eb248e4d12b61d3",
     "autoprefixer": "10.2.4",
     "axios": "0.21.1",
     "babel-loader": "8.2.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@63d864a25413a3060a53edd52a4200f528239b2e#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@0a066f3be27d61b641c6260a8eb248e4d12b61d3#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0


### PR DESCRIPTION
Together with the a4 update this makes us properly show the attribution everywhere.