### PR TITLE
apps/notifications: only send schedule notifications for a4 projects …

### DIFF
--- a/meinberlin/apps/notifications/signals.py
+++ b/meinberlin/apps/notifications/signals.py
@@ -25,7 +25,8 @@ def send_notifications(instance, created, **kwargs):
         if action.project:
             emails.NotifyModeratorsEmail.send(action)
 
-    elif action.type == 'phase':
+    elif (action.type == 'phase' and
+          action.project.project_type == 'a4projects.Project'):
         if verb == Verbs.START:
             emails.NotifyFollowersOnPhaseStartedEmail.send(action)
         elif verb == Verbs.SCHEDULE:


### PR DESCRIPTION
…- fixes #1901

To test, add phases to an a4 project, a bplan and an external project. They all need to end soon (>24 hours). Now create the schedule actions by `python manage.py create_system_actions`. Now there should be three new actions, but only one new task.

I tried to add tests, but then didn't want to invest too much time. :grimacing: 