### PR TITLE
WIP plans/assets: Render project tiles on demand

### DIFF
--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -2,6 +2,9 @@
 const React = require('react')
 const Moment = require('moment')
 
+const autoScrollThreshold = 500
+const itemListInterval = 10
+
 class LazyBackground extends React.Component {
   constructor (props) {
     super(props)
@@ -70,6 +73,56 @@ class LazyBackground extends React.Component {
 }
 
 class PlansList extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.addItemsToList = this.addItemsToList.bind(this)
+    this.bindList = this.bindList.bind(this)
+    this.handleScroll = this.handleScroll.bind(this)
+    this.renderTopics = this.renderTopics.bind(this)
+
+    this.state = {
+      itemList: []
+    }
+  }
+
+  componentDidMount () {
+    window.addEventListener('scroll', this.handleScroll, { passive: true })
+    this.addItemsToList()
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('scroll', this.handleScroll)
+  }
+
+  getDocumentHeight () {
+    const D = document
+    return Math.max(
+      D.body.scrollHeight, D.documentElement.scrollHeight,
+      D.body.offsetHeight, D.documentElement.offsetHeight,
+      D.body.clientHeight, D.documentElement.clientHeight
+    )
+  }
+
+  handleScroll () {
+    const html = document.documentElement
+    if (html.scrollTop + html.clientHeight > this.getDocumentHeight() - autoScrollThreshold) {
+      this.addItemsToList()
+    }
+  }
+
+  addItemsToList () {
+    const newItemList = this.state.itemList.slice()
+    for (let i = this.state.itemList.length;
+      i < this.props.items.length &&
+      (i - this.state.itemList.length) < itemListInterval; i++) {
+      newItemList.push(this.renderListItem(this.props.items[i], i))
+    }
+    this.setState({
+      itemList: newItemList
+    })
+  }
+
   bindList (element) {
     this.listElement = element
   }
@@ -140,7 +193,7 @@ class PlansList extends React.Component {
               {item.tile_image &&
                 <LazyBackground
                   item={item}
-                  renderTopics={this.renderTopics.bind(this)}
+                  renderTopics={this.renderTopics}
                   isHorizontal={this.props.isHorizontal}
                 />}
               <div className="participation-tile__content">
@@ -234,15 +287,10 @@ class PlansList extends React.Component {
   }
 
   renderList () {
-    const list = []
-    this.props.items.forEach((item, i) => {
-      list.push(this.renderListItem(item, i))
-    })
-
-    if (list.length > 0) {
+    if (this.state.itemList.length > 0) {
       return (
         <ul className="u-list-reset participation-tile__list">
-          {list}
+          {this.state.itemList}
         </ul>
       )
     } else {
@@ -254,7 +302,7 @@ class PlansList extends React.Component {
 
   render () {
     return (
-      <div ref={this.bindList.bind(this)}>
+      <div ref={this.bindList}>
         {this.renderList()}
       </div>
     )


### PR DESCRIPTION
The list of active projects can get quite long, resulting in high
client cpu load. Skip rendering until the tile becomes visible.

This will need some testing. Also it might make sense to set the interval number slightly higher as otherwise we rist to not initially show enough tiles on big screens.