### PR TITLE
webpack: Remove vendor chunk

### DIFF
--- a/meinberlin/apps/embed/templates/meinberlin_embed/embed.html
+++ b/meinberlin/apps/embed/templates/meinberlin_embed/embed.html
@@ -7,10 +7,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Embedded meinBerlin</title>
     <link rel="shortcut icon" type="image/x-icon" href="{% static 'images/favicon.ico' %}?v=2" />
-    <link rel="stylesheet" type="text/css" href="{% static 'vendor.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'adhocracy4.css' %}" />
     <script src="{% url 'javascript-catalog' %}"></script>
-    <script src="{% static 'vendor.js' %}"></script>
     <script src="{% static 'adhocracy4.js' %}"></script>
     <script src="{% static 'embed.js' %}"></script>
     <meta name="viewport" content="width=device-width" />

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -85,7 +85,6 @@ document.addEventListener('click', function () {
 })
 
 // This function is overwritten with custom behavior in embed.js.
-window.adhocracy4 = {}
-window.adhocracy4.getCurrentPath = function () {
+export function getCurrentPath () {
   return location.pathname
 }

--- a/meinberlin/templates/500.html
+++ b/meinberlin/templates/500.html
@@ -2,7 +2,6 @@
 <html>
     <head>
         <title>Error &mdash; {% trans 'meinBerlin' %}</title>
-        <link rel="stylesheet" type="text/css" href="{% static 'vendor.css' %}" />
         <link rel="stylesheet" type="text/css" href="{% static 'adhocracy4.css' %}" />
     </head>
 

--- a/meinberlin/templates/base.html
+++ b/meinberlin/templates/base.html
@@ -7,13 +7,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>{% block title %}{% trans 'meinBerlin' %}{% endblock %}</title>
     <link rel="shortcut icon" type="image/x-icon" href="{% static 'images/favicon.ico' %}?v=2" />
-    <link rel="stylesheet" type="text/css" href="{% static 'vendor.css' %}" />
     {% block extra_css %}
         {# Override this in templates to add extra stylesheets #}
     {% endblock %}
     <link rel="stylesheet" type="text/css" href="{% static 'adhocracy4.css' %}" />
     <script src="{% url 'javascript-catalog' %}"></script>
-    <script src="{% static 'vendor.js' %}"></script>
     <script src="{% static 'adhocracy4.js' %}"></script>
     <meta name="viewport" content="width=device-width" />
     {% block header_meta %}{% endblock %}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,31 +5,18 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 module.exports = {
   entry: {
-    vendor: [
+    adhocracy4: [
       '@fortawesome/fontawesome-free/scss/fontawesome.scss',
       '@fortawesome/fontawesome-free/scss/brands.scss',
       '@fortawesome/fontawesome-free/scss/regular.scss',
       '@fortawesome/fontawesome-free/scss/solid.scss',
-      'adhocracy4',
-      'classnames',
-      'immutability-helper',
-      'js-cookie',
-      'react',
-      'react-dom',
-      'react-flip-move',
-      'react-sticky-box'
+      'shariff/dist/shariff.min.css',
+      'select2/dist/css/select2.min.css',
+      'slick-carousel/slick/slick.css',
+      './meinberlin/assets/extra_css/_slick-theme.css',
+      './meinberlin/assets/scss/style.scss',
+      './meinberlin/assets/js/app.js'
     ],
-    adhocracy4: {
-      import: [
-        'shariff/dist/shariff.min.css',
-        'select2/dist/css/select2.min.css',
-        'slick-carousel/slick/slick.css',
-        './meinberlin/assets/extra_css/_slick-theme.css',
-        './meinberlin/assets/scss/style.scss',
-        './meinberlin/assets/js/app.js'
-      ],
-      dependOn: 'vendor'
-    },
     captcheck: {
       import: [
         './meinberlin/apps/captcha/assets/captcheck.js'
@@ -215,10 +202,6 @@ module.exports = {
       jQuery: 'jquery',
       Promise: ['es6-promise', 'Promise'],
       fetch: ['whatwg-fetch', 'fetch']
-    }),
-    new webpack.optimize.SplitChunksPlugin({
-      name: 'vendor',
-      filename: 'vendor.js'
     }),
     new MiniCssExtractPlugin({
       filename: '[name].css',


### PR DESCRIPTION
Using the vendor chunk is, IIUC, a leftover from Webpack <= 3 times.
Webpack >= 4 promote a different kind of chunk splitting. This is
a step into that direction.

The probably biggest benefit is that there's now a single big `adhocracy4`
entry point which includes all base dependencies, avoid odd ordering issues
and making it clearer where to add stuff to.

Port of some improvements found in https://github.com/liqd/adhocracy-plus/pull/1128, which again was a port of https://github.com/liqd/a4-meinberlin/pull/3440