### PR TITLE
jd 2021 06 requirements/base.txt: upgrade from raven to sentry-sdk

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-capture-tag==1.0
 django-cloudflare-push==0.2.0
 django-sites==0.10
 django_csp==3.7
-raven==6.10.0
+sentry-sdk==1.1.0
 requests==2.25.1
 wagtail==2.11.7 # pyup: <2.12
 whitenoise==5.2.0


### PR DESCRIPTION
move to the newer sentry-sdk as raven has been deprecated for
a while now.