### PR TITLE
assets/apps.js: Explicitely initialize window.adhocracy4

### DIFF
--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -81,7 +81,8 @@ $(document).on('click', function () {
 })
 
 // This function is overwritten with custom behavior in embed.js.
-export function getCurrentPath () {
+window.adhocracy4 = {}
+window.adhocracy4.getCurrentPath = function () {
   return location.pathname
 }
 

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', init, false)
 document.addEventListener('a4.embed.ready', init, false)
 
 // Closes bootstrap collapse on click elsewhere
-$(document).on('click', function () {
+document.addEventListener('click', function () {
   $('.collapse').collapse('hide')
 })
 

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -70,6 +70,10 @@ function init () {
   if ($.fn.select2) {
     $('.js-select2').select2()
   }
+
+  // This function adds required classes to iframes added by ckeditor
+  $('.rich-text iframe').addClass('ck_embed_iframe')
+  $('.ck_embed_iframe').parent('div').addClass('ck_embed_iframe__container')
 }
 
 document.addEventListener('DOMContentLoaded', init, false)
@@ -85,9 +89,3 @@ window.adhocracy4 = {}
 window.adhocracy4.getCurrentPath = function () {
   return location.pathname
 }
-
-// This function adds required classes to iframes added by ckeditor
-$(document).ready(function () {
-  $('.rich-text iframe').addClass('ck_embed_iframe')
-  $('.ck_embed_iframe').parent('div').addClass('ck_embed_iframe__container')
-})


### PR DESCRIPTION
And set `window.adhocracy4.getCurrentPath` like we do in `embed.js`.

I'm not sure how this worked in the past, but it appears to be
something implicit we shouldn't rely on.