### PR TITLE
apps/plans: fix plan detail when there are only topics not existing i…

### DIFF
--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -46,9 +46,11 @@
                         </dl>
                         {% endif %}
 
+                        {% if object.topic_names %}
                         <dl>
                             <dt>{% trans 'Topic' %}</dt><dd>{{ object.topic_names.0 }}{% if object.topic_names.1 %}, {{ object.topic_names.1 }}{% endif %}</dd>
                         </dl>
+                        {% endif %}
 
                         {% if object.duration %}
                         <dl>


### PR DESCRIPTION
…n the settings

fixes https://sentry.liqd.net/organizations/sentry/issues/343 
It's a bit odd, because there should be only topics that are set in the settings and the field is required, so every plan should have it. But if there is a wrong topic, it should just not be shown instead of causing a 500.