### PR TITLE
maps/assets: Fix select2 for polygon areasetting

### DIFF
--- a/meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js
+++ b/meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js
@@ -19,6 +19,8 @@ function getBaseBounds (L, polygon, bbox) {
 }
 
 function init () {
+  // select2 needs stateful jQuery
+  const $ = window.jQuery
   const L = window.L
 
   const ImportControl = L.Control.extend({

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-react": "7.12.13",
     "@fortawesome/fontawesome-free": "5.15.2",
     "acorn": "8.0.5",
-    "adhocracy4": "liqd/adhocracy4#0a066f3be27d61b641c6260a8eb248e4d12b61d3",
+    "adhocracy4": "liqd/adhocracy4#4f8efd0822a424787138ac8e51d8740d4c2849a8",
     "autoprefixer": "10.2.4",
     "axios": "0.21.1",
     "babel-loader": "8.2.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@0a066f3be27d61b641c6260a8eb248e4d12b61d3#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@4f8efd0822a424787138ac8e51d8740d4c2849a8#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0


### PR DESCRIPTION
`select2` is a jQuery extension, thus we need to use the window-global
jQuery instance instead of the webpack provided one.

Depends on https://github.com/liqd/adhocracy4/pull/673