### PR TITLE
webpack: Readd flattening with proper syntax

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -184,7 +184,7 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [{
         from: './meinberlin/assets/images/**/*',
-        to: 'images/'
+        to: 'images/[name].[ext]'
       }]
     })
   ]


### PR DESCRIPTION
The old `flatten` syntax was dropped, however we still rely on its
effect. Use the common syntax to archive the same.