### PR TITLE
Center title and wording text

### DIFF
--- a/meinberlin/assets/scss/components/_blocks.scss
+++ b/meinberlin/assets/scss/components/_blocks.scss
@@ -213,6 +213,7 @@
 .block--map-teaser_background {
     background-image: radial-gradient($white-shadow, rgba(0, 0, 0, 0));
     border-radius: 100px;
+    text-align: center;
 }
 
 //as filter is different on homepage styling must be nested


### PR DESCRIPTION
Adding css selector h2 and p for .block--map-teaser_background
fixes #3547

Note:
I have to move the entire class, because of css specificity (what a word!)

stylelint complaint about it.
https://stylelint.io/user-guide/rules/no-descending-specificity
