### PR TITLE
apps/dashboard: filter dashboard project, bplan, extproject, containe…

### DIFF
--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/bplan_list_dashboard.html
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/bplan_list_dashboard.html
@@ -17,18 +17,13 @@
 
     {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
 
-    {% if bplan_list|length > 0 %}
-        <ul class="u-list-reset">
-            {% for bplan in bplan_list %}
-                {% has_perm 'a4projects.change_project' request.user bplan as can_change_project %}
-                {% if can_change_project %}
-                {% include "a4dashboard/includes/project_list_item.html" with project=bplan %}
-                {% endif %}
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>{% trans 'We could not find any development plans.' %}</p>
-    {% endif %}
+    <ul class="u-list-reset">
+        {% for bplan in bplan_list %}
+            {% include "a4dashboard/includes/project_list_item.html" with project=bplan %}
+        {% empty %}
+            <p>{% trans 'We could not find any development plans.' %}</p>
+        {% endfor %}
+    </ul>
 
     {% include "meinberlin_contrib/includes/pagination.html" %}
 {% endblock %}

--- a/meinberlin/apps/bplan/views.py
+++ b/meinberlin/apps/bplan/views.py
@@ -7,6 +7,7 @@ from adhocracy4.dashboard.components.forms.views import \
     ProjectComponentFormView
 from adhocracy4.dashboard.mixins import DashboardBaseMixin
 from meinberlin.apps.bplan import phases as bplan_phases
+from meinberlin.apps.dashboard.mixins import DashboardProjectListGroupMixin
 from meinberlin.apps.extprojects.views import ExternalProjectCreateView
 
 from . import forms
@@ -55,7 +56,8 @@ class BplanProjectUpdateView(ProjectComponentFormView):
         return self.project
 
 
-class BplanProjectListView(DashboardBaseMixin,
+class BplanProjectListView(DashboardProjectListGroupMixin,
+                           DashboardBaseMixin,
                            generic.ListView):
     model = models.Bplan
     paginate_by = 12

--- a/meinberlin/apps/dashboard/mixins.py
+++ b/meinberlin/apps/dashboard/mixins.py
@@ -1,0 +1,16 @@
+from rules.predicates import is_superuser
+
+from adhocracy4.organisations.predicates import is_initiator
+
+
+class DashboardProjectListGroupMixin():
+    def get_queryset(self, **kwargs):
+        qs = super().get_queryset()
+        if (is_initiator(self.request.user, self.organisation)
+                or is_superuser(self.request.user)):
+            return qs
+        else:
+            return qs.filter(
+                group__id__in=[self.request.user.groups.values_list(
+                    'id', flat=True)]
+            )

--- a/meinberlin/apps/dashboard/views.py
+++ b/meinberlin/apps/dashboard/views.py
@@ -20,6 +20,7 @@ from adhocracy4.phases import models as phase_models
 from adhocracy4.projects import models as project_models
 from adhocracy4.projects.mixins import ProjectMixin
 from meinberlin.apps.dashboard.forms import DashboardProjectCreateForm
+from meinberlin.apps.dashboard.mixins import DashboardProjectListGroupMixin
 
 
 class ModuleBlueprintListView(ProjectMixin,
@@ -210,7 +211,8 @@ class ModuleDeleteView(generic.DeleteView):
         })
 
 
-class DashboardProjectListView(a4dashboard_views.ProjectListView):
+class DashboardProjectListView(DashboardProjectListGroupMixin,
+                               a4dashboard_views.ProjectListView):
     def get_queryset(self):
         return super().get_queryset().filter(
             projectcontainer=None,

--- a/meinberlin/apps/extprojects/templates/meinberlin_extprojects/extproject_list_dashboard.html
+++ b/meinberlin/apps/extprojects/templates/meinberlin_extprojects/extproject_list_dashboard.html
@@ -17,18 +17,13 @@
 
     {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
 
-    {% if externalproject_list|length > 0 %}
-        <ul class="u-list-reset">
-            {% for linkage in externalproject_list %}
-                {% has_perm 'a4projects.change_project' request.user linkage as can_change_project %}
-                {% if can_change_project %}
-                {% include "a4dashboard/includes/project_list_item.html" with project=linkage %}
-                {% endif %}
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>{% trans 'We could not find any linkages.' %}</p>
-    {% endif %}
+    <ul class="u-list-reset">
+        {% for linkage in externalproject_list %}
+            {% include "a4dashboard/includes/project_list_item.html" with project=linkage %}
+        {% empty %}
+            <p>{% trans 'We could not find any linkages.' %}</p>
+        {% endfor %}
+    </ul>
 
     {% include "meinberlin_contrib/includes/pagination.html" %}
 {% endblock %}

--- a/meinberlin/apps/extprojects/views.py
+++ b/meinberlin/apps/extprojects/views.py
@@ -6,6 +6,7 @@ from adhocracy4.dashboard.components.forms.views import \
     ProjectComponentFormView
 from adhocracy4.dashboard.mixins import DashboardBaseMixin
 from adhocracy4.dashboard.views import ProjectCreateView
+from meinberlin.apps.dashboard.mixins import DashboardProjectListGroupMixin
 from meinberlin.apps.extprojects import phases as extprojects_phases
 
 from . import apps
@@ -48,7 +49,8 @@ class ExternalProjectUpdateView(ProjectComponentFormView):
         return self.project
 
 
-class ExternalProjectListView(DashboardBaseMixin,
+class ExternalProjectListView(DashboardProjectListGroupMixin,
+                              DashboardBaseMixin,
                               generic.ListView):
     model = models.ExternalProject
     paginate_by = 12

--- a/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/container_list_dashboard.html
+++ b/meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/container_list_dashboard.html
@@ -18,18 +18,13 @@
 
     {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
 
-    {% if projectcontainer_list|length > 0 %}
-        <ul class="u-list-reset">
-            {% for container in projectcontainer_list %}
-                {% has_perm 'a4projects.change_project' request.user container as can_change_project %}
-                {% if can_change_project %}
-                {% include "a4dashboard/includes/project_list_item.html" with project=container %}
-                {% endif %}
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>{% trans 'We could not find any containers.' %}</p>
-    {% endif %}
+    <ul class="u-list-reset">
+        {% for container in projectcontainer_list %}
+            {% include "a4dashboard/includes/project_list_item.html" with project=container %}
+        {% empty %}
+            <p>{% trans 'We could not find any containers.' %}</p>
+        {% endfor %}
+    </ul>
 
     {% include "meinberlin_contrib/includes/pagination.html" %}
 {% endblock %}

--- a/meinberlin/apps/projectcontainers/views.py
+++ b/meinberlin/apps/projectcontainers/views.py
@@ -6,6 +6,7 @@ from adhocracy4.dashboard.blueprints import ProjectBlueprint
 from adhocracy4.dashboard.components.forms.views import \
     ProjectComponentFormView
 from adhocracy4.dashboard.views import ProjectCreateView
+from meinberlin.apps.dashboard.mixins import DashboardProjectListGroupMixin
 
 from . import forms
 from . import models
@@ -61,7 +62,8 @@ class ContainerProjectsView(ProjectComponentFormView):
         return kwargs
 
 
-class ContainerListView(dashboard_mixins.DashboardBaseMixin,
+class ContainerListView(DashboardProjectListGroupMixin,
+                        dashboard_mixins.DashboardBaseMixin,
                         generic.ListView):
     model = models.ProjectContainer
     paginate_by = 12

--- a/meinberlin/templates/a4dashboard/project_list.html
+++ b/meinberlin/templates/a4dashboard/project_list.html
@@ -17,18 +17,13 @@
 
     {% include "meinberlin_contrib/includes/filter_and_sort.html" with filter=view.filter %}
 
-    {% if project_list|length > 0 %}
-        <ul class="u-list-reset">
-            {% for project in project_list %}
-                {% has_perm 'a4projects.change_project' request.user project as can_change_project %}
-                {% if can_change_project %}
-                {% include "a4dashboard/includes/project_list_item.html" with project=project %}
-                {% endif %}
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>{% trans 'We could not find any projects.' %}</p>
-    {% endif %}
+    <ul class="u-list-reset">
+        {% for project in project_list %}
+            {% include "a4dashboard/includes/project_list_item.html" with project=project %}
+        {% empty %}
+            <p>{% trans 'We could not find any projects.' %}</p>
+        {% endfor %}
+    </ul>
 
     {% include "meinberlin_contrib/includes/pagination.html" %}
 {% endblock %}

--- a/tests/bplan/dashboard_components/test_views_bplan_list.py
+++ b/tests/bplan/dashboard_components/test_views_bplan_list.py
@@ -57,8 +57,6 @@ def test_dashboard_bplan_list_view_group_member(
     response = client.get(url)
     assert response.status_code == 200
     assert bplan_1 in response.context_data['bplan_list']
-    # Currently we don't show the project in the list, but it's in the
-    # queryset...
-    assert bplan_2 in response.context_data['bplan_list']
+    assert bplan_2 not in response.context_data['bplan_list']
     assert bplan_3 not in response.context_data['bplan_list']
     assert project not in response.context_data['bplan_list']

--- a/tests/dashboard/test_dashboard_views_project_list.py
+++ b/tests/dashboard/test_dashboard_views_project_list.py
@@ -1,0 +1,62 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_dashboard_project_list_view(
+        project_factory, bplan_factory, organisation, client):
+    project_1 = project_factory(organisation=organisation)
+    project_2 = project_factory(organisation=organisation)
+    project_3 = project_factory()
+    assert project_3.organisation != organisation
+    bplan = bplan_factory(organisation=organisation)
+    assert bplan.organisation == organisation
+    initiator = organisation.initiators.first()
+    url = reverse('a4dashboard:project-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=initiator.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert project_1 in response.context_data['project_list']
+    assert project_2 in response.context_data['project_list']
+    assert project_3 not in response.context_data['project_list']
+    assert bplan not in response.context_data['project_list']
+
+
+@pytest.mark.django_db
+def test_dashboard_project_list_view_user(user, organisation,
+                                          client):
+    assert user not in organisation.initiators.all()
+    url = reverse('a4dashboard:project-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=user.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_dashboard_project_list_view_group_member(
+        project_factory, bplan_factory, organisation, client,
+        user_factory, group_factory):
+    group1 = group_factory()
+    group_member = user_factory.create(groups=(group1, ))
+    organisation.groups.add(group1)
+    project_1 = project_factory(organisation=organisation)
+    project_1.group = group1
+    project_1.save()
+    project_2 = project_factory(organisation=organisation)
+    project_3 = project_factory()
+    assert project_3.organisation != organisation
+    bplan = bplan_factory(organisation=organisation)
+    bplan.group = group1
+    bplan.save()
+    assert bplan.organisation == organisation
+    url = reverse('a4dashboard:project-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=group_member.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert project_1 in response.context_data['project_list']
+    assert project_2 not in response.context_data['project_list']
+    assert project_3 not in response.context_data['project_list']
+    assert bplan not in response.context_data['project_list']

--- a/tests/extprojects/dashboard_components/test_views_extproject_list.py
+++ b/tests/extprojects/dashboard_components/test_views_extproject_list.py
@@ -1,0 +1,63 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_dashboard_external_project_list_view(
+        external_project_factory, project_factory,
+        organisation, client):
+    external_1 = external_project_factory(organisation=organisation)
+    external_2 = external_project_factory(organisation=organisation)
+    external_3 = external_project_factory()
+    assert external_3.organisation != organisation
+    project = project_factory(organisation=organisation)
+    assert project.organisation == organisation
+    initiator = organisation.initiators.first()
+    url = reverse('a4dashboard:extproject-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=initiator.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert external_1 in response.context_data['externalproject_list']
+    assert external_2 in response.context_data['externalproject_list']
+    assert external_3 not in response.context_data['externalproject_list']
+    assert project not in response.context_data['externalproject_list']
+
+
+@pytest.mark.django_db
+def test_dashboard_external_project_list_view_user(user, organisation,
+                                                   client):
+    assert user not in organisation.initiators.all()
+    url = reverse('a4dashboard:extproject-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=user.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_dashboard_external_project_list_view_group_member(
+        external_project_factory, project_factory, organisation, client,
+        user_factory, group_factory):
+    group1 = group_factory()
+    group_member = user_factory.create(groups=(group1, ))
+    organisation.groups.add(group1)
+    external_1 = external_project_factory(organisation=organisation)
+    external_1.group = group1
+    external_1.save()
+    external_2 = external_project_factory(organisation=organisation)
+    external_3 = external_project_factory()
+    assert external_3.organisation != organisation
+    project = project_factory(organisation=organisation)
+    project.group = group1
+    project.save()
+    assert project.organisation == organisation
+    url = reverse('a4dashboard:extproject-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=group_member.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert external_1 in response.context_data['externalproject_list']
+    assert external_2 not in response.context_data['externalproject_list']
+    assert external_3 not in response.context_data['externalproject_list']
+    assert project not in response.context_data['externalproject_list']

--- a/tests/projectcontainers/dashboard_components/test_views_container_list.py
+++ b/tests/projectcontainers/dashboard_components/test_views_container_list.py
@@ -1,0 +1,63 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_dashboard_container_list_view(
+        project_container_factory, project_factory,
+        organisation, client):
+    container_1 = project_container_factory(organisation=organisation)
+    container_2 = project_container_factory(organisation=organisation)
+    container_3 = project_container_factory()
+    assert container_3.organisation != organisation
+    project = project_factory(organisation=organisation)
+    assert project.organisation == organisation
+    initiator = organisation.initiators.first()
+    url = reverse('a4dashboard:container-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=initiator.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert container_1 in response.context_data['projectcontainer_list']
+    assert container_2 in response.context_data['projectcontainer_list']
+    assert container_3 not in response.context_data['projectcontainer_list']
+    assert project not in response.context_data['projectcontainer_list']
+
+
+@pytest.mark.django_db
+def test_dashboard_container_list_view_user(user, organisation,
+                                            client):
+    assert user not in organisation.initiators.all()
+    url = reverse('a4dashboard:container-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=user.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_dashboard_container_list_view_group_member(
+        project_container_factory, project_factory, organisation, client,
+        user_factory, group_factory):
+    group1 = group_factory()
+    group_member = user_factory.create(groups=(group1, ))
+    organisation.groups.add(group1)
+    container_1 = project_container_factory(organisation=organisation)
+    container_1.group = group1
+    container_1.save()
+    container_2 = project_container_factory(organisation=organisation)
+    container_3 = project_container_factory()
+    assert container_3.organisation != organisation
+    project = project_factory(organisation=organisation)
+    project.group = group1
+    project.save()
+    assert project.organisation == organisation
+    url = reverse('a4dashboard:container-list',
+                  kwargs={'organisation_slug': organisation.slug})
+    client.login(username=group_member.email, password='password')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert container_1 in response.context_data['projectcontainer_list']
+    assert container_2 not in response.context_data['projectcontainer_list']
+    assert container_3 not in response.context_data['projectcontainer_list']
+    assert project not in response.context_data['projectcontainer_list']


### PR DESCRIPTION
…r lists for group members - fixes #2616

It would have been much better to filter by permissions instead of doing
this dance, but as explained in issue #2616 it's not that easy. With
this we have to take care, when we add or remove project update
permissions, as this (instead of working with permissions) works with
knowing the roles and showing respective projects only to people allowed
to update them.

PS to the reviewer: If I want to test sth. with querysets, I just decrease its size instead of adding that many projects. :)