### PR TITLE
styling/drowpdowns: give dropdown-menu higher z than dropdown toggle …

### DIFF
--- a/meinberlin/assets/scss/components/_dropdown.scss
+++ b/meinberlin/assets/scss/components/_dropdown.scss
@@ -42,7 +42,7 @@
     max-width: none;
     padding: 0;
     margin: 0;
-    z-index: 2;
+    z-index: 3;
     background-color: $body-bg;
     color: contrast-color($body-bg);
     border: 1px solid $text-color;


### PR DESCRIPTION
…- fixes #3365

I am not sure if it destroys something else, though. I guess, the dropdown menu should always be above the button, though?!