### PR TITLE
translations: first round

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -647,12 +647,12 @@ msgstr "Anzahl Kommentare"
 #: adhocracy4/exports/mixins/comments.py:77
 #: adhocracy4/exports/mixins/comments.py:77
 msgid "Reply to Comment"
-msgstr ""
+msgstr "Antwort auf Kommentar"
 
 #: adhocracy4/exports/mixins/comments.py:95
 #: adhocracy4/exports/mixins/comments.py:95
 msgid "Reply to Reference"
-msgstr ""
+msgstr "Kommentar zur Referenz"
 
 #: adhocracy4/exports/mixins/general.py:14
 #: adhocracy4/exports/mixins/general.py:14
@@ -1106,13 +1106,15 @@ msgstr ""
 #: adhocracy4/polls/phases.py:16
 msgctxt "A4: voting phase name"
 msgid "Voting phase"
-msgstr ""
+msgstr "Machen Sie mit bei unserer Umfrage!"
 
 #: adhocracy4/polls/phases.py:19
 #: adhocracy4/polls/phases.py:19
 msgctxt "A4: voting phase description"
 msgid "Answer the questions and comment on the poll."
 msgstr ""
+"Helfen Sie uns, indem Sie die unten stehenden Fragen beantworten. Am Ende "
+"des Fragebogens ist Platz für Ihre Kommentare."
 
 #: adhocracy4/polls/phases.py:21
 #: adhocracy4/polls/phases.py:21

--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-27 15:55+0200\n"
+"POT-Creation-Date: 2021-07-05 17:25+0200\n"
 "PO-Revision-Date: 2017-10-16 13:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,6 +17,39 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.1\n"
+
+#: adhocracy4/categories/dashboard.py:13
+#: adhocracy4/categories/dashboard.py:13
+msgid "Categories"
+msgstr "Kategorien"
+
+#: adhocracy4/categories/dashboard.py:15
+#: adhocracy4/categories/dashboard.py:15
+msgid "Edit categories"
+msgstr "Kategorien bearbeiten"
+
+#: adhocracy4/categories/fields.py:12
+#: adhocracy4/categories/filters.py:16
+#: adhocracy4/categories/forms.py:45
+#: adhocracy4/exports/mixins/items.py:14
+#: adhocracy4/categories/fields.py:12
+#: adhocracy4/categories/filters.py:16
+#: adhocracy4/categories/forms.py:45
+#: adhocracy4/exports/mixins/items.py:14
+msgid "Category"
+msgstr "Kategorie"
+
+#: adhocracy4/categories/forms.py:38
+#: adhocracy4/labels/forms.py:14
+#: adhocracy4/categories/forms.py:38
+#: adhocracy4/labels/forms.py:14
+msgid "Category name"
+msgstr "Kategoriename"
+
+#: adhocracy4/categories/forms.py:39
+#: adhocracy4/categories/forms.py:39
+msgid "Category icon"
+msgstr "Kategorieicon"
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
@@ -34,6 +67,291 @@ msgstr ""
 #: meinberlin/templates/a4categories/includes/module_categories_form.html:21
 msgid "Add category"
 msgstr "Kategorie hinzufügen"
+
+#: adhocracy4/comments/models.py:53
+#: adhocracy4/comments/models.py:53
+msgctxt "noun"
+msgid "Comment"
+msgstr "Kommentar"
+
+#: adhocracy4/comments/models.py:54
+#: adhocracy4/exports/mixins/comments.py:46
+#: adhocracy4/comments/models.py:54
+#: adhocracy4/exports/mixins/comments.py:46
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:16
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:17
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:18
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:19
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:18
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:20
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:18
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:20
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:18
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:20
+msgid "Comments"
+msgstr "Kommentare"
+
+#: adhocracy4/comments/models.py:74
+#: adhocracy4/comments_async/serializers.py:151
+#: adhocracy4/comments/models.py:74
+#: adhocracy4/comments_async/serializers.py:151
+msgid "deleted by creator"
+msgstr "Vom Ersteller gelöscht"
+
+#: adhocracy4/comments/models.py:77
+#: adhocracy4/comments_async/serializers.py:153
+#: adhocracy4/comments/models.py:77
+#: adhocracy4/comments_async/serializers.py:153
+msgid "deleted by moderator"
+msgstr "Vom Moderator gelöscht"
+
+#: adhocracy4/comments/serializers.py:52
+#: adhocracy4/comments/serializers.py:151
+#: adhocracy4/comments/serializers.py:52
+#: adhocracy4/comments/serializers.py:151
+msgid "Please choose a category"
+msgstr "Bitte wählen Sie eine Kategorie"
+
+#: adhocracy4/comments/serializers.py:61
+#: adhocracy4/comments_async/serializers.py:79
+#: adhocracy4/comments/serializers.py:61
+#: adhocracy4/comments_async/serializers.py:79
+msgid "unknown user"
+msgstr "unbekannter Nutzer"
+
+#: adhocracy4/comments_async/serializers.py:58
+#: adhocracy4/comments_async/serializers.py:58
+msgid "Please choose one or more categories."
+msgstr "Bitte wählen Sie eine oder mehrere Kategorien aus."
+
+#: adhocracy4/dashboard/components/forms/views.py:22
+#: adhocracy4/dashboard/components/forms/views.py:22
+msgid "The project has been updated."
+msgstr "Das Projekt wurde aktualisiert."
+
+#: adhocracy4/dashboard/components/forms/views.py:47
+#: adhocracy4/dashboard/components/forms/views.py:47
+msgid "The module has been updated."
+msgstr "Das Modul wurde aktualisiert."
+
+#: adhocracy4/dashboard/dashboard.py:13
+#: adhocracy4/dashboard/dashboard.py:13
+#: meinberlin/apps/projectcontainers/dashboard.py:14
+msgid "Basic settings"
+msgstr "Grundeinstellungen"
+
+#: adhocracy4/dashboard/dashboard.py:15
+#: adhocracy4/dashboard/dashboard.py:15
+#: meinberlin/apps/bplan/dashboard.py:16
+#: meinberlin/apps/extprojects/dashboard.py:16
+msgid "Edit basic settings"
+msgstr "Grundeinstellungen bearbeiten"
+
+#: adhocracy4/dashboard/dashboard.py:23
+#: adhocracy4/dashboard/dashboard.py:23
+#: meinberlin/apps/projectcontainers/dashboard.py:46
+#: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:41
+msgid "Information"
+msgstr "Information"
+
+#: adhocracy4/dashboard/dashboard.py:25
+#: adhocracy4/dashboard/dashboard.py:25
+#: meinberlin/apps/projectcontainers/dashboard.py:48
+msgid "Edit project information"
+msgstr "Projektinformation bearbeiten"
+
+#: adhocracy4/dashboard/dashboard.py:33
+#: adhocracy4/dashboard/dashboard.py:33
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:107
+msgid "Result"
+msgstr "Ergebnis"
+
+#: adhocracy4/dashboard/dashboard.py:35
+#: adhocracy4/dashboard/dashboard.py:35
+msgid "Edit project result"
+msgstr "Projektresultat bearbeiten"
+
+#: adhocracy4/dashboard/dashboard.py:43
+#: adhocracy4/dashboard/dashboard.py:43
+msgid "Basic information"
+msgstr "Grundeinstellungen"
+
+#: adhocracy4/dashboard/dashboard.py:45
+#: adhocracy4/dashboard/dashboard.py:45
+msgid "Edit basic module information"
+msgstr "Moduleinstellungen bearbeiten"
+
+#: adhocracy4/dashboard/dashboard.py:53
+#: adhocracy4/dashboard/dashboard.py:53
+msgid "Phases"
+msgstr "Phasen"
+
+#: adhocracy4/dashboard/dashboard.py:55
+#: adhocracy4/dashboard/dashboard.py:55
+msgid "Edit phases information"
+msgstr "Phaseneinstellungen bearbeiten"
+
+#: adhocracy4/dashboard/dashboard.py:64
+#: adhocracy4/dashboard/dashboard.py:64
+msgid "Areasettings"
+msgstr "Karte"
+
+#: adhocracy4/dashboard/dashboard.py:65
+#: adhocracy4/dashboard/dashboard.py:65
+msgid "Edit areasettings"
+msgstr "Kartenbereich bearbeiten"
+
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: meinberlin/apps/ideas/views.py:29 meinberlin/apps/projects/views.py:53
+#: meinberlin/apps/topicprio/views.py:21
+#: meinberlin/templates/a4filters/widgets/free_text_filter.html:4
+#: meinberlin/templates/a4filters/widgets/free_text_filter.html:10
+#: meinberlin/templates/a4filters/widgets/free_text_filter.html:11
+#: meinberlin/templates/a4maps/map_choose_point_widget.html:6
+#: meinberlin/templates/a4maps/map_choose_point_widget.html:7
+msgid "Search"
+msgstr "Suchen"
+
+#: adhocracy4/dashboard/filter.py:15
+#: adhocracy4/dashboard/filter.py:15
+#: meinberlin/apps/projects/views.py:57
+msgid "Archived"
+msgstr "Archiviert"
+
+#: adhocracy4/dashboard/filter.py:19
+#: adhocracy4/filters/widgets.py:32
+#: adhocracy4/dashboard/filter.py:19
+#: adhocracy4/filters/widgets.py:32
+#: meinberlin/apps/projects/views.py:61
+msgid "All"
+msgstr "Alle"
+
+#: adhocracy4/dashboard/filter.py:20
+#: adhocracy4/dashboard/filter.py:20
+#: meinberlin/apps/projects/views.py:62
+msgid "No"
+msgstr "Nein"
+
+#: adhocracy4/dashboard/filter.py:21
+#: adhocracy4/dashboard/filter.py:21
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_confirm_delete.html:13
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html:13
+#: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_confirm_delete.html:13
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_confirm_delete.html:13
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_confirm_delete.html:12
+#: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_confirm_delete.html:12
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_confirm_delete.html:11
+#: meinberlin/apps/projects/serializers.py:156
+#: meinberlin/apps/projects/views.py:63
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_confirm_delete.html:12
+msgid "Yes"
+msgstr "Ja"
+
+#: adhocracy4/dashboard/forms.py:76
+#: adhocracy4/dashboard/forms.py:76
+msgid "All users can participate (public)."
+msgstr "Alle Nutzerinnen und Nutzer können sich beteiligen (öffentlich)."
+
+#: adhocracy4/dashboard/forms.py:78
+#: adhocracy4/dashboard/forms.py:78
+msgid "Only invited users can participate (private)."
+msgstr ""
+"Nur eingeladene Nutzerinnen und Nutzer können sich beteiligen (privat)."
+
+#: adhocracy4/dashboard/forms.py:86
+#: adhocracy4/dashboard/forms.py:86
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:126
+msgid "Contact for questions"
+msgstr "Kontakt für Rückfragen"
+
+#: adhocracy4/dashboard/forms.py:87
+#: adhocracy4/dashboard/forms.py:87
+msgid ""
+"Please name a contact person. The user will then know who is carrying out "
+"this project and to whom they can address possible questions. The contact "
+"person will be shown in the information tab on the project page."
+msgstr ""
+"Bitte benennen Sie eine Kontaktperson. So wissen die Nutzer*innen, wer das "
+"Projekt durchführt und an wen sie sich mit möglichen Fragen wenden können. "
+"Die Kontaktperson wird im Informationsreiter der Projektseite angezeigt."
+
+#: adhocracy4/dashboard/forms.py:92
+#: adhocracy4/dashboard/forms.py:92
+msgid "More contact possibilities"
+msgstr "weitere Kontaktmöglichkeiten"
+
+#: adhocracy4/dashboard/forms.py:105
+#: adhocracy4/phases/models.py:69
+#: adhocracy4/dashboard/forms.py:105
+#: adhocracy4/phases/models.py:69
+#: meinberlin/apps/newsletters/models.py:30
+#: meinberlin/apps/platformemails/models.py:16
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_user_list.html:7
+msgid "Name"
+msgstr "Name"
+
+#: adhocracy4/dashboard/forms.py:107
+#: adhocracy4/dashboard/forms.py:107
+msgid "Address"
+msgstr "Adresse"
+
+#: adhocracy4/dashboard/forms.py:110
+#: adhocracy4/dashboard/forms.py:110
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:134
+msgid "Telephone"
+msgstr "Telefon"
+
+#: adhocracy4/dashboard/forms.py:112
+#: adhocracy4/dashboard/forms.py:112
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
+msgid "Email"
+msgstr "E-Mail"
+
+#: adhocracy4/dashboard/forms.py:114
+#: adhocracy4/dashboard/forms.py:114
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:143
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:158
+msgid "Website"
+msgstr "Webseite"
+
+#: adhocracy4/dashboard/forms.py:144
+#: adhocracy4/phases/models.py:77
+#: adhocracy4/dashboard/forms.py:144
+#: adhocracy4/phases/models.py:77
+#: meinberlin/apps/extprojects/forms.py:29
+#: meinberlin/apps/extprojects/models.py:19
+msgid "End date"
+msgstr "Enddatum"
+
+#: adhocracy4/dashboard/forms.py:144
+#: adhocracy4/dashboard/forms.py:144
+#: meinberlin/apps/extprojects/forms.py:29
+msgid "End time"
+msgstr "Endzeit"
+
+#: adhocracy4/dashboard/forms.py:150
+#: adhocracy4/phases/models.py:75
+#: adhocracy4/dashboard/forms.py:150
+#: adhocracy4/phases/models.py:75
+#: meinberlin/apps/extprojects/forms.py:23
+#: meinberlin/apps/extprojects/models.py:17
+msgid "Start date"
+msgstr "Anfangsdatum"
+
+#: adhocracy4/dashboard/forms.py:150
+#: adhocracy4/dashboard/forms.py:150
+#: meinberlin/apps/extprojects/forms.py:23
+msgid "Start time"
+msgstr "Anfangszeit"
+
+#: adhocracy4/dashboard/mixins.py:207
+#: adhocracy4/dashboard/mixins.py:207
+msgid "Project successfully duplicated."
+msgstr "Projekt erfolgreich dupliziert."
 
 #: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
 #: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
@@ -218,7 +536,7 @@ msgstr "Abbrechen"
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
-#: meinberlin/apps/plans/exports.py:50
+#: meinberlin/apps/plans/exports.py:49
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_list.html:4
 #: meinberlin/apps/projectcontainers/dashboard.py:60
 #: meinberlin/apps/projectcontainers/models.py:14
@@ -235,12 +553,14 @@ msgid "Finished"
 msgstr "Abgeschlossen"
 
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/projects/enums.py:14
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
 #: adhocracy4/projects/enums.py:14
 msgid "semipublic"
 msgstr "halb-öffentlich"
 
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/projects/enums.py:15
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
 #: adhocracy4/projects/enums.py:15
 msgid "private"
@@ -253,7 +573,7 @@ msgstr "privat"
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:43
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:126
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:28
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:69
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:73
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_dashboard_list_item.html:19
 #: meinberlin/templates/a4dashboard/includes/project_list_item.html:44
 msgid "Edit"
@@ -272,18 +592,156 @@ msgstr "Duplizieren"
 msgid "We could not find any projects."
 msgstr "Wir konnten keine Projekte finden."
 
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: adhocracy4/dashboard/filter.py:11
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: meinberlin/apps/ideas/views.py:29 meinberlin/apps/projects/views.py:53
-#: meinberlin/apps/topicprio/views.py:21
-#: meinberlin/templates/a4filters/widgets/free_text_filter.html:4
-#: meinberlin/templates/a4filters/widgets/free_text_filter.html:10
-#: meinberlin/templates/a4filters/widgets/free_text_filter.html:11
-#: meinberlin/templates/a4maps/map_choose_point_widget.html:6
-#: meinberlin/templates/a4maps/map_choose_point_widget.html:7
-msgid "Search"
-msgstr "Suchen"
+#: adhocracy4/dashboard/views.py:69
+#: adhocracy4/dashboard/views.py:69
+msgid "Project successfully created."
+msgstr "Projekt erfolgreich erstellt."
+
+#: adhocracy4/dashboard/views.py:154
+#: adhocracy4/dashboard/views.py:154
+#: meinberlin/apps/dashboard/views.py:130
+msgid "Invalid action"
+msgstr "Ungültige Aktion"
+
+#: adhocracy4/dashboard/views.py:171
+#: adhocracy4/dashboard/views.py:171
+msgid "Project is already published"
+msgstr "Das Projekt wurde bereits veröffentlicht"
+
+#: adhocracy4/dashboard/views.py:176
+#: adhocracy4/dashboard/views.py:176
+msgid "Project cannot be published. No module is added."
+msgstr "Das Projekt kann nicht veröffentlicht werden. Kein Modul hinzugefügt."
+
+#: adhocracy4/dashboard/views.py:191
+#: adhocracy4/dashboard/views.py:191
+msgid "Project cannot be published. Required fields are missing."
+msgstr ""
+"Das Projekt kann nicht veröffentlicht werden. Es fehlen benötigte Felder."
+
+#: adhocracy4/dashboard/views.py:200
+#: adhocracy4/dashboard/views.py:200
+msgid "Project cannot be published."
+msgstr "Das Projekt kann nicht veröffentlicht werden."
+
+#: adhocracy4/dashboard/views.py:211
+#: adhocracy4/dashboard/views.py:211
+msgid "the project has been published."
+msgstr "Das Projekt wurde veröffentlicht."
+
+#: adhocracy4/dashboard/views.py:216
+#: adhocracy4/dashboard/views.py:216
+msgid "Project is already unpublished"
+msgstr "Das Projekt wurde bereits depubliziert."
+
+#: adhocracy4/dashboard/views.py:225
+#: adhocracy4/dashboard/views.py:225
+msgid "the project has been unpublished."
+msgstr "Das Projekt wurde depubliziert."
+
+#: adhocracy4/exports/mixins/comments.py:16
+#: adhocracy4/exports/mixins/comments.py:16
+msgid "Comment count"
+msgstr "Anzahl Kommentare"
+
+#: adhocracy4/exports/mixins/comments.py:77
+#: adhocracy4/exports/mixins/comments.py:77
+msgid "Reply to Comment"
+msgstr ""
+
+#: adhocracy4/exports/mixins/comments.py:95
+#: adhocracy4/exports/mixins/comments.py:95
+msgid "Reply to Reference"
+msgstr ""
+
+#: adhocracy4/exports/mixins/general.py:14
+#: adhocracy4/exports/mixins/general.py:14
+msgid "Creator"
+msgstr "Urheber"
+
+#: adhocracy4/exports/mixins/general.py:16
+#: adhocracy4/exports/mixins/general.py:16
+#: meinberlin/apps/budgeting/exports.py:81
+#: meinberlin/apps/documents/exports.py:40 meinberlin/apps/ideas/exports.py:72
+#: meinberlin/apps/kiezkasse/exports.py:74
+#: meinberlin/apps/mapideas/exports.py:72
+#: meinberlin/apps/maptopicprio/exports.py:70
+#: meinberlin/apps/polls/exports.py:38 meinberlin/apps/topicprio/exports.py:69
+msgid "Created"
+msgstr "Erstellt"
+
+#: adhocracy4/exports/mixins/general.py:34
+#: adhocracy4/exports/mixins/general.py:34
+msgid "Link"
+msgstr "Link"
+
+#: adhocracy4/exports/mixins/general.py:49
+#: adhocracy4/exports/mixins/general.py:49
+msgid "Location (Longitude)"
+msgstr "Ort (Längengrad)"
+
+#: adhocracy4/exports/mixins/general.py:51
+#: adhocracy4/exports/mixins/general.py:51
+msgid "Location (Latitude)"
+msgstr "Ort (Breitengrad)"
+
+#: adhocracy4/exports/mixins/general.py:53
+#: adhocracy4/exports/mixins/general.py:53
+msgid "Location label"
+msgstr "Ortsbezeichnung"
+
+#: adhocracy4/exports/mixins/items.py:29
+#: adhocracy4/labels/dashboard.py:13
+#: adhocracy4/exports/mixins/items.py:29
+#: adhocracy4/labels/dashboard.py:13
+#: meinberlin/apps/ideas/models.py:45 meinberlin/apps/maptopicprio/models.py:45
+#: meinberlin/apps/topicprio/models.py:60
+msgid "Labels"
+msgstr "Merkmale"
+
+#: adhocracy4/exports/mixins/items.py:46
+#: adhocracy4/exports/mixins/items.py:46
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:77
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
+msgid "Reference No."
+msgstr "Referenznr."
+
+#: adhocracy4/exports/mixins/items.py:65
+#: adhocracy4/exports/mixins/items.py:65
+msgid "Moderator feedback"
+msgstr "Rückmeldung der Moderation"
+
+#: adhocracy4/exports/mixins/items.py:67
+#: adhocracy4/exports/mixins/items.py:67
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:122
+msgid "Official Statement"
+msgstr "Offizielle Rückmeldung"
+
+#: adhocracy4/exports/mixins/items.py:89
+#: adhocracy4/exports/mixins/items.py:89
+#: meinberlin/apps/moderatorremark/models.py:18
+#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:5
+#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:21
+msgid "Remark"
+msgstr "Notiz"
+
+#: adhocracy4/exports/mixins/rates.py:15
+#: adhocracy4/exports/mixins/rates.py:15
+msgid "Positive ratings"
+msgstr "Positive Bewertungen"
+
+#: adhocracy4/exports/mixins/rates.py:17
+#: adhocracy4/exports/mixins/rates.py:17
+msgid "Negative ratings"
+msgstr "Negative Bewertungen"
+
+#: adhocracy4/forms/fields.py:18
+#: adhocracy4/forms/fields.py:18
+#, python-format
+msgid "Time of %(date_label)s"
+msgstr "Uhrzeit für %(date_label)s"
 
 #: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
 #: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
@@ -302,6 +760,30 @@ msgstr "Dieses Feld muss ausgefüllt werden"
 #: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
 msgid "Remove category"
 msgstr "Kategorie entfernen"
+
+#: adhocracy4/images/fields.py:71
+#: adhocracy4/images/fields.py:71
+#, python-brace-format
+msgid ""
+"{help_prefix} It must be min. {min_resolution[0]} pixel wide and "
+"{min_resolution[1]} pixel tall. Allowed file formats are {fileformats_str}. "
+"The file size should be max. {max_size_mb} MB."
+msgstr ""
+"{help_prefix} Das Bild muss mindestens {min_resolution[0]} Pixel breit und "
+"{min_resolution[1]} Pixel hoch sein. Erlaubte Dateiformate: "
+"{fileformats_str}. Die maximale Dateigröße beträgt {max_size_mb} MB."
+
+#: adhocracy4/images/fields.py:91
+#: adhocracy4/images/fields.py:91
+#, python-brace-format
+msgid "{image_name} copyright"
+msgstr "{image_name} Urheber*in"
+
+#: adhocracy4/images/fields.py:94
+#: adhocracy4/images/fields.py:94
+#, python-brace-format
+msgid "Copyright shown in the {image_name}."
+msgstr "Urheber*in, die im {image_name} angezeigt wird."
 
 #: adhocracy4/images/templates/a4images/image_upload_widget.html:8
 #: adhocracy4/images/templates/a4images/image_upload_widget.html:8
@@ -329,6 +811,50 @@ msgstr ""
 "Ihr Bild wird hochgeladen sobald Sie Ihre Änderungen am Ende der Seite "
 "speichern."
 
+#: adhocracy4/images/validators.py:20
+#: adhocracy4/images/validators.py:20
+msgid "Unsupported file format. Supported formats are {}."
+msgstr "Dieses Dateiformat ist nicht unterstützt. Unterstützt werden: {}."
+
+#: adhocracy4/images/validators.py:27
+#: adhocracy4/images/validators.py:27
+#, python-brace-format
+msgid "Image should be at most {max_size} MB"
+msgstr "Das Bild darf höchstens {max_size} MB groß sein."
+
+#: adhocracy4/images/validators.py:30
+#: adhocracy4/images/validators.py:30
+#, python-brace-format
+msgid "Image must be at least {min_width} pixels wide"
+msgstr "Das Bild muss mindestens {min_width} Pixel breit sein."
+
+#: adhocracy4/images/validators.py:33
+#: adhocracy4/images/validators.py:33
+#, python-brace-format
+msgid "Image must be at least {min_height} pixels high"
+msgstr "Das Bild muss mindestens {min_height} Pixel hoch sein."
+
+#: adhocracy4/images/validators.py:43
+#: adhocracy4/images/validators.py:43
+#, python-brace-format
+msgid "Image aspect ratio should be {aspect_width}:{aspect_height}"
+msgstr "Das Seitenverhältnis muss {aspect_width}:{aspect_height} entsprechen."
+
+#: adhocracy4/images/widgets.py:25
+#: adhocracy4/images/widgets.py:25
+msgid "Select a picture from your local folder."
+msgstr "Ein Bild aus einem lokalen Ordner auswählen."
+
+#: adhocracy4/labels/dashboard.py:15
+#: adhocracy4/labels/dashboard.py:15
+msgid "Edit labels"
+msgstr "Merkmale bearbeiten"
+
+#: adhocracy4/labels/forms.py:17
+#: adhocracy4/labels/forms.py:17
+msgid "Label"
+msgstr "Merkmal"
+
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
 #: meinberlin/templates/a4labels/includes/module_labels_form.html:3
@@ -346,419 +872,14 @@ msgstr ""
 msgid "Add label"
 msgstr "Merkmal hinzufügen"
 
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-#: meinberlin/apps/polls/templates/meinberlin_polls/poll_404.html:8
-#: meinberlin/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr ""
-"Die Beteiligung ist aktuell noch nicht möglich. Die Umfrage wird gerade "
-"angelegt."
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-#: meinberlin/apps/polls/templates/meinberlin_polls/poll_404.html:15
-#: meinberlin/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr ""
-"Legen Sie die Umfrage an indem Sie Fragen und Antwortmöglichkeiten in der "
-"Projektverwaltung hinzufügen."
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-#: meinberlin/apps/polls/templates/meinberlin_polls/poll_dashboard.html:5
-#: meinberlin/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
-msgstr "Umfrage bearbeiten"
-
-#: adhocracy4/categories/dashboard.py:13
-msgid "Categories"
-msgstr "Kategorien"
-
-#: adhocracy4/categories/dashboard.py:15
-msgid "Edit categories"
-msgstr "Kategorien bearbeiten"
-
-#: adhocracy4/categories/fields.py:12
-#: adhocracy4/categories/filters.py:16
-#: adhocracy4/categories/forms.py:45
-#: adhocracy4/exports/mixins.py:151
-msgid "Category"
-msgstr "Kategorie"
-
-#: adhocracy4/categories/forms.py:38
-#: adhocracy4/labels/forms.py:14
-msgid "Category name"
-msgstr "Kategoriename"
-
-#: adhocracy4/categories/forms.py:39
-msgid "Category icon"
-msgstr "Kategorieicon"
-
-#: adhocracy4/comments/models.py:53
-msgctxt "noun"
-msgid "Comment"
-msgstr "Kommentar"
-
-#: adhocracy4/comments/models.py:54
-#: adhocracy4/exports/mixins.py:123
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:16
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:17
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:18
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:19
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:18
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:20
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:18
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:20
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:18
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:20
-msgid "Comments"
-msgstr "Kommentare"
-
-#: adhocracy4/comments/models.py:74
-#: adhocracy4/comments_async/serializers.py:151
-msgid "deleted by creator"
-msgstr "Vom Ersteller gelöscht"
-
-#: adhocracy4/comments/models.py:77
-#: adhocracy4/comments_async/serializers.py:153
-msgid "deleted by moderator"
-msgstr "Vom Moderator gelöscht"
-
-#: adhocracy4/comments/serializers.py:52
-#: adhocracy4/comments/serializers.py:151
-msgid "Please choose a category"
-msgstr "Bitte wählen Sie eine Kategorie"
-
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
-msgid "unknown user"
-msgstr "unbekannter Nutzer"
-
-#: adhocracy4/comments_async/serializers.py:58
-msgid "Please choose one or more categories."
-msgstr "Bitte wählen Sie eine oder mehrere Kategorien aus."
-
-#: adhocracy4/dashboard/components/forms/views.py:22
-msgid "The project has been updated."
-msgstr "Das Projekt wurde aktualisiert."
-
-#: adhocracy4/dashboard/components/forms/views.py:47
-msgid "The module has been updated."
-msgstr "Das Modul wurde aktualisiert."
-
-#: adhocracy4/dashboard/dashboard.py:13
-#: meinberlin/apps/projectcontainers/dashboard.py:14
-msgid "Basic settings"
-msgstr "Grundeinstellungen"
-
-#: adhocracy4/dashboard/dashboard.py:15
-#: meinberlin/apps/bplan/dashboard.py:16
-#: meinberlin/apps/extprojects/dashboard.py:16
-msgid "Edit basic settings"
-msgstr "Grundeinstellungen bearbeiten"
-
-#: adhocracy4/dashboard/dashboard.py:23
-#: meinberlin/apps/projectcontainers/dashboard.py:46
-#: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:41
-msgid "Information"
-msgstr "Information"
-
-#: adhocracy4/dashboard/dashboard.py:25
-#: meinberlin/apps/projectcontainers/dashboard.py:48
-msgid "Edit project information"
-msgstr "Projektinformation bearbeiten"
-
-#: adhocracy4/dashboard/dashboard.py:33
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:102
-msgid "Result"
-msgstr "Ergebnis"
-
-#: adhocracy4/dashboard/dashboard.py:35
-msgid "Edit project result"
-msgstr "Projektresultat bearbeiten"
-
-#: adhocracy4/dashboard/dashboard.py:43
-msgid "Basic information"
-msgstr "Grundeinstellungen"
-
-#: adhocracy4/dashboard/dashboard.py:45
-msgid "Edit basic module information"
-msgstr "Moduleinstellungen bearbeiten"
-
-#: adhocracy4/dashboard/dashboard.py:53
-msgid "Phases"
-msgstr "Phasen"
-
-#: adhocracy4/dashboard/dashboard.py:55
-msgid "Edit phases information"
-msgstr "Phaseneinstellungen bearbeiten"
-
-#: adhocracy4/dashboard/dashboard.py:64
-msgid "Areasettings"
-msgstr "Karte"
-
-#: adhocracy4/dashboard/dashboard.py:65
-msgid "Edit areasettings"
-msgstr "Kartenbereich bearbeiten"
-
-#: adhocracy4/dashboard/filter.py:15
-#: meinberlin/apps/projects/views.py:57
-msgid "Archived"
-msgstr "Archiviert"
-
-#: adhocracy4/dashboard/filter.py:19
-#: adhocracy4/filters/widgets.py:32
-#: meinberlin/apps/projects/views.py:61
-msgid "All"
-msgstr "Alle"
-
-#: adhocracy4/dashboard/filter.py:20
-#: meinberlin/apps/projects/views.py:62
-msgid "No"
-msgstr "Nein"
-
-#: adhocracy4/dashboard/filter.py:21
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_confirm_delete.html:13
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html:13
-#: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_confirm_delete.html:13
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_confirm_delete.html:13
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_confirm_delete.html:12
-#: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_confirm_delete.html:12
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_confirm_delete.html:11
-#: meinberlin/apps/projects/serializers.py:156
-#: meinberlin/apps/projects/views.py:63
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_confirm_delete.html:12
-msgid "Yes"
-msgstr "Ja"
-
-#: adhocracy4/dashboard/forms.py:76
-msgid "All users can participate (public)."
-msgstr "Alle Nutzerinnen und Nutzer können sich beteiligen (öffentlich)."
-
-#: adhocracy4/dashboard/forms.py:78
-msgid "Only invited users can participate (private)."
-msgstr ""
-"Nur eingeladene Nutzerinnen und Nutzer können sich beteiligen (privat)."
-
-#: adhocracy4/dashboard/forms.py:86
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:121
-msgid "Contact for questions"
-msgstr "Kontakt für Rückfragen"
-
-#: adhocracy4/dashboard/forms.py:87
-msgid ""
-"Please name a contact person. The user will then know who is carrying out "
-"this project and to whom they can address possible questions. The contact "
-"person will be shown in the information tab on the project page."
-msgstr ""
-"Bitte benennen Sie eine Kontaktperson. So wissen die Nutzer*innen, wer das "
-"Projekt durchführt und an wen sie sich mit möglichen Fragen wenden können. "
-"Die Kontaktperson wird im Informationsreiter der Projektseite angezeigt."
-
-#: adhocracy4/dashboard/forms.py:92
-msgid "More contact possibilities"
-msgstr "weitere Kontaktmöglichkeiten"
-
-#: adhocracy4/dashboard/forms.py:105
-#: adhocracy4/phases/models.py:69
-#: meinberlin/apps/newsletters/models.py:30
-#: meinberlin/apps/platformemails/models.py:16
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_user_list.html:7
-msgid "Name"
-msgstr "Name"
-
-#: adhocracy4/dashboard/forms.py:107
-msgid "Address"
-msgstr "Adresse"
-
-#: adhocracy4/dashboard/forms.py:110
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:129
-msgid "Telephone"
-msgstr "Telefon"
-
-#: adhocracy4/dashboard/forms.py:112
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:133
-msgid "Email"
-msgstr "E-Mail"
-
-#: adhocracy4/dashboard/forms.py:114
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:153
-msgid "Website"
-msgstr "Webseite"
-
-#: adhocracy4/dashboard/forms.py:144
-#: adhocracy4/phases/models.py:77
-#: meinberlin/apps/extprojects/forms.py:29
-#: meinberlin/apps/extprojects/models.py:19
-msgid "End date"
-msgstr "Enddatum"
-
-#: adhocracy4/dashboard/forms.py:144
-#: meinberlin/apps/extprojects/forms.py:29
-msgid "End time"
-msgstr "Endzeit"
-
-#: adhocracy4/dashboard/forms.py:150
-#: adhocracy4/phases/models.py:75
-#: meinberlin/apps/extprojects/forms.py:23
-#: meinberlin/apps/extprojects/models.py:17
-msgid "Start date"
-msgstr "Anfangsdatum"
-
-#: adhocracy4/dashboard/forms.py:150
-#: meinberlin/apps/extprojects/forms.py:23
-msgid "Start time"
-msgstr "Anfangszeit"
-
-#: adhocracy4/dashboard/mixins.py:204
-msgid "Project successfully duplicated."
-msgstr "Projekt erfolgreich dupliziert."
-
-#: adhocracy4/dashboard/views.py:69
-msgid "Project successfully created."
-msgstr "Projekt erfolgreich erstellt."
-
-#: adhocracy4/dashboard/views.py:154
-#: meinberlin/apps/dashboard/views.py:130
-msgid "Invalid action"
-msgstr "Ungültige Aktion"
-
-#: adhocracy4/dashboard/views.py:171
-msgid "Project is already published"
-msgstr "Das Projekt wurde bereits veröffentlicht"
-
-#: adhocracy4/dashboard/views.py:176
-msgid "Project cannot be published. No module is added."
-msgstr "Das Projekt kann nicht veröffentlicht werden. Kein Modul hinzugefügt."
-
-#: adhocracy4/dashboard/views.py:191
-msgid "Project cannot be published. Required fields are missing."
-msgstr ""
-"Das Projekt kann nicht veröffentlicht werden. Es fehlen benötigte Felder."
-
-#: adhocracy4/dashboard/views.py:200
-msgid "Project cannot be published."
-msgstr "Das Projekt kann nicht veröffentlicht werden."
-
-#: adhocracy4/dashboard/views.py:211
-msgid "the project has been published."
-msgstr "Das Projekt wurde veröffentlicht."
-
-#: adhocracy4/dashboard/views.py:216
-msgid "Project is already unpublished"
-msgstr "Das Projekt wurde bereits depubliziert."
-
-#: adhocracy4/dashboard/views.py:225
-msgid "the project has been unpublished."
-msgstr "Das Projekt wurde depubliziert."
-
-#: adhocracy4/exports/mixins.py:18
-msgid "Link"
-msgstr "Link"
-
-#: adhocracy4/exports/mixins.py:64
-msgid "Positive ratings"
-msgstr "Positive Bewertungen"
-
-#: adhocracy4/exports/mixins.py:66
-msgid "Negative ratings"
-msgstr "Negative Bewertungen"
-
-#: adhocracy4/exports/mixins.py:99
-msgid "Comment count"
-msgstr "Anzahl Kommentare"
-
-#: adhocracy4/exports/mixins.py:164
-#: adhocracy4/labels/dashboard.py:13
-#: meinberlin/apps/ideas/models.py:45 meinberlin/apps/maptopicprio/models.py:45
-#: meinberlin/apps/topicprio/models.py:45
-msgid "Labels"
-msgstr "Merkmale"
-
-#: adhocracy4/exports/mixins.py:176
-msgid "Location (Longitude)"
-msgstr "Ort (Längengrad)"
-
-#: adhocracy4/exports/mixins.py:178
-msgid "Location (Latitude)"
-msgstr "Ort (Breitengrad)"
-
-#: adhocracy4/exports/mixins.py:180
-msgid "Location label"
-msgstr "Ortsbezeichnung"
-
-#: adhocracy4/forms/fields.py:18
-#, python-format
-msgid "Time of %(date_label)s"
-msgstr "Uhrzeit für %(date_label)s"
-
-#: adhocracy4/images/fields.py:71
-#, python-brace-format
-msgid ""
-"{help_prefix} It must be min. {min_resolution[0]} pixel wide and "
-"{min_resolution[1]} pixel tall. Allowed file formats are {fileformats_str}. "
-"The file size should be max. {max_size_mb} MB."
-msgstr ""
-"{help_prefix} Das Bild muss mindestens {min_resolution[0]} Pixel breit und "
-"{min_resolution[1]} Pixel hoch sein. Erlaubte Dateiformate: "
-"{fileformats_str}. Die maximale Dateigröße beträgt {max_size_mb} MB."
-
-#: adhocracy4/images/fields.py:91
-#, python-brace-format
-msgid "{image_name} copyright"
-msgstr "{image_name} Urheber*in"
-
-#: adhocracy4/images/fields.py:94
-#, python-brace-format
-msgid "Copyright shown in the {image_name}."
-msgstr "Urheber*in, die im {image_name} angezeigt wird."
-
-#: adhocracy4/images/validators.py:20
-msgid "Unsupported file format. Supported formats are {}."
-msgstr "Dieses Dateiformat ist nicht unterstützt. Unterstützt werden: {}."
-
-#: adhocracy4/images/validators.py:27
-#, python-brace-format
-msgid "Image should be at most {max_size} MB"
-msgstr "Das Bild darf höchstens {max_size} MB groß sein."
-
-#: adhocracy4/images/validators.py:30
-#, python-brace-format
-msgid "Image must be at least {min_width} pixels wide"
-msgstr "Das Bild muss mindestens {min_width} Pixel breit sein."
-
-#: adhocracy4/images/validators.py:33
-#, python-brace-format
-msgid "Image must be at least {min_height} pixels high"
-msgstr "Das Bild muss mindestens {min_height} Pixel hoch sein."
-
-#: adhocracy4/images/validators.py:43
-#, python-brace-format
-msgid "Image aspect ratio should be {aspect_width}:{aspect_height}"
-msgstr "Das Seitenverhältnis muss {aspect_width}:{aspect_height} entsprechen."
-
-#: adhocracy4/images/widgets.py:25
-msgid "Select a picture from your local folder."
-msgstr "Ein Bild aus einem lokalen Ordner auswählen."
-
-#: adhocracy4/labels/dashboard.py:15
-msgid "Edit labels"
-msgstr "Merkmale bearbeiten"
-
-#: adhocracy4/labels/forms.py:17
-msgid "Label"
-msgstr "Merkmal"
-
+#: adhocracy4/maps/admin.py:14
+#: adhocracy4/maps/models.py:11
 #: adhocracy4/maps/admin.py:14
 #: adhocracy4/maps/models.py:11
 msgid "Polygon"
 msgstr "Polygon"
 
+#: adhocracy4/maps/admin.py:16
 #: adhocracy4/maps/admin.py:16
 msgid ""
 "Enter a valid GeoJSON object. To initialize a new areasetting enter the "
@@ -768,13 +889,16 @@ msgstr ""
 "Anführungszeichen eingeben."
 
 #: adhocracy4/maps/fields.py:17
+#: adhocracy4/maps/fields.py:17
 msgid "Geometry as GeoJSON"
 msgstr "GeoJSON kodierte Koordinaten"
 
 #: adhocracy4/maps/fields.py:35
+#: adhocracy4/maps/fields.py:35
 msgid "Please add a Marker on the map"
 msgstr "Bitte setzen Sie einen Punkt auf der Karte."
 
+#: adhocracy4/maps/fields.py:40
 #: adhocracy4/maps/fields.py:40
 msgid "Please draw a Polygon on the map"
 msgstr ""
@@ -782,15 +906,18 @@ msgstr ""
 "vordefinierten Bereich aus"
 
 #: adhocracy4/maps/models.py:12
+#: adhocracy4/maps/models.py:12
 msgid "Please draw an area on the map."
 msgstr ""
 "Bitte zeichnen Sie einen Bereich auf der Karte ein, in dem Ihr Projekt "
 "stattfindet und Ideen verortet werden sollen."
 
 #: adhocracy4/modules/models.py:67
+#: adhocracy4/modules/models.py:67
 msgid "Title of the module"
 msgstr "Modultitel"
 
+#: adhocracy4/modules/models.py:68
 #: adhocracy4/modules/models.py:68
 msgid ""
 "This title will appear in the timeline and the header on the module and "
@@ -801,9 +928,11 @@ msgstr ""
 "512 Zeichen lang sein."
 
 #: adhocracy4/modules/models.py:76
+#: adhocracy4/modules/models.py:76
 msgid "Short description of the module"
 msgstr "Kurzbeschreibung des Moduls"
 
+#: adhocracy4/modules/models.py:77
 #: adhocracy4/modules/models.py:77
 msgid ""
 "This short description will appear on the header of the module and project "
@@ -814,74 +943,98 @@ msgstr ""
 "Projekt mehr als ein Modul oder eine Veranstaltung hat. Sie sollte in "
 "maximal 512 Zeichen das Ziel des Moduls beschreiben."
 
-#: adhocracy4/modules/models.py:184
-#: adhocracy4/projects/models.py:586
+#: adhocracy4/modules/models.py:192
+#: adhocracy4/projects/models.py:588
+#: adhocracy4/modules/models.py:192
+#: adhocracy4/projects/models.py:588
 #: meinberlin/apps/projects/serializers.py:216
 msgid "day"
 msgstr "Tag"
 
-#: adhocracy4/modules/models.py:184
-#: adhocracy4/projects/models.py:586
+#: adhocracy4/modules/models.py:192
+#: adhocracy4/projects/models.py:588
+#: adhocracy4/modules/models.py:192
+#: adhocracy4/projects/models.py:588
 #: meinberlin/apps/projects/serializers.py:216
 msgid "days"
 msgstr "Tage"
 
-#: adhocracy4/modules/models.py:185
-#: adhocracy4/projects/models.py:587
+#: adhocracy4/modules/models.py:193
+#: adhocracy4/projects/models.py:589
+#: adhocracy4/modules/models.py:193
+#: adhocracy4/projects/models.py:589
 #: meinberlin/apps/projects/serializers.py:217
 msgid "hour"
 msgstr "Stunde"
 
-#: adhocracy4/modules/models.py:185
-#: adhocracy4/projects/models.py:587
+#: adhocracy4/modules/models.py:193
+#: adhocracy4/projects/models.py:589
+#: adhocracy4/modules/models.py:193
+#: adhocracy4/projects/models.py:589
 #: meinberlin/apps/projects/serializers.py:217
 msgid "hours"
 msgstr "Stunden"
 
-#: adhocracy4/modules/models.py:186
-#: adhocracy4/projects/models.py:588
+#: adhocracy4/modules/models.py:194
+#: adhocracy4/projects/models.py:590
+#: adhocracy4/modules/models.py:194
+#: adhocracy4/projects/models.py:590
 #: meinberlin/apps/projects/serializers.py:218
 msgid "minute"
 msgstr "Minute"
 
-#: adhocracy4/modules/models.py:186
-#: adhocracy4/projects/models.py:588
+#: adhocracy4/modules/models.py:194
+#: adhocracy4/projects/models.py:590
+#: adhocracy4/modules/models.py:194
+#: adhocracy4/projects/models.py:590
 #: meinberlin/apps/projects/serializers.py:218
 msgid "minutes"
 msgstr "Minuten"
 
-#: adhocracy4/modules/models.py:187
-#: adhocracy4/projects/models.py:589
+#: adhocracy4/modules/models.py:195
+#: adhocracy4/projects/models.py:591
+#: adhocracy4/modules/models.py:195
+#: adhocracy4/projects/models.py:591
 #: meinberlin/apps/projects/serializers.py:219
 msgid "second"
 msgstr "Sekunde"
 
-#: adhocracy4/modules/models.py:187
-#: adhocracy4/modules/models.py:198
-#: adhocracy4/projects/models.py:589
-#: adhocracy4/projects/models.py:600
+#: adhocracy4/modules/models.py:195
+#: adhocracy4/modules/models.py:206
+#: adhocracy4/projects/models.py:591
+#: adhocracy4/projects/models.py:602
+#: adhocracy4/modules/models.py:195
+#: adhocracy4/modules/models.py:206
+#: adhocracy4/projects/models.py:591
+#: adhocracy4/projects/models.py:602
 #: meinberlin/apps/projects/serializers.py:219
 msgid "seconds"
 msgstr "Sekunden"
 
+#: adhocracy4/phases/forms.py:23
 #: adhocracy4/phases/forms.py:23
 msgid "Phases cannot run at the same time and must follow after each other."
 msgstr ""
 "Phasen könnnen nicht gleichzeitig laufen und dürfen sich nicht überschneiden."
 
 #: adhocracy4/phases/models.py:71
+#: adhocracy4/phases/models.py:71
 #: meinberlin/apps/activities/models.py:21 meinberlin/apps/ideas/models.py:32
-#: meinberlin/apps/maptopicprio/forms.py:26
+#: meinberlin/apps/maptopicprio/forms.py:19
 #: meinberlin/apps/maptopicprio/models.py:31
 #: meinberlin/apps/offlineevents/models.py:36
-#: meinberlin/apps/plans/models.py:84
+#: meinberlin/apps/plans/models.py:84 meinberlin/apps/topicprio/forms.py:19
+#: meinberlin/apps/topicprio/models.py:39
 msgid "Description"
 msgstr "Beschreibung"
 
 #: adhocracy4/phases/models.py:95
+#: adhocracy4/phases/models.py:95
 msgid "End date can not be before start date."
 msgstr "Das Enddatum kann nicht vor dem Startdatum liegen."
 
+#: adhocracy4/phases/models.py:100
+#: adhocracy4/phases/models.py:104
 #: adhocracy4/phases/models.py:100
 #: adhocracy4/phases/models.py:104
 msgid "Either both or no date has to be set."
@@ -889,40 +1042,121 @@ msgstr ""
 "Entweder müssen Start- und Enddatum angegeben werden oder keines der beiden."
 
 #: adhocracy4/polls/dashboard.py:14
+#: adhocracy4/polls/dashboard.py:14
 #: meinberlin/apps/dashboard/blueprints.py:154
-#: meinberlin/apps/polls/dashboard.py:15
 msgid "Poll"
 msgstr "Umfrage"
 
-#: adhocracy4/polls/phases.py:15
-msgid "Voting phase"
-msgstr "Abstimmungsphase"
+#: adhocracy4/polls/models.py:52
+#: adhocracy4/polls/models.py:52
+msgid "Help text"
+msgstr ""
+
+#: adhocracy4/polls/models.py:76
+#: adhocracy4/polls/models.py:76
+msgid "Questions with open answers cannot have multiple choices."
+msgstr ""
+
+#: adhocracy4/polls/models.py:81
+#: adhocracy4/polls/models.py:81
+msgid ""
+"Question with choices cannot become open question. Delete choices or add new "
+"open question."
+msgstr ""
+
+#: adhocracy4/polls/models.py:146
+#: adhocracy4/polls/models.py:259
+#: adhocracy4/polls/models.py:146
+#: adhocracy4/polls/models.py:259
+msgid "Answer"
+msgstr ""
+
+#: adhocracy4/polls/models.py:158
+#: adhocracy4/polls/models.py:158
+msgid "Only open questions can have answers."
+msgstr ""
+
+#: adhocracy4/polls/models.py:195
+#: adhocracy4/polls/models.py:195
+msgid "Open questions cannot have choices."
+msgstr ""
+
+#: adhocracy4/polls/models.py:199
+#: adhocracy4/polls/models.py:199
+msgid ""
+"\"Other\" cannot be the only choice. Use open question or add more choices."
+msgstr ""
+
+#: adhocracy4/polls/models.py:204
+#: adhocracy4/polls/models.py:204
+msgid "Question already has \"other\" choice."
+msgstr ""
+
+#: adhocracy4/polls/models.py:265
+#: adhocracy4/polls/models.py:265
+msgid "Other vote can only be created for vote on \"other\" choice."
+msgstr ""
+
+#: adhocracy4/polls/models.py:286
+#: adhocracy4/polls/models.py:286
+msgid "other"
+msgstr ""
 
 #: adhocracy4/polls/phases.py:16
-msgid "Cast votes and discuss the poll."
-msgstr "Abgeben von Stimmen und kommentieren der Umfrage."
+#: adhocracy4/polls/phases.py:16
+msgctxt "A4: voting phase name"
+msgid "Voting phase"
+msgstr ""
 
-#: adhocracy4/polls/phases.py:17
-#: meinberlin/apps/polls/phases.py:18
+#: adhocracy4/polls/phases.py:19
+#: adhocracy4/polls/phases.py:19
+msgctxt "A4: voting phase description"
+msgid "Answer the questions and comment on the poll."
+msgstr ""
+
+#: adhocracy4/polls/phases.py:21
+#: adhocracy4/polls/phases.py:21
 msgid "polls"
 msgstr "Umfragen"
 
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr ""
+"Die Beteiligung ist aktuell noch nicht möglich. Die Umfrage wird gerade "
+"angelegt."
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr ""
+"Legen Sie die Umfrage an indem Sie Fragen und Antwortmöglichkeiten in der "
+"Projektverwaltung hinzufügen."
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr "Umfrage bearbeiten"
+
 #: adhocracy4/polls/validators.py:15
-#: meinberlin/apps/polls/validators.py:15
+#: adhocracy4/polls/validators.py:15
 #, python-format
 msgid "Item of type %(item)s for that module already exists"
 msgstr "Beitrag des Typs %(item)s für dieses Modul existiert bereits."
 
 #: adhocracy4/polls/validators.py:38
-#: meinberlin/apps/polls/validators.py:38
+#: adhocracy4/polls/validators.py:38
 msgid "Only one vote per question is allowed per user."
 msgstr "Jeder Nutzer darf pro Frage nur eine Stimme abgeben."
 
 #: adhocracy4/polls/validators.py:47
-#: meinberlin/apps/polls/validators.py:47
+#: adhocracy4/polls/validators.py:47
 msgid "Choice has to belong to the question set in the url."
 msgstr "Die Auswahl muss zu der richtigen Frage gehören."
 
+#: adhocracy4/projects/admin.py:8
 #: adhocracy4/projects/admin.py:8
 #: meinberlin/apps/adminlog/models.py:42
 #: meinberlin/apps/newsletters/forms.py:35
@@ -932,10 +1166,12 @@ msgid "Project"
 msgstr "Projekt"
 
 #: adhocracy4/projects/admin.py:47
+#: adhocracy4/projects/admin.py:47
 #: meinberlin/apps/projects/admin.py:43
 msgid "Information and result"
 msgstr "Informationen und Ergebnis"
 
+#: adhocracy4/projects/admin.py:50
 #: adhocracy4/projects/admin.py:50
 #: meinberlin/apps/organisations/templates/meinberlin_organisations/organisation_form.html:4
 #: meinberlin/apps/projects/admin.py:46
@@ -943,10 +1179,12 @@ msgid "Settings"
 msgstr "Einstellungen"
 
 #: adhocracy4/projects/admin.py:54
+#: adhocracy4/projects/admin.py:54
 #: meinberlin/apps/projects/admin.py:51
 msgid "Images"
 msgstr "Bilder"
 
+#: adhocracy4/projects/admin.py:59
 #: adhocracy4/projects/admin.py:59
 #: meinberlin/apps/plans/models.py:78
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:100
@@ -956,9 +1194,11 @@ msgid "Contact"
 msgstr "Kontakt"
 
 #: adhocracy4/projects/enums.py:13
+#: adhocracy4/projects/enums.py:13
 msgid "public"
 msgstr "öffentlich"
 
+#: adhocracy4/projects/models.py:43
 #: adhocracy4/projects/models.py:43
 msgid ""
 "Phone numbers can only contain digits, spaces and the following characters: "
@@ -968,18 +1208,22 @@ msgstr ""
 "enthalten: -, +, (, ). Sie müssen zwischen 8 und 20 Zeichen lang sein."
 
 #: adhocracy4/projects/models.py:49
+#: adhocracy4/projects/models.py:49
 #: meinberlin/apps/organisations/models.py:33
 msgid "Postal address"
 msgstr "Postadresse"
 
 #: adhocracy4/projects/models.py:58
+#: adhocracy4/projects/models.py:58
 msgid "Contact person"
 msgstr "Kontaktperson"
 
 #: adhocracy4/projects/models.py:78
+#: adhocracy4/projects/models.py:78
 msgid "Can your project be located on the map?"
 msgstr "Kann Ihr Projekt auf der Karte verortet werden?"
 
+#: adhocracy4/projects/models.py:79
 #: adhocracy4/projects/models.py:79
 msgid ""
 "Locate your project. Click inside the marked area or type in an address to "
@@ -991,13 +1235,16 @@ msgstr ""
 "ein. Ein gesetzter Pin kann verschoben werden, wenn Sie ihn gedrückt halten."
 
 #: adhocracy4/projects/models.py:90
+#: adhocracy4/projects/models.py:90
 msgid "Administrative district"
 msgstr "Bezirk"
 
 #: adhocracy4/projects/models.py:174
+#: adhocracy4/projects/models.py:174
 msgid "Title of your project"
 msgstr "Titel Ihres Projekts"
 
+#: adhocracy4/projects/models.py:175
 #: adhocracy4/projects/models.py:175
 msgid ""
 "This title will appear on the teaser card and on top of the project detail "
@@ -1007,9 +1254,11 @@ msgstr ""
 "darf maximal 120 Zeichen lang sein."
 
 #: adhocracy4/projects/models.py:191
+#: adhocracy4/projects/models.py:191
 msgid "Short description of your project"
 msgstr "Kurzbeschreibung Ihres Projekts"
 
+#: adhocracy4/projects/models.py:192
 #: adhocracy4/projects/models.py:192
 msgid ""
 "This short description will appear on the header of the project and in the "
@@ -1019,9 +1268,11 @@ msgstr ""
 "werden. Sie sollte das Ziel des Projekts in maximal 250 Zeichen beschreiben."
 
 #: adhocracy4/projects/models.py:200
+#: adhocracy4/projects/models.py:200
 msgid "Description of your project"
 msgstr "Beschreibung Ihres Projekts"
 
+#: adhocracy4/projects/models.py:201
 #: adhocracy4/projects/models.py:201
 msgid ""
 "This description should tell participants what the goal of the project is, "
@@ -1033,9 +1284,11 @@ msgstr ""
 "Tab der Projektseite angezeigt werden."
 
 #: adhocracy4/projects/models.py:209
+#: adhocracy4/projects/models.py:209
 msgid "Results of your project"
 msgstr "Ergebnisse Ihres Projekts"
 
+#: adhocracy4/projects/models.py:210
 #: adhocracy4/projects/models.py:210
 msgid ""
 "Here you should explain what the expected outcome of the project will be and "
@@ -1047,31 +1300,40 @@ msgstr ""
 "ist, sollten Sie hier eine Zusammenfassung der Resultate hinzufügen."
 
 #: adhocracy4/projects/models.py:218
+#: adhocracy4/projects/models.py:218
 msgid "Access to the project"
 msgstr "Zugang zum Projekt"
 
+#: adhocracy4/projects/models.py:223
+#: adhocracy4/projects/models.py:230
 #: adhocracy4/projects/models.py:223
 #: adhocracy4/projects/models.py:230
 msgid "Header image"
 msgstr "Headerbild"
 
 #: adhocracy4/projects/models.py:225
+#: adhocracy4/projects/models.py:225
 msgid "The image will be shown as a decorative background image."
 msgstr "Das Bild wird als dekoratives Hintergrundbild angezeigt."
 
+#: adhocracy4/projects/models.py:233
+#: adhocracy4/projects/models.py:241
 #: adhocracy4/projects/models.py:233
 #: adhocracy4/projects/models.py:241
 msgid "Tile image"
 msgstr "Kachel-Bild"
 
 #: adhocracy4/projects/models.py:235
+#: adhocracy4/projects/models.py:235
 msgid "The image will be shown in the project tile."
 msgstr "Das Bild wird in der Projekt-Kachel angezeigt."
 
 #: adhocracy4/projects/models.py:254
+#: adhocracy4/projects/models.py:254
 msgid "Project is archived"
 msgstr "Projekt ist archiviert."
 
+#: adhocracy4/projects/models.py:255
 #: adhocracy4/projects/models.py:255
 msgid ""
 "Archived projects are not shown in the project overview. For project "
@@ -1081,9 +1343,11 @@ msgstr ""
 "Projektinitiator*innen sind sie weiterhin im Dashboard einsehbar."
 
 #: adhocracy4/projects/models.py:260
+#: adhocracy4/projects/models.py:260
 msgid "Project topics"
 msgstr "Projektthemen"
 
+#: adhocracy4/projects/models.py:261
 #: adhocracy4/projects/models.py:261
 #: meinberlin/apps/plans/models.py:101
 msgid "Add topics to your project."
@@ -1092,6 +1356,7 @@ msgstr ""
 "Projektübersicht nach diesen Themen gefiltert werden."
 
 #: adhocracy4/projects/templatetags/project_tags.py:12
+#: adhocracy4/projects/templatetags/project_tags.py:12
 #, python-format
 msgid "%(number)d day left"
 msgid_plural "%(number)d days left"
@@ -1099,17 +1364,21 @@ msgstr[0] "noch %(number)d Tag"
 msgstr[1] "noch %(number)d Tage"
 
 #: adhocracy4/projects/templatetags/project_tags.py:19
+#: adhocracy4/projects/templatetags/project_tags.py:19
 msgid "a few hours left"
 msgstr "noch wenige Stunden"
 
+#: adhocracy4/projects/utils.py:45
 #: adhocracy4/projects/utils.py:45
 msgid "{}. Online Participation"
 msgstr "{}. Online-Beteiligung"
 
 #: adhocracy4/projects/utils.py:54
+#: adhocracy4/projects/utils.py:54
 msgid "Online Participation"
 msgstr "Online-Beteiligung"
 
+#: adhocracy4/reports/templatetags/react_reports.py:29
 #: adhocracy4/reports/templatetags/react_reports.py:29
 msgid "Report"
 msgstr "Melden"
@@ -1221,7 +1490,7 @@ msgstr "Informationen Vor-Ort-Beteiligung"
 
 #: meinberlin/apps/activities/models.py:12 meinberlin/apps/ideas/models.py:31
 #: meinberlin/apps/maptopicprio/models.py:29 meinberlin/apps/plans/models.py:40
-#: meinberlin/apps/topicprio/models.py:28
+#: meinberlin/apps/topicprio/models.py:35
 msgid "Title"
 msgstr "Titel"
 
@@ -1569,45 +1838,36 @@ msgstr ""
 #: meinberlin/apps/kiezkasse/dashboard.py:14
 #: meinberlin/apps/mapideas/dashboard.py:14
 #: meinberlin/apps/maptopicprio/dashboard.py:59
-#: meinberlin/apps/polls/dashboard.py:45
+#: meinberlin/apps/polls/dashboard.py:14
 #: meinberlin/apps/topicprio/dashboard.py:54
 msgid "Export Excel"
 msgstr "Excel exportieren"
 
-#: meinberlin/apps/budgeting/exports.py:43
+#: meinberlin/apps/budgeting/exports.py:42
 msgid "Contact E-Mail"
 msgstr "Kontakt E-Mail"
 
-#: meinberlin/apps/budgeting/exports.py:44
+#: meinberlin/apps/budgeting/exports.py:43
 msgid "Contact Phone"
 msgstr "Kontakt Telefon"
+
+#: meinberlin/apps/budgeting/exports.py:79
+#: meinberlin/apps/documents/exports.py:38 meinberlin/apps/ideas/exports.py:70
+#: meinberlin/apps/kiezkasse/exports.py:72
+#: meinberlin/apps/mapideas/exports.py:70
+#: meinberlin/apps/maptopicprio/exports.py:68
+#: meinberlin/apps/polls/exports.py:36 meinberlin/apps/topicprio/exports.py:67
+msgid "ID"
+msgstr "ID"
 
 #: meinberlin/apps/budgeting/exports.py:80
 #: meinberlin/apps/documents/exports.py:39 meinberlin/apps/ideas/exports.py:71
 #: meinberlin/apps/kiezkasse/exports.py:73
 #: meinberlin/apps/mapideas/exports.py:71
 #: meinberlin/apps/maptopicprio/exports.py:69
-#: meinberlin/apps/polls/exports.py:35 meinberlin/apps/topicprio/exports.py:68
-msgid "ID"
-msgstr "ID"
-
-#: meinberlin/apps/budgeting/exports.py:81
-#: meinberlin/apps/documents/exports.py:40 meinberlin/apps/ideas/exports.py:72
-#: meinberlin/apps/kiezkasse/exports.py:74
-#: meinberlin/apps/mapideas/exports.py:72
-#: meinberlin/apps/maptopicprio/exports.py:70
-#: meinberlin/apps/polls/exports.py:36 meinberlin/apps/topicprio/exports.py:69
+#: meinberlin/apps/polls/exports.py:37 meinberlin/apps/topicprio/exports.py:68
 msgid "Comment"
 msgstr "Kommentar"
-
-#: meinberlin/apps/budgeting/exports.py:82
-#: meinberlin/apps/documents/exports.py:41 meinberlin/apps/exports/mixins.py:80
-#: meinberlin/apps/ideas/exports.py:73 meinberlin/apps/kiezkasse/exports.py:75
-#: meinberlin/apps/mapideas/exports.py:73
-#: meinberlin/apps/maptopicprio/exports.py:71
-#: meinberlin/apps/polls/exports.py:37 meinberlin/apps/topicprio/exports.py:70
-msgid "Created"
-msgstr "Erstellt"
 
 #: meinberlin/apps/budgeting/forms.py:25
 msgid ""
@@ -1912,7 +2172,7 @@ msgstr[0] "%(counter)s Projekt anzeigen"
 msgstr[1] "%(counter)s Projekte anzeigen"
 
 #: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:28
-#: meinberlin/apps/plans/exports.py:58 meinberlin/apps/plans/forms.py:43
+#: meinberlin/apps/plans/exports.py:57 meinberlin/apps/plans/forms.py:43
 #: meinberlin/apps/plans/templatetags/react_map_teaser.py:18
 #: meinberlin/apps/plans/views.py:62 meinberlin/apps/projects/admin.py:65
 #: meinberlin/apps/projects/forms.py:100
@@ -2086,14 +2346,6 @@ msgstr "Positive Bewertungen"
 msgid "Negative Ratings"
 msgstr "Negative Bewertungen"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
-#: meinberlin/apps/exports/mixins.py:12
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:77
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
-msgid "Reference No."
-msgstr "Referenznr."
-
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:82
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:91
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:109
@@ -2116,11 +2368,6 @@ msgstr "zurück melden"
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:107
 msgid "report"
 msgstr "melden"
-
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:122
-#: meinberlin/apps/exports/mixins.py:26
-msgid "Official Statement"
-msgstr "Offizielle Rückmeldung"
 
 #: meinberlin/apps/dashboard/blueprints.py:17
 msgid "Brainstorming"
@@ -2309,13 +2556,9 @@ msgstr ""
 "Nur eingeladene Nutzer*innen können Projektkachel und -inhalte sehen und "
 "sich beteiligen (privat)."
 
-#: meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html:4
+#: meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html:7
 msgid "New Module"
 msgstr "Neues Modul"
-
-#: meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html:7
-msgid "Choose Participation Module"
-msgstr "Beteiligungsmodul wählen"
 
 #: meinberlin/apps/dashboard/views.py:52
 msgid "The module was created"
@@ -2443,32 +2686,10 @@ msgstr ""
 msgid "Embed Code"
 msgstr "Code zum Einbetten des Projekts"
 
-#: meinberlin/apps/exports/mixins.py:24
-msgid "Moderator feedback"
-msgstr "Rückmeldung der Moderation"
-
-#: meinberlin/apps/exports/mixins.py:41
-#: meinberlin/apps/moderatorremark/models.py:18
-#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:5
-#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:21
-msgid "Remark"
-msgstr "Notiz"
-
-#: meinberlin/apps/exports/mixins.py:53
-msgid "replies to comment"
-msgstr "Antwort auf Kommentar"
-
-#: meinberlin/apps/exports/mixins.py:65
-msgid "comment on reference"
-msgstr "Kommentar zur Referenz"
-
-#: meinberlin/apps/exports/mixins.py:78
-msgid "Creator"
-msgstr "Urheber"
-
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:5
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:23
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:35
+#: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:47
 msgid "Export"
 msgstr "Exportieren"
 
@@ -2484,6 +2705,10 @@ msgid "here you can export all ideas"
 msgstr "hier können Sie alle Ideen exportieren"
 
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:31
+msgid "here you can export all answers"
+msgstr ""
+
+#: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:43
 msgid "here you can export all comments"
 msgstr "hier können Sie alle Kommentare exportieren"
 
@@ -2543,7 +2768,7 @@ msgstr ""
 "meinBerlin verlinkt."
 
 #: meinberlin/apps/ideas/models.py:35 meinberlin/apps/plans/models.py:87
-#: meinberlin/apps/topicprio/models.py:32
+#: meinberlin/apps/topicprio/models.py:43
 msgid "Add image"
 msgstr "Bild hinzufügen"
 
@@ -2828,7 +3053,7 @@ msgstr ""
 "Datenschutzerklärung{} gelesen habe und akzeptiere."
 
 #: meinberlin/apps/mapideas/forms.py:23
-#: meinberlin/apps/maptopicprio/forms.py:25
+#: meinberlin/apps/maptopicprio/forms.py:28
 msgid "Please locate your proposal on the map."
 msgstr "Bitte verorten Sie Ihren Vorschlag auf der Karte."
 
@@ -2895,11 +3120,11 @@ msgstr "Sie können einen vordefinierten Bereich auswählen."
 msgid "Places"
 msgstr "Orte"
 
-#: meinberlin/apps/maptopicprio/forms.py:33
+#: meinberlin/apps/maptopicprio/forms.py:35
 msgid "Locate the place on a map"
 msgstr "Verortung auf der Karte"
 
-#: meinberlin/apps/maptopicprio/forms.py:34
+#: meinberlin/apps/maptopicprio/forms.py:36
 msgid "Place label"
 msgstr "Ortsbezeichnung"
 
@@ -3205,7 +3430,7 @@ msgstr "Vorhaben"
 msgid "Edit Plan"
 msgstr "Vorhaben bearbeiten"
 
-#: meinberlin/apps/plans/exports.py:51
+#: meinberlin/apps/plans/exports.py:50
 msgid "Project Links"
 msgstr "Projektlinks"
 
@@ -3294,7 +3519,7 @@ msgstr "Status"
 #: meinberlin/apps/plans/models.py:108
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:68
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:51
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:92
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:97
 msgid "Participation"
 msgstr "Beteiligung"
 
@@ -3417,18 +3642,6 @@ msgid "Platform email has been saved and will be sent to the recipients."
 msgstr ""
 "Die Plattform-E-Mail wurde gespeichert und wird an die Empfänger versendet."
 
-#: meinberlin/apps/polls/phases.py:15
-msgid "Please take part in our poll!"
-msgstr "Machen Sie mit bei unserer Umfrage!"
-
-#: meinberlin/apps/polls/phases.py:16
-msgid ""
-"Help us by answering the questions below. There is space for your comments "
-"at the end of the questionnaire."
-msgstr ""
-"Helfen Sie uns, indem Sie die unten stehenden Fragen beantworten. Am Ende "
-"des Fragebogens ist Platz für Ihre Kommentare."
-
 #: meinberlin/apps/projectcontainers/dashboard.py:16
 msgid "Edit container settings"
 msgstr "Projektsammlung bearbeiten"
@@ -3506,8 +3719,9 @@ msgid ""
 "No new project containers can be created. Please use the multimodule "
 "feature. Existing project containers can still be edited."
 msgstr ""
-"Es können keine neuen Projektsammlungen angelegt werden. Bitte nutzen Sie die Multimodul-Funktion."
-" Bestehende Projektsammlungen können weiterhin bearbeitet werden."
+"Es können keine neuen Projektsammlungen angelegt werden. Bitte nutzen Sie "
+"die Multimodul-Funktion. Bestehende Projektsammlungen können weiterhin "
+"bearbeitet werden."
 
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/container_list_dashboard.html:19
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/container_list_dashboard.html:25
@@ -3811,15 +4025,15 @@ msgstr "Dieses Projekt ist noch nicht veröffentlicht."
 msgid "to project collection %(name)s"
 msgstr "zur Projektsammlung %(name)s"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:82
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:87
 msgid "About the Project"
 msgstr "über das Projekt"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:146
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:151
 msgid "Responsible body"
 msgstr "Verantwortliche Stelle"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:221
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:226
 msgid "No results yet."
 msgstr "Noch gibt es keine Ergebnisse."
 
@@ -4070,122 +4284,122 @@ msgstr "Nutzerkonto Einstellungen"
 msgid "Platform Email"
 msgstr "Plattform-Mail"
 
-#: meinberlin/config/settings/base.py:307
-#: meinberlin/config/settings/base.py:317
-#: meinberlin/config/settings/base.py:328
-#: meinberlin/config/settings/base.py:343
+#: meinberlin/config/settings/base.py:309
+#: meinberlin/config/settings/base.py:319
+#: meinberlin/config/settings/base.py:330
+#: meinberlin/config/settings/base.py:345
 msgid "Rich text editor"
 msgstr "Rich Text Editor"
 
-#: meinberlin/config/settings/base.py:487
+#: meinberlin/config/settings/base.py:488
 msgid "Pin without icon"
 msgstr "Pin ohne Icon"
 
-#: meinberlin/config/settings/base.py:488
+#: meinberlin/config/settings/base.py:489
 msgid "Diamond"
 msgstr "Diamant"
 
-#: meinberlin/config/settings/base.py:489
+#: meinberlin/config/settings/base.py:490
 msgid "Triangle up"
 msgstr "Dreieck Spitze oben"
 
-#: meinberlin/config/settings/base.py:490
+#: meinberlin/config/settings/base.py:491
 msgid "Triangle down"
 msgstr "Dreieck Spitze unten"
 
-#: meinberlin/config/settings/base.py:491
+#: meinberlin/config/settings/base.py:492
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: meinberlin/config/settings/base.py:492
+#: meinberlin/config/settings/base.py:493
 msgid "Semi circle"
 msgstr "Halbkreis"
 
-#: meinberlin/config/settings/base.py:493
+#: meinberlin/config/settings/base.py:494
 msgid "Hexagon"
 msgstr "Sechseck"
 
-#: meinberlin/config/settings/base.py:494
+#: meinberlin/config/settings/base.py:495
 msgid "Rhomboid"
 msgstr "Parallelogramm"
 
-#: meinberlin/config/settings/base.py:495
+#: meinberlin/config/settings/base.py:496
 msgid "Star"
 msgstr "Stern"
 
-#: meinberlin/config/settings/base.py:496
+#: meinberlin/config/settings/base.py:497
 msgid "Square"
 msgstr "Quadrat"
 
-#: meinberlin/config/settings/base.py:497
+#: meinberlin/config/settings/base.py:498
 msgid "Octothorpe"
 msgstr "Raute"
 
-#: meinberlin/config/settings/base.py:498
+#: meinberlin/config/settings/base.py:499
 msgid "Rectangle"
 msgstr "Viereck"
 
-#: meinberlin/config/settings/base.py:499
+#: meinberlin/config/settings/base.py:500
 msgid "Circle"
 msgstr "Kreis"
 
-#: meinberlin/config/settings/base.py:500
+#: meinberlin/config/settings/base.py:501
 msgid "Right triangle"
 msgstr "Dreieck Spitze rechts"
 
-#: meinberlin/config/settings/base.py:501
+#: meinberlin/config/settings/base.py:502
 msgid "Zigzag"
 msgstr "ZickZack"
 
-#: meinberlin/config/settings/base.py:510
+#: meinberlin/config/settings/base.py:511
 msgid "Anti-discrimination"
 msgstr "Antidiskriminierung"
 
-#: meinberlin/config/settings/base.py:511
+#: meinberlin/config/settings/base.py:512
 msgid "Work & economy"
 msgstr "Arbeit & Wirtschaft"
 
-#: meinberlin/config/settings/base.py:512
+#: meinberlin/config/settings/base.py:513
 msgid "Building & living"
 msgstr "Bauen & Wohnen"
 
-#: meinberlin/config/settings/base.py:513
+#: meinberlin/config/settings/base.py:514
 msgid "Education & research"
 msgstr "Bildung & Forschung"
 
-#: meinberlin/config/settings/base.py:514
+#: meinberlin/config/settings/base.py:515
 msgid "Children, youth & family"
 msgstr "Kinder, Jugend & Familie"
 
-#: meinberlin/config/settings/base.py:515
+#: meinberlin/config/settings/base.py:516
 msgid "Finances"
 msgstr "Finanzen"
 
-#: meinberlin/config/settings/base.py:516
+#: meinberlin/config/settings/base.py:517
 msgid "Health & sports"
 msgstr "Gesundheit & Sport"
 
-#: meinberlin/config/settings/base.py:517
+#: meinberlin/config/settings/base.py:518
 msgid "Integration"
 msgstr "Integration"
 
-#: meinberlin/config/settings/base.py:518
+#: meinberlin/config/settings/base.py:519
 msgid "Culture & leisure"
 msgstr "Kultur & Freizeit"
 
-#: meinberlin/config/settings/base.py:519
+#: meinberlin/config/settings/base.py:520
 msgid "Neighborhood & participation"
 msgstr "Nachbarschaft & Teilhabe"
 
-#: meinberlin/config/settings/base.py:520
+#: meinberlin/config/settings/base.py:521
 msgid "Urban development"
 msgstr "Stadtentwicklung"
 
-#: meinberlin/config/settings/base.py:521
+#: meinberlin/config/settings/base.py:522
 msgid "Environment & public green space"
 msgstr "Umwelt & Grünflächen"
 
-#: meinberlin/config/settings/base.py:522
+#: meinberlin/config/settings/base.py:523
 msgid "Traffic"
 msgstr "Verkehr"
 
@@ -4243,13 +4457,23 @@ msgid_plural "Participation Modules"
 msgstr[0] "Beteiligungsmodul"
 msgstr[1] "Beteiligungsmodule"
 
-#: meinberlin/templates/a4dashboard/includes/nav_modules.html:7
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:14
 msgid "Create Module"
 msgstr "Modul anlegen"
 
-#: meinberlin/templates/a4dashboard/includes/nav_modules.html:13
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:21
 msgid "You have not set up a participation module yet."
 msgstr "Sie haben noch kein Beteiligungsmodul angelegt."
+
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:29
+msgid "Choose Participation Module"
+msgstr "Beteiligungsmodul wählen"
+
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:30
+#: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:67
+#: meinberlin/templates/a4dashboard/includes/progress.html:30
+msgid "Close"
+msgstr "Schließen"
 
 #: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:6
 #: meinberlin/templates/a4dashboard/includes/nav_project.html:6
@@ -4286,11 +4510,6 @@ msgstr "Modul löschen"
 #: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:66
 msgid "Are you sure you want to delete your module?"
 msgstr "Wollen Sie das Beteiligungsmodul wirklich löschen?"
-
-#: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:67
-#: meinberlin/templates/a4dashboard/includes/progress.html:30
-msgid "Close"
-msgstr "Schließen"
 
 #: meinberlin/templates/a4dashboard/includes/nav_project.html:13
 msgid "Project ready for publication"
@@ -4665,27 +4884,27 @@ msgstr "Guten Tag"
 msgid "meinBerlin is a participation platform operated by"
 msgstr "meinBerlin ist die Plattform für Beteiligung, betrieben durch"
 
-#: meinberlin/templates/header.html:7
+#: meinberlin/templates/header.html:13
 msgid "Menu"
 msgstr "Menü"
 
-#: meinberlin/templates/header.html:13
+#: meinberlin/templates/header.html:19
 msgid "Home"
 msgstr "Home"
 
-#: meinberlin/templates/header.html:17
+#: meinberlin/templates/header.html:23
 msgid "Project overview"
 msgstr "Projektübersicht"
 
-#: meinberlin/templates/header.html:34
+#: meinberlin/templates/header.html:46
 msgid "User Menu"
 msgstr "Nutzer*innen-Menu"
 
-#: meinberlin/templates/header.html:44
+#: meinberlin/templates/header.html:56
 msgid "Help"
 msgstr "Hilfe"
 
-#: meinberlin/templates/header.html:49
+#: meinberlin/templates/header.html:61
 msgid "Give Feedback"
 msgstr "Feedback geben"
 
@@ -4739,6 +4958,28 @@ msgid ""
 msgstr ""
 "Sie sind dabei sich mit Ihrem %(provider_name)s-Konto auf %(site_name)s "
 "anzumelden. Füllen Sie bitte das folgende Formular als letzten Schritt aus:"
+
+#~ msgid "Voting phase"
+#~ msgstr "Abstimmungsphase"
+
+#~ msgid "Cast votes and discuss the poll."
+#~ msgstr "Abgeben von Stimmen und kommentieren der Umfrage."
+
+#~ msgid "replies to comment"
+#~ msgstr "Antwort auf Kommentar"
+
+#~ msgid "comment on reference"
+#~ msgstr "Kommentar zur Referenz"
+
+#~ msgid "Please take part in our poll!"
+#~ msgstr "Machen Sie mit bei unserer Umfrage!"
+
+#~ msgid ""
+#~ "Help us by answering the questions below. There is space for your "
+#~ "comments at the end of the questionnaire."
+#~ msgstr ""
+#~ "Helfen Sie uns, indem Sie die unten stehenden Fragen beantworten. Am Ende "
+#~ "des Fragebogens ist Platz für Ihre Kommentare."
 
 #~ msgid "replies to"
 #~ msgstr "Antwort auf"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-27 15:55+0200\n"
+"POT-Creation-Date: 2021-07-05 17:25+0200\n"
 "PO-Revision-Date: 2017-05-30 12:06+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,9 +55,7 @@ msgstr[0] "Antwort einblenden"
 msgstr[1] "%s Antworten einblenden"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:30
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:9
 #: adhocracy4/comments/static/comments/Comment.jsx:30
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:9
 msgid "Answer"
 msgstr "Antworten"
 
@@ -108,18 +106,26 @@ msgstr "Möchten Sie diesen Kommentar wirklich löschen?"
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:238
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:14
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:66
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:71
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:146
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:151
 #: adhocracy4/comments/static/comments/Comment.jsx:148
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:238
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:14
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:66
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:71
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:146
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:151
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:56
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:61
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:133
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:138
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:100
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:105
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:71
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:76
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:151
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:156
 msgid "Delete"
 msgstr "Löschen"
 
@@ -132,6 +138,7 @@ msgstr "Löschen"
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:239
 #: adhocracy4/comments_async/static/modals/modal.jsx:58
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
+#: adhocracy4/static/Modal.jsx:59
 msgid "Abort"
 msgstr "Abbrechen"
 
@@ -453,144 +460,153 @@ msgstr "Folgen"
 msgid "Following"
 msgstr "Folge ich"
 
-#: adhocracy4/polls/static/polls/ChoiceForm.jsx:6
-#: adhocracy4/polls/static/polls/ChoiceForm.jsx:6
-#: meinberlin/apps/polls/assets/ChoiceForm.jsx:23
-#: meinberlin/apps/polls/assets/ChoiceForm.jsx:28
+#: adhocracy4/polls/assets/EditPollChoice.jsx:24
+#: adhocracy4/polls/assets/EditPollChoice.jsx:30
+#: adhocracy4/polls/assets/EditPollChoice.jsx:24
+#: adhocracy4/polls/assets/EditPollChoice.jsx:30
+#: meinberlin/apps/polls/assets/ChoiceForm.jsx:24
+#: meinberlin/apps/polls/assets/ChoiceForm.jsx:30
 msgid "remove"
 msgstr "entfernen"
 
-#: adhocracy4/polls/static/polls/PollManagement.jsx:179
-#: adhocracy4/polls/static/polls/PollManagement.jsx:179
-#: meinberlin/apps/polls/assets/PollManagement.jsx:188
-msgid "The poll has been updated."
-msgstr "Die Umfrage wurde aktualisiert."
-
-#: adhocracy4/polls/static/polls/PollManagement.jsx:180
-#: adhocracy4/polls/static/polls/PollManagement.jsx:180
-#: meinberlin/apps/polls/assets/PollManagement.jsx:205
-msgid "The poll could not be updated."
-msgstr "Die Umfrage konnte nicht aktualisiert werden."
-
-#: adhocracy4/polls/static/polls/PollManagement.jsx:216
-#: adhocracy4/polls/static/polls/PollManagement.jsx:216
-#: meinberlin/apps/polls/assets/PollManagement.jsx:247
-msgid "Add a new question"
-msgstr "Neue Frage"
-
-#: adhocracy4/polls/static/polls/PollManagement.jsx:217
-#: adhocracy4/polls/static/polls/PollManagement.jsx:217
-#: meinberlin/apps/documents/assets/DocumentManagement.jsx:324
-#: meinberlin/apps/polls/assets/PollManagement.jsx:253
-msgid "Save"
-msgstr "Speichern"
-
-#: adhocracy4/polls/static/polls/Question.jsx:9
-#: adhocracy4/polls/static/polls/Question.jsx:9
-#: meinberlin/apps/polls/assets/Question.jsx:204
-msgid "Your choice"
-msgstr "Ihre Wahl"
-
-#: adhocracy4/polls/static/polls/Question.jsx:10
-#: adhocracy4/polls/static/polls/Question.jsx:10
-msgid "Multiple answers are possible for this question"
-msgstr "Für diese Frage sind mehrere Antworten möglich"
-
-#: adhocracy4/polls/static/polls/Question.jsx:36
-#: adhocracy4/polls/static/polls/Question.jsx:36
-#: meinberlin/apps/polls/assets/Question.jsx:52
-msgid "Vote counted"
-msgstr "Ihre Stimme wurde gezählt."
-
-#: adhocracy4/polls/static/polls/Question.jsx:37
-#: adhocracy4/polls/static/polls/Question.jsx:37
-#: meinberlin/apps/polls/assets/Question.jsx:62
-msgid "Vote has not been counted due to a server error."
-msgstr "Ihre Stimme konnte aufgrund eines Serverfehlers nicht gezählt werden."
-
-#: adhocracy4/polls/static/polls/Question.jsx:104
-#: adhocracy4/polls/static/polls/Question.jsx:104
-#: meinberlin/apps/polls/assets/Question.jsx:110
-msgid "Vote"
-msgstr "Stimme abgeben"
-
-#: adhocracy4/polls/static/polls/Question.jsx:105
-#: adhocracy4/polls/static/polls/Question.jsx:105
-#: meinberlin/apps/polls/assets/Question.jsx:116
-msgid "Please login to vote"
-msgstr "Bitte melden Sie sich zum Abstimmen an."
-
-#: adhocracy4/polls/static/polls/Question.jsx:140
-#: adhocracy4/polls/static/polls/Question.jsx:140
-#: meinberlin/apps/polls/assets/Question.jsx:171
-msgid "To poll"
-msgstr "Zur Umfrage"
-
-#: adhocracy4/polls/static/polls/Question.jsx:142
-#: adhocracy4/polls/static/polls/Question.jsx:142
-#: meinberlin/apps/polls/assets/Question.jsx:174
-msgid "Change vote"
-msgstr "Stimme ändern"
-
-#: adhocracy4/polls/static/polls/Question.jsx:145
-#: adhocracy4/polls/static/polls/Question.jsx:145
-#: meinberlin/apps/polls/assets/Question.jsx:178
-msgid "Show preliminary results"
-msgstr "Vorläufiges Ergebnis zeigen"
-
-#: adhocracy4/polls/static/polls/Question.jsx:157
-#: adhocracy4/polls/static/polls/Question.jsx:157
-msgid "vote"
-msgid_plural "votes"
-msgstr[0] "Stimme"
-msgstr[1] "Stimmen"
-
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:8
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:8
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:16
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:19
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:16
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:19
 #: meinberlin/apps/livequestions/assets/QuestionForm.jsx:69
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:15
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:16
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:19
 msgid "Question"
 msgstr "Frage"
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:10
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:10
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:36
-msgid "Users can select more than one answer."
-msgstr "Nutzer*innen können für mehrere Antworten abstimmen."
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:34
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:113
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:34
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:113
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:39
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:118
+msgid "Add Helptext"
+msgstr ""
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:11
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:11
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:68
-msgid "Add a new choice"
-msgstr "Neue Antwort"
-
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:12
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:12
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:43
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:48
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:123
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:128
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:43
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:48
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:123
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:128
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:32
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:37
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:110
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:115
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:77
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:82
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:48
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:53
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:128
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:133
 msgid "Move up"
 msgstr "nach oben"
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:13
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:13
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:55
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:60
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:135
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:140
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:55
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:60
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:135
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:140
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:44
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:49
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:122
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:127
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:89
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:94
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:60
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:65
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:140
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:145
 msgid "Move down"
 msgstr "nach unten"
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:54
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:54
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:44
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:44
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:44
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:49
+msgid "Users can select more than one answer."
+msgstr "Nutzer*innen können für mehrere Antworten abstimmen."
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:59
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:59
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:64
+msgid "Users can answer openly."
+msgstr ""
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:67
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:67
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:72
 msgid "Choice"
 msgstr "Auswahl"
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:89
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:90
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:89
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:90
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:94
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:95
+msgid "Other"
+msgstr ""
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:106
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:106
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:111
+msgid "Add a new choice"
+msgstr "Neue Antwort"
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:162
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:162
+#: meinberlin/apps/polls/assets/PollManagement.jsx:161
+msgid "The poll has been updated."
+msgstr "Die Umfrage wurde aktualisiert."
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:176
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:176
+#: meinberlin/apps/polls/assets/PollManagement.jsx:175
+msgid "The poll could not be updated."
+msgstr "Die Umfrage konnte nicht aktualisiert werden."
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:195
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:195
+#: meinberlin/apps/polls/assets/PollManagement.jsx:194
+msgid "Add a new question"
+msgstr "Neue Frage"
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:201
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:201
+#: meinberlin/apps/polls/assets/PollManagement.jsx:200
+msgid "predefined answers"
+msgstr ""
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:206
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:206
+#: meinberlin/apps/polls/assets/PollManagement.jsx:205
+msgid "open answers"
+msgstr ""
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:278
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:278
+#: meinberlin/apps/documents/assets/DocumentManagement.jsx:324
+#: meinberlin/apps/polls/assets/PollManagement.jsx:277
+msgid "Save"
+msgstr "Speichern"
+
+#: adhocracy4/polls/assets/HelptextForm.jsx:11
+#: adhocracy4/polls/assets/HelptextForm.jsx:11
+#: meinberlin/apps/polls/assets/HelptextForm.jsx:11
+msgid "Helptext"
+msgstr ""
+
+#: adhocracy4/polls/assets/PollQuestion.jsx:5
+#: adhocracy4/polls/assets/PollQuestion.jsx:5
+#: meinberlin/apps/polls/assets/Question.jsx:132
+msgid "Multiple answers are possible."
+msgstr "Mehrfachantworten sind möglich."
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
@@ -598,9 +614,9 @@ msgid "Thank you! We are taking care of it."
 msgstr "Vielen Dank! Wir werden uns darum kümmern."
 
 #: adhocracy4/static/Alert.jsx:5
+#: adhocracy4/static/Alert.jsx:5
 #: meinberlin/apps/contrib/assets/Alert.jsx:10
 #: meinberlin/apps/contrib/assets/Alert.jsx:11
-#: meinberlin/apps/dashboard/assets/ajax_modal.js:12
 #: meinberlin/apps/embed/assets/embed.js:59
 #: meinberlin/apps/embed/assets/embed.js:60
 #: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:85
@@ -1004,31 +1020,31 @@ msgstr "laufend"
 msgid "done"
 msgstr "abgeschlossen"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:139
+#: meinberlin/apps/plans/assets/PlansList.jsx:86
 #: meinberlin/apps/plans/assets/PopUp.jsx:20
 msgid "More than 1 year remaining"
 msgstr "noch länger als 1 Jahr"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:143
+#: meinberlin/apps/plans/assets/PlansList.jsx:90
 #: meinberlin/apps/plans/assets/PopUp.jsx:24
 msgid "remaining"
 msgstr "noch"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:245
+#: meinberlin/apps/plans/assets/PlansList.jsx:192
 #: meinberlin/apps/plans/assets/PopUp.jsx:68
 msgid "Participation ended. Read result."
 msgstr "Beteiligung beendet. Ergebnis lesen."
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:263
+#: meinberlin/apps/plans/assets/PlansList.jsx:210
 #: meinberlin/apps/plans/assets/PopUp.jsx:88
 msgid "Participation projects: "
 msgstr "Beteiligungsprojekte: "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:272
+#: meinberlin/apps/plans/assets/PlansList.jsx:219
 msgid "Status: "
 msgstr "Status: "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:298
+#: meinberlin/apps/plans/assets/PlansList.jsx:250
 #: meinberlin/apps/plans/assets/PlansMap.jsx:293
 msgid "Nothing to show"
 msgstr "Keine Ergebnisse"
@@ -1095,9 +1111,21 @@ msgstr "Karte anzeigen"
 msgid "Map"
 msgstr "Karte"
 
-#: meinberlin/apps/polls/assets/Question.jsx:132
-msgid "Multiple answers are possible."
-msgstr "Mehrfachantworten sind möglich."
+#: meinberlin/apps/polls/assets/Question.jsx:52
+msgid "Vote counted"
+msgstr "Ihre Stimme wurde gezählt."
+
+#: meinberlin/apps/polls/assets/Question.jsx:62
+msgid "Vote has not been counted due to a server error."
+msgstr "Ihre Stimme konnte aufgrund eines Serverfehlers nicht gezählt werden."
+
+#: meinberlin/apps/polls/assets/Question.jsx:110
+msgid "Vote"
+msgstr "Stimme abgeben"
+
+#: meinberlin/apps/polls/assets/Question.jsx:116
+msgid "Please login to vote"
+msgstr "Bitte melden Sie sich zum Abstimmen an."
 
 #: meinberlin/apps/polls/assets/Question.jsx:148
 #, javascript-format
@@ -1125,6 +1153,22 @@ msgid "1 person has answered."
 msgid_plural "%s people have answered."
 msgstr[0] "1 Teilnehmer*in hat geantwortet."
 msgstr[1] "%s Teilnehmer*innen haben geantwortet."
+
+#: meinberlin/apps/polls/assets/Question.jsx:171
+msgid "To poll"
+msgstr "Zur Umfrage"
+
+#: meinberlin/apps/polls/assets/Question.jsx:174
+msgid "Change vote"
+msgstr "Stimme ändern"
+
+#: meinberlin/apps/polls/assets/Question.jsx:178
+msgid "Show preliminary results"
+msgstr "Vorläufiges Ergebnis zeigen"
+
+#: meinberlin/apps/polls/assets/Question.jsx:204
+msgid "Your choice"
+msgstr "Ihre Wahl"
 
 #: meinberlin/assets/js/unload_warning.js:16
 msgid "If you leave this page changes you made will not be saved."
@@ -1186,6 +1230,14 @@ msgid "More information can be found in the privacy policy of Vimeo under: "
 msgstr ""
 "Weitere Informationen finden Sie in der Datenschutzerklärung von Vimeo "
 "unter: "
+
+#~ msgid "Multiple answers are possible for this question"
+#~ msgstr "Für diese Frage sind mehrere Antworten möglich"
+
+#~ msgid "vote"
+#~ msgid_plural "votes"
+#~ msgstr[0] "Stimme"
+#~ msgstr[1] "Stimmen"
 
 #~ msgid "Show List"
 #~ msgstr "Liste anzeigen"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-27 15:55+0200\n"
+"POT-Creation-Date: 2021-07-05 17:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: adhocracy4/categories/dashboard.py:13
+msgid "Categories"
+msgstr "Categories"
+
+#: adhocracy4/categories/dashboard.py:15
+msgid "Edit categories"
+msgstr "Edit categories"
+
+#: adhocracy4/categories/fields.py:12 adhocracy4/categories/filters.py:16
+#: adhocracy4/categories/forms.py:45 adhocracy4/exports/mixins/items.py:14
+msgid "Category"
+msgstr "Category"
+
+#: adhocracy4/categories/forms.py:38 adhocracy4/labels/forms.py:14
+msgid "Category name"
+msgstr "Category name"
+
+#: adhocracy4/categories/forms.py:39
+msgid "Category icon"
+msgstr "Category icon"
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
 #: meinberlin/templates/a4categories/includes/module_categories_form.html:3
@@ -33,6 +54,228 @@ msgstr ""
 #: meinberlin/templates/a4categories/includes/module_categories_form.html:21
 msgid "Add category"
 msgstr "Add category"
+
+#: adhocracy4/comments/models.py:53
+msgctxt "noun"
+msgid "Comment"
+msgstr "Comment"
+
+#: adhocracy4/comments/models.py:54 adhocracy4/exports/mixins/comments.py:46
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:16
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:17
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:18
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:19
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:18
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:20
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:18
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:20
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:18
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:20
+msgid "Comments"
+msgstr "Comments"
+
+#: adhocracy4/comments/models.py:74
+#: adhocracy4/comments_async/serializers.py:151
+msgid "deleted by creator"
+msgstr "deleted by creator"
+
+#: adhocracy4/comments/models.py:77
+#: adhocracy4/comments_async/serializers.py:153
+msgid "deleted by moderator"
+msgstr "deleted by moderator"
+
+#: adhocracy4/comments/serializers.py:52 adhocracy4/comments/serializers.py:151
+msgid "Please choose a category"
+msgstr "Please choose a category"
+
+#: adhocracy4/comments/serializers.py:61
+#: adhocracy4/comments_async/serializers.py:79
+msgid "unknown user"
+msgstr "unknown user"
+
+#: adhocracy4/comments_async/serializers.py:58
+msgid "Please choose one or more categories."
+msgstr "Please choose one or more categories."
+
+#: adhocracy4/dashboard/components/forms/views.py:22
+msgid "The project has been updated."
+msgstr "The project has been updated."
+
+#: adhocracy4/dashboard/components/forms/views.py:47
+msgid "The module has been updated."
+msgstr "The module has been updated."
+
+#: adhocracy4/dashboard/dashboard.py:13
+#: meinberlin/apps/projectcontainers/dashboard.py:14
+msgid "Basic settings"
+msgstr "Basic settings"
+
+#: adhocracy4/dashboard/dashboard.py:15 meinberlin/apps/bplan/dashboard.py:16
+#: meinberlin/apps/extprojects/dashboard.py:16
+msgid "Edit basic settings"
+msgstr "Edit basic settings"
+
+#: adhocracy4/dashboard/dashboard.py:23
+#: meinberlin/apps/projectcontainers/dashboard.py:46
+#: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:41
+msgid "Information"
+msgstr "Information"
+
+#: adhocracy4/dashboard/dashboard.py:25
+#: meinberlin/apps/projectcontainers/dashboard.py:48
+msgid "Edit project information"
+msgstr "Edit project information"
+
+#: adhocracy4/dashboard/dashboard.py:33
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:107
+msgid "Result"
+msgstr "Result"
+
+#: adhocracy4/dashboard/dashboard.py:35
+msgid "Edit project result"
+msgstr "Edit project result"
+
+#: adhocracy4/dashboard/dashboard.py:43
+msgid "Basic information"
+msgstr "Basic information"
+
+#: adhocracy4/dashboard/dashboard.py:45
+msgid "Edit basic module information"
+msgstr "Edit basic module information"
+
+#: adhocracy4/dashboard/dashboard.py:53
+msgid "Phases"
+msgstr "Phases"
+
+#: adhocracy4/dashboard/dashboard.py:55
+msgid "Edit phases information"
+msgstr "Edit phases information"
+
+#: adhocracy4/dashboard/dashboard.py:64
+msgid "Areasettings"
+msgstr "Areasettings"
+
+#: adhocracy4/dashboard/dashboard.py:65
+msgid "Edit areasettings"
+msgstr "Edit areasettings"
+
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: meinberlin/apps/ideas/views.py:29 meinberlin/apps/projects/views.py:53
+#: meinberlin/apps/topicprio/views.py:21
+#: meinberlin/templates/a4filters/widgets/free_text_filter.html:4
+#: meinberlin/templates/a4filters/widgets/free_text_filter.html:10
+#: meinberlin/templates/a4filters/widgets/free_text_filter.html:11
+#: meinberlin/templates/a4maps/map_choose_point_widget.html:6
+#: meinberlin/templates/a4maps/map_choose_point_widget.html:7
+msgid "Search"
+msgstr "Search"
+
+#: adhocracy4/dashboard/filter.py:15 meinberlin/apps/projects/views.py:57
+msgid "Archived"
+msgstr "Archived"
+
+#: adhocracy4/dashboard/filter.py:19 adhocracy4/filters/widgets.py:32
+#: meinberlin/apps/projects/views.py:61
+msgid "All"
+msgstr "All"
+
+#: adhocracy4/dashboard/filter.py:20 meinberlin/apps/projects/views.py:62
+msgid "No"
+msgstr "No"
+
+#: adhocracy4/dashboard/filter.py:21
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_confirm_delete.html:13
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html:13
+#: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_confirm_delete.html:13
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_confirm_delete.html:13
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_confirm_delete.html:12
+#: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_confirm_delete.html:12
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_confirm_delete.html:11
+#: meinberlin/apps/projects/serializers.py:156
+#: meinberlin/apps/projects/views.py:63
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_confirm_delete.html:12
+msgid "Yes"
+msgstr "Yes"
+
+#: adhocracy4/dashboard/forms.py:76
+msgid "All users can participate (public)."
+msgstr "All users can participate (public)."
+
+#: adhocracy4/dashboard/forms.py:78
+msgid "Only invited users can participate (private)."
+msgstr "Only invited users can participate (private)."
+
+#: adhocracy4/dashboard/forms.py:86
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:126
+msgid "Contact for questions"
+msgstr "Contact for questions"
+
+#: adhocracy4/dashboard/forms.py:87
+msgid ""
+"Please name a contact person. The user will then know who is carrying out "
+"this project and to whom they can address possible questions. The contact "
+"person will be shown in the information tab on the project page."
+msgstr ""
+"Please name a contact person. The user will then know who is carrying out "
+"this project and to whom they can address possible questions. The contact "
+"person will be shown in the information tab on the project page."
+
+#: adhocracy4/dashboard/forms.py:92
+msgid "More contact possibilities"
+msgstr "More contact possibilities"
+
+#: adhocracy4/dashboard/forms.py:105 adhocracy4/phases/models.py:69
+#: meinberlin/apps/newsletters/models.py:30
+#: meinberlin/apps/platformemails/models.py:16
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_user_list.html:7
+msgid "Name"
+msgstr "Name"
+
+#: adhocracy4/dashboard/forms.py:107
+msgid "Address"
+msgstr "Address"
+
+#: adhocracy4/dashboard/forms.py:110
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:134
+msgid "Telephone"
+msgstr "Telephone"
+
+#: adhocracy4/dashboard/forms.py:112
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
+msgid "Email"
+msgstr "Email"
+
+#: adhocracy4/dashboard/forms.py:114
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:143
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:158
+msgid "Website"
+msgstr "Website"
+
+#: adhocracy4/dashboard/forms.py:144 adhocracy4/phases/models.py:77
+#: meinberlin/apps/extprojects/forms.py:29
+#: meinberlin/apps/extprojects/models.py:19
+msgid "End date"
+msgstr "End date"
+
+#: adhocracy4/dashboard/forms.py:144 meinberlin/apps/extprojects/forms.py:29
+msgid "End time"
+msgstr "End time"
+
+#: adhocracy4/dashboard/forms.py:150 adhocracy4/phases/models.py:75
+#: meinberlin/apps/extprojects/forms.py:23
+#: meinberlin/apps/extprojects/models.py:17
+msgid "Start date"
+msgstr "Start date"
+
+#: adhocracy4/dashboard/forms.py:150 meinberlin/apps/extprojects/forms.py:23
+msgid "Start time"
+msgstr "Start time"
+
+#: adhocracy4/dashboard/mixins.py:207
+msgid "Project successfully duplicated."
+msgstr "Project successfully duplicated."
 
 #: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
 #: meinberlin/templates/a4dashboard/base_dashboard.html:43
@@ -188,7 +431,7 @@ msgstr "Cancel"
 
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
 #: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
-#: meinberlin/apps/plans/exports.py:50
+#: meinberlin/apps/plans/exports.py:49
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_list.html:4
 #: meinberlin/apps/projectcontainers/dashboard.py:60
 #: meinberlin/apps/projectcontainers/models.py:14
@@ -219,7 +462,7 @@ msgstr "private"
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:43
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:126
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:28
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:69
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:73
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_dashboard_list_item.html:19
 #: meinberlin/templates/a4dashboard/includes/project_list_item.html:44
 msgid "Edit"
@@ -235,323 +478,6 @@ msgstr "Duplicate"
 #: meinberlin/templates/a4dashboard/project_list.html:24
 msgid "We could not find any projects."
 msgstr "We could not find any projects."
-
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: adhocracy4/dashboard/filter.py:11 meinberlin/apps/ideas/views.py:29
-#: meinberlin/apps/projects/views.py:53 meinberlin/apps/topicprio/views.py:21
-#: meinberlin/templates/a4filters/widgets/free_text_filter.html:4
-#: meinberlin/templates/a4filters/widgets/free_text_filter.html:10
-#: meinberlin/templates/a4filters/widgets/free_text_filter.html:11
-#: meinberlin/templates/a4maps/map_choose_point_widget.html:6
-#: meinberlin/templates/a4maps/map_choose_point_widget.html:7
-msgid "Search"
-msgstr "Search"
-
-#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html:5
-#: meinberlin/templates/a4forms/includes/form_field.html:5
-msgid "This field is required"
-msgstr "This field is required"
-
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
-msgid "Remove category"
-msgstr "Remove category"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
-#: meinberlin/templates/a4images/image_upload_widget.html:9
-#: meinberlin/templates/a4images/image_upload_widget.html:10
-msgid "Remove the picture"
-msgstr "Remove the picture"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
-#: meinberlin/templates/a4images/image_upload_widget.html:15
-#: meinberlin/templates/a4images/image_upload_widget.html:16
-msgid "Upload a picture"
-msgstr "Upload a picture"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
-msgid ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
-msgstr ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-#: meinberlin/templates/a4labels/includes/module_labels_form.html:3
-msgid ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-msgstr ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-#: meinberlin/templates/a4labels/includes/module_labels_form.html:21
-msgid "Add label"
-msgstr "Add label"
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-#: meinberlin/apps/polls/templates/meinberlin_polls/poll_404.html:8
-#: meinberlin/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-#: meinberlin/apps/polls/templates/meinberlin_polls/poll_404.html:15
-#: meinberlin/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr "Setup the poll by adding questions and answers in the dashboard."
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-#: meinberlin/apps/polls/templates/meinberlin_polls/poll_dashboard.html:5
-#: meinberlin/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
-msgstr "Edit poll"
-
-#: adhocracy4/categories/dashboard.py:13
-msgid "Categories"
-msgstr "Categories"
-
-#: adhocracy4/categories/dashboard.py:15
-msgid "Edit categories"
-msgstr "Edit categories"
-
-#: adhocracy4/categories/fields.py:12 adhocracy4/categories/filters.py:16
-#: adhocracy4/categories/forms.py:45 adhocracy4/exports/mixins.py:151
-msgid "Category"
-msgstr "Category"
-
-#: adhocracy4/categories/forms.py:38 adhocracy4/labels/forms.py:14
-msgid "Category name"
-msgstr "Category name"
-
-#: adhocracy4/categories/forms.py:39
-msgid "Category icon"
-msgstr "Category icon"
-
-#: adhocracy4/comments/models.py:53
-msgctxt "noun"
-msgid "Comment"
-msgstr "Comment"
-
-#: adhocracy4/comments/models.py:54 adhocracy4/exports/mixins.py:123
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:16
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:17
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:18
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:19
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:18
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:20
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:18
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_list_item.html:20
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:18
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html:20
-msgid "Comments"
-msgstr "Comments"
-
-#: adhocracy4/comments/models.py:74
-#: adhocracy4/comments_async/serializers.py:151
-msgid "deleted by creator"
-msgstr "deleted by creator"
-
-#: adhocracy4/comments/models.py:77
-#: adhocracy4/comments_async/serializers.py:153
-msgid "deleted by moderator"
-msgstr "deleted by moderator"
-
-#: adhocracy4/comments/serializers.py:52 adhocracy4/comments/serializers.py:151
-msgid "Please choose a category"
-msgstr "Please choose a category"
-
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
-msgid "unknown user"
-msgstr "unknown user"
-
-#: adhocracy4/comments_async/serializers.py:58
-msgid "Please choose one or more categories."
-msgstr "Please choose one or more categories."
-
-#: adhocracy4/dashboard/components/forms/views.py:22
-msgid "The project has been updated."
-msgstr "The project has been updated."
-
-#: adhocracy4/dashboard/components/forms/views.py:47
-msgid "The module has been updated."
-msgstr "The module has been updated."
-
-#: adhocracy4/dashboard/dashboard.py:13
-#: meinberlin/apps/projectcontainers/dashboard.py:14
-msgid "Basic settings"
-msgstr "Basic settings"
-
-#: adhocracy4/dashboard/dashboard.py:15 meinberlin/apps/bplan/dashboard.py:16
-#: meinberlin/apps/extprojects/dashboard.py:16
-msgid "Edit basic settings"
-msgstr "Edit basic settings"
-
-#: adhocracy4/dashboard/dashboard.py:23
-#: meinberlin/apps/projectcontainers/dashboard.py:46
-#: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:41
-msgid "Information"
-msgstr "Information"
-
-#: adhocracy4/dashboard/dashboard.py:25
-#: meinberlin/apps/projectcontainers/dashboard.py:48
-msgid "Edit project information"
-msgstr "Edit project information"
-
-#: adhocracy4/dashboard/dashboard.py:33
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:102
-msgid "Result"
-msgstr "Result"
-
-#: adhocracy4/dashboard/dashboard.py:35
-msgid "Edit project result"
-msgstr "Edit project result"
-
-#: adhocracy4/dashboard/dashboard.py:43
-msgid "Basic information"
-msgstr "Basic information"
-
-#: adhocracy4/dashboard/dashboard.py:45
-msgid "Edit basic module information"
-msgstr "Edit basic module information"
-
-#: adhocracy4/dashboard/dashboard.py:53
-msgid "Phases"
-msgstr "Phases"
-
-#: adhocracy4/dashboard/dashboard.py:55
-msgid "Edit phases information"
-msgstr "Edit phases information"
-
-#: adhocracy4/dashboard/dashboard.py:64
-msgid "Areasettings"
-msgstr "Areasettings"
-
-#: adhocracy4/dashboard/dashboard.py:65
-msgid "Edit areasettings"
-msgstr "Edit areasettings"
-
-#: adhocracy4/dashboard/filter.py:15 meinberlin/apps/projects/views.py:57
-msgid "Archived"
-msgstr "Archived"
-
-#: adhocracy4/dashboard/filter.py:19 adhocracy4/filters/widgets.py:32
-#: meinberlin/apps/projects/views.py:61
-msgid "All"
-msgstr "All"
-
-#: adhocracy4/dashboard/filter.py:20 meinberlin/apps/projects/views.py:62
-msgid "No"
-msgstr "No"
-
-#: adhocracy4/dashboard/filter.py:21
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_confirm_delete.html:13
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html:13
-#: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_confirm_delete.html:13
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_confirm_delete.html:13
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_confirm_delete.html:12
-#: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_confirm_delete.html:12
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_confirm_delete.html:11
-#: meinberlin/apps/projects/serializers.py:156
-#: meinberlin/apps/projects/views.py:63
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_confirm_delete.html:12
-msgid "Yes"
-msgstr "Yes"
-
-#: adhocracy4/dashboard/forms.py:76
-msgid "All users can participate (public)."
-msgstr "All users can participate (public)."
-
-#: adhocracy4/dashboard/forms.py:78
-msgid "Only invited users can participate (private)."
-msgstr "Only invited users can participate (private)."
-
-#: adhocracy4/dashboard/forms.py:86
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:121
-msgid "Contact for questions"
-msgstr "Contact for questions"
-
-#: adhocracy4/dashboard/forms.py:87
-msgid ""
-"Please name a contact person. The user will then know who is carrying out "
-"this project and to whom they can address possible questions. The contact "
-"person will be shown in the information tab on the project page."
-msgstr ""
-"Please name a contact person. The user will then know who is carrying out "
-"this project and to whom they can address possible questions. The contact "
-"person will be shown in the information tab on the project page."
-
-#: adhocracy4/dashboard/forms.py:92
-msgid "More contact possibilities"
-msgstr "More contact possibilities"
-
-#: adhocracy4/dashboard/forms.py:105 adhocracy4/phases/models.py:69
-#: meinberlin/apps/newsletters/models.py:30
-#: meinberlin/apps/platformemails/models.py:16
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_user_list.html:7
-msgid "Name"
-msgstr "Name"
-
-#: adhocracy4/dashboard/forms.py:107
-msgid "Address"
-msgstr "Address"
-
-#: adhocracy4/dashboard/forms.py:110
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:129
-msgid "Telephone"
-msgstr "Telephone"
-
-#: adhocracy4/dashboard/forms.py:112
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:133
-msgid "Email"
-msgstr "Email"
-
-#: adhocracy4/dashboard/forms.py:114
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:153
-msgid "Website"
-msgstr "Website"
-
-#: adhocracy4/dashboard/forms.py:144 adhocracy4/phases/models.py:77
-#: meinberlin/apps/extprojects/forms.py:29
-#: meinberlin/apps/extprojects/models.py:19
-msgid "End date"
-msgstr "End date"
-
-#: adhocracy4/dashboard/forms.py:144 meinberlin/apps/extprojects/forms.py:29
-msgid "End time"
-msgstr "End time"
-
-#: adhocracy4/dashboard/forms.py:150 adhocracy4/phases/models.py:75
-#: meinberlin/apps/extprojects/forms.py:23
-#: meinberlin/apps/extprojects/models.py:17
-msgid "Start date"
-msgstr "Start date"
-
-#: adhocracy4/dashboard/forms.py:150 meinberlin/apps/extprojects/forms.py:23
-msgid "Start time"
-msgstr "Start time"
-
-#: adhocracy4/dashboard/mixins.py:204
-msgid "Project successfully duplicated."
-msgstr "Project successfully duplicated."
 
 #: adhocracy4/dashboard/views.py:69
 msgid "Project successfully created."
@@ -589,44 +515,103 @@ msgstr "Project is already unpublished"
 msgid "the project has been unpublished."
 msgstr "the project has been unpublished."
 
-#: adhocracy4/exports/mixins.py:18
-msgid "Link"
-msgstr "Link"
-
-#: adhocracy4/exports/mixins.py:64
-msgid "Positive ratings"
-msgstr "Positive ratings"
-
-#: adhocracy4/exports/mixins.py:66
-msgid "Negative ratings"
-msgstr "Negative ratings"
-
-#: adhocracy4/exports/mixins.py:99
+#: adhocracy4/exports/mixins/comments.py:16
 msgid "Comment count"
 msgstr "Comment count"
 
-#: adhocracy4/exports/mixins.py:164 adhocracy4/labels/dashboard.py:13
-#: meinberlin/apps/ideas/models.py:45 meinberlin/apps/maptopicprio/models.py:45
-#: meinberlin/apps/topicprio/models.py:45
-msgid "Labels"
-msgstr "Labels"
+#: adhocracy4/exports/mixins/comments.py:77
+msgid "Reply to Comment"
+msgstr "Reply to Comment"
 
-#: adhocracy4/exports/mixins.py:176
+#: adhocracy4/exports/mixins/comments.py:95
+msgid "Reply to Reference"
+msgstr "Reply to Reference"
+
+#: adhocracy4/exports/mixins/general.py:14
+msgid "Creator"
+msgstr "Creator"
+
+#: adhocracy4/exports/mixins/general.py:16
+#: meinberlin/apps/budgeting/exports.py:81
+#: meinberlin/apps/documents/exports.py:40 meinberlin/apps/ideas/exports.py:72
+#: meinberlin/apps/kiezkasse/exports.py:74
+#: meinberlin/apps/mapideas/exports.py:72
+#: meinberlin/apps/maptopicprio/exports.py:70
+#: meinberlin/apps/polls/exports.py:38 meinberlin/apps/topicprio/exports.py:69
+msgid "Created"
+msgstr "Created"
+
+#: adhocracy4/exports/mixins/general.py:34
+msgid "Link"
+msgstr "Link"
+
+#: adhocracy4/exports/mixins/general.py:49
 msgid "Location (Longitude)"
 msgstr "Location (Longitude)"
 
-#: adhocracy4/exports/mixins.py:178
+#: adhocracy4/exports/mixins/general.py:51
 msgid "Location (Latitude)"
 msgstr "Location (Latitude)"
 
-#: adhocracy4/exports/mixins.py:180
+#: adhocracy4/exports/mixins/general.py:53
 msgid "Location label"
 msgstr "Location label"
+
+#: adhocracy4/exports/mixins/items.py:29 adhocracy4/labels/dashboard.py:13
+#: meinberlin/apps/ideas/models.py:45 meinberlin/apps/maptopicprio/models.py:45
+#: meinberlin/apps/topicprio/models.py:60
+msgid "Labels"
+msgstr "Labels"
+
+#: adhocracy4/exports/mixins/items.py:46
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
+#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:77
+#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
+msgid "Reference No."
+msgstr "Reference No."
+
+#: adhocracy4/exports/mixins/items.py:65
+msgid "Moderator feedback"
+msgstr "Moderator feedback"
+
+#: adhocracy4/exports/mixins/items.py:67
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:122
+msgid "Official Statement"
+msgstr "Official Statement"
+
+#: adhocracy4/exports/mixins/items.py:89
+#: meinberlin/apps/moderatorremark/models.py:18
+#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:5
+#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:21
+msgid "Remark"
+msgstr "Remark"
+
+#: adhocracy4/exports/mixins/rates.py:15
+msgid "Positive ratings"
+msgstr "Positive ratings"
+
+#: adhocracy4/exports/mixins/rates.py:17
+msgid "Negative ratings"
+msgstr "Negative ratings"
 
 #: adhocracy4/forms/fields.py:18
 #, python-format
 msgid "Time of %(date_label)s"
 msgstr "Time of %(date_label)s"
+
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html:5
+#: meinberlin/templates/a4forms/includes/form_field.html:5
+msgid "This field is required"
+msgstr "This field is required"
+
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+msgid "Remove category"
+msgstr "Remove category"
 
 #: adhocracy4/images/fields.py:71
 #, python-brace-format
@@ -648,6 +633,30 @@ msgstr "{image_name} copyright"
 #, python-brace-format
 msgid "Copyright shown in the {image_name}."
 msgstr "Copyright shown in the {image_name}."
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: meinberlin/templates/a4images/image_upload_widget.html:9
+#: meinberlin/templates/a4images/image_upload_widget.html:10
+msgid "Remove the picture"
+msgstr "Remove the picture"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: meinberlin/templates/a4images/image_upload_widget.html:15
+#: meinberlin/templates/a4images/image_upload_widget.html:16
+msgid "Upload a picture"
+msgstr "Upload a picture"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+msgid ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+msgstr ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
 
 #: adhocracy4/images/validators.py:20
 msgid "Unsupported file format. Supported formats are {}."
@@ -684,6 +693,22 @@ msgstr "Edit labels"
 #: adhocracy4/labels/forms.py:17
 msgid "Label"
 msgstr "Label"
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+#: meinberlin/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+msgstr ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+#: meinberlin/templates/a4labels/includes/module_labels_form.html:21
+msgid "Add label"
+msgstr "Add label"
 
 #: adhocracy4/maps/admin.py:14 adhocracy4/maps/models.py:11
 msgid "Polygon"
@@ -739,43 +764,43 @@ msgstr ""
 "detail pages. It should briefly state the goal of the module in max. 512 "
 "chars."
 
-#: adhocracy4/modules/models.py:184 adhocracy4/projects/models.py:586
+#: adhocracy4/modules/models.py:192 adhocracy4/projects/models.py:588
 #: meinberlin/apps/projects/serializers.py:216
 msgid "day"
 msgstr "day"
 
-#: adhocracy4/modules/models.py:184 adhocracy4/projects/models.py:586
+#: adhocracy4/modules/models.py:192 adhocracy4/projects/models.py:588
 #: meinberlin/apps/projects/serializers.py:216
 msgid "days"
 msgstr "days"
 
-#: adhocracy4/modules/models.py:185 adhocracy4/projects/models.py:587
+#: adhocracy4/modules/models.py:193 adhocracy4/projects/models.py:589
 #: meinberlin/apps/projects/serializers.py:217
 msgid "hour"
 msgstr "hour"
 
-#: adhocracy4/modules/models.py:185 adhocracy4/projects/models.py:587
+#: adhocracy4/modules/models.py:193 adhocracy4/projects/models.py:589
 #: meinberlin/apps/projects/serializers.py:217
 msgid "hours"
 msgstr "hours"
 
-#: adhocracy4/modules/models.py:186 adhocracy4/projects/models.py:588
+#: adhocracy4/modules/models.py:194 adhocracy4/projects/models.py:590
 #: meinberlin/apps/projects/serializers.py:218
 msgid "minute"
 msgstr "minute"
 
-#: adhocracy4/modules/models.py:186 adhocracy4/projects/models.py:588
+#: adhocracy4/modules/models.py:194 adhocracy4/projects/models.py:590
 #: meinberlin/apps/projects/serializers.py:218
 msgid "minutes"
 msgstr "minutes"
 
-#: adhocracy4/modules/models.py:187 adhocracy4/projects/models.py:589
+#: adhocracy4/modules/models.py:195 adhocracy4/projects/models.py:591
 #: meinberlin/apps/projects/serializers.py:219
 msgid "second"
 msgstr "second"
 
-#: adhocracy4/modules/models.py:187 adhocracy4/modules/models.py:198
-#: adhocracy4/projects/models.py:589 adhocracy4/projects/models.py:600
+#: adhocracy4/modules/models.py:195 adhocracy4/modules/models.py:206
+#: adhocracy4/projects/models.py:591 adhocracy4/projects/models.py:602
 #: meinberlin/apps/projects/serializers.py:219
 msgid "seconds"
 msgstr "seconds"
@@ -785,10 +810,11 @@ msgid "Phases cannot run at the same time and must follow after each other."
 msgstr "Phases cannot run at the same time and must follow after each other."
 
 #: adhocracy4/phases/models.py:71 meinberlin/apps/activities/models.py:21
-#: meinberlin/apps/ideas/models.py:32 meinberlin/apps/maptopicprio/forms.py:26
+#: meinberlin/apps/ideas/models.py:32 meinberlin/apps/maptopicprio/forms.py:19
 #: meinberlin/apps/maptopicprio/models.py:31
 #: meinberlin/apps/offlineevents/models.py:36
-#: meinberlin/apps/plans/models.py:84
+#: meinberlin/apps/plans/models.py:84 meinberlin/apps/topicprio/forms.py:19
+#: meinberlin/apps/topicprio/models.py:39
 msgid "Description"
 msgstr "Description"
 
@@ -801,32 +827,95 @@ msgid "Either both or no date has to be set."
 msgstr "Either both or no date has to be set."
 
 #: adhocracy4/polls/dashboard.py:14 meinberlin/apps/dashboard/blueprints.py:154
-#: meinberlin/apps/polls/dashboard.py:15
 msgid "Poll"
 msgstr "Poll"
 
-#: adhocracy4/polls/phases.py:15
+#: adhocracy4/polls/models.py:52
+msgid "Help text"
+msgstr "Help text"
+
+#: adhocracy4/polls/models.py:76
+msgid "Questions with open answers cannot have multiple choices."
+msgstr "Questions with open answers cannot have multiple choices."
+
+#: adhocracy4/polls/models.py:81
+msgid ""
+"Question with choices cannot become open question. Delete choices or add new "
+"open question."
+msgstr ""
+"Question with choices cannot become open question. Delete choices or add new "
+"open question."
+
+#: adhocracy4/polls/models.py:146 adhocracy4/polls/models.py:259
+msgid "Answer"
+msgstr "Answer"
+
+#: adhocracy4/polls/models.py:158
+msgid "Only open questions can have answers."
+msgstr "Only open questions can have answers."
+
+#: adhocracy4/polls/models.py:195
+msgid "Open questions cannot have choices."
+msgstr "Open questions cannot have choices."
+
+#: adhocracy4/polls/models.py:199
+msgid ""
+"\"Other\" cannot be the only choice. Use open question or add more choices."
+msgstr ""
+"\"Other\" cannot be the only choice. Use open question or add more choices."
+
+#: adhocracy4/polls/models.py:204
+msgid "Question already has \"other\" choice."
+msgstr "Question already has \"other\" choice."
+
+#: adhocracy4/polls/models.py:265
+msgid "Other vote can only be created for vote on \"other\" choice."
+msgstr "Other vote can only be created for vote on \"other\" choice."
+
+#: adhocracy4/polls/models.py:286
+msgid "other"
+msgstr "other"
+
+#: adhocracy4/polls/phases.py:16
+msgctxt "A4: voting phase name"
 msgid "Voting phase"
 msgstr "Voting phase"
 
-#: adhocracy4/polls/phases.py:16
-msgid "Cast votes and discuss the poll."
-msgstr "Cast votes and discuss the poll."
+#: adhocracy4/polls/phases.py:19
+msgctxt "A4: voting phase description"
+msgid "Answer the questions and comment on the poll."
+msgstr "Answer the questions and comment on the poll."
 
-#: adhocracy4/polls/phases.py:17 meinberlin/apps/polls/phases.py:18
+#: adhocracy4/polls/phases.py:21
 msgid "polls"
 msgstr "polls"
 
-#: adhocracy4/polls/validators.py:15 meinberlin/apps/polls/validators.py:15
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr "Setup the poll by adding questions and answers in the dashboard."
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr "Edit poll"
+
+#: adhocracy4/polls/validators.py:15
 #, python-format
 msgid "Item of type %(item)s for that module already exists"
 msgstr "Item of type %(item)s for that module already exists"
 
-#: adhocracy4/polls/validators.py:38 meinberlin/apps/polls/validators.py:38
+#: adhocracy4/polls/validators.py:38
 msgid "Only one vote per question is allowed per user."
 msgstr "Only one vote per question is allowed per user."
 
-#: adhocracy4/polls/validators.py:47 meinberlin/apps/polls/validators.py:47
+#: adhocracy4/polls/validators.py:47
 msgid "Choice has to belong to the question set in the url."
 msgstr "Choice has to belong to the question set in the url."
 
@@ -1116,7 +1205,7 @@ msgstr "Face-to-Face Information"
 
 #: meinberlin/apps/activities/models.py:12 meinberlin/apps/ideas/models.py:31
 #: meinberlin/apps/maptopicprio/models.py:29 meinberlin/apps/plans/models.py:40
-#: meinberlin/apps/topicprio/models.py:28
+#: meinberlin/apps/topicprio/models.py:35
 msgid "Title"
 msgstr "Title"
 
@@ -1463,45 +1552,36 @@ msgstr ""
 #: meinberlin/apps/kiezkasse/dashboard.py:14
 #: meinberlin/apps/mapideas/dashboard.py:14
 #: meinberlin/apps/maptopicprio/dashboard.py:59
-#: meinberlin/apps/polls/dashboard.py:45
+#: meinberlin/apps/polls/dashboard.py:14
 #: meinberlin/apps/topicprio/dashboard.py:54
 msgid "Export Excel"
 msgstr "Export Excel"
 
-#: meinberlin/apps/budgeting/exports.py:43
+#: meinberlin/apps/budgeting/exports.py:42
 msgid "Contact E-Mail"
 msgstr "Contact E-Mail"
 
-#: meinberlin/apps/budgeting/exports.py:44
+#: meinberlin/apps/budgeting/exports.py:43
 msgid "Contact Phone"
 msgstr "Contact Phone"
+
+#: meinberlin/apps/budgeting/exports.py:79
+#: meinberlin/apps/documents/exports.py:38 meinberlin/apps/ideas/exports.py:70
+#: meinberlin/apps/kiezkasse/exports.py:72
+#: meinberlin/apps/mapideas/exports.py:70
+#: meinberlin/apps/maptopicprio/exports.py:68
+#: meinberlin/apps/polls/exports.py:36 meinberlin/apps/topicprio/exports.py:67
+msgid "ID"
+msgstr "ID"
 
 #: meinberlin/apps/budgeting/exports.py:80
 #: meinberlin/apps/documents/exports.py:39 meinberlin/apps/ideas/exports.py:71
 #: meinberlin/apps/kiezkasse/exports.py:73
 #: meinberlin/apps/mapideas/exports.py:71
 #: meinberlin/apps/maptopicprio/exports.py:69
-#: meinberlin/apps/polls/exports.py:35 meinberlin/apps/topicprio/exports.py:68
-msgid "ID"
-msgstr "ID"
-
-#: meinberlin/apps/budgeting/exports.py:81
-#: meinberlin/apps/documents/exports.py:40 meinberlin/apps/ideas/exports.py:72
-#: meinberlin/apps/kiezkasse/exports.py:74
-#: meinberlin/apps/mapideas/exports.py:72
-#: meinberlin/apps/maptopicprio/exports.py:70
-#: meinberlin/apps/polls/exports.py:36 meinberlin/apps/topicprio/exports.py:69
+#: meinberlin/apps/polls/exports.py:37 meinberlin/apps/topicprio/exports.py:68
 msgid "Comment"
 msgstr "Comment"
-
-#: meinberlin/apps/budgeting/exports.py:82
-#: meinberlin/apps/documents/exports.py:41 meinberlin/apps/exports/mixins.py:80
-#: meinberlin/apps/ideas/exports.py:73 meinberlin/apps/kiezkasse/exports.py:75
-#: meinberlin/apps/mapideas/exports.py:73
-#: meinberlin/apps/maptopicprio/exports.py:71
-#: meinberlin/apps/polls/exports.py:37 meinberlin/apps/topicprio/exports.py:70
-msgid "Created"
-msgstr "Created"
 
 #: meinberlin/apps/budgeting/forms.py:25
 msgid ""
@@ -1802,7 +1882,7 @@ msgstr[0] "display %(counter)s project"
 msgstr[1] "display %(counter)s projects"
 
 #: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:28
-#: meinberlin/apps/plans/exports.py:58 meinberlin/apps/plans/forms.py:43
+#: meinberlin/apps/plans/exports.py:57 meinberlin/apps/plans/forms.py:43
 #: meinberlin/apps/plans/templatetags/react_map_teaser.py:18
 #: meinberlin/apps/plans/views.py:62 meinberlin/apps/projects/admin.py:65
 #: meinberlin/apps/projects/forms.py:100
@@ -1974,14 +2054,6 @@ msgstr "Positive Ratings"
 msgid "Negative Ratings"
 msgstr "Negative Ratings"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
-#: meinberlin/apps/exports/mixins.py:12
-#: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:77
-#: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
-msgid "Reference No."
-msgstr "Reference No."
-
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:82
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:91
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:109
@@ -2004,11 +2076,6 @@ msgstr "give feedback"
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:107
 msgid "report"
 msgstr "report"
-
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:122
-#: meinberlin/apps/exports/mixins.py:26
-msgid "Official Statement"
-msgstr "Official Statement"
 
 #: meinberlin/apps/dashboard/blueprints.py:17
 msgid "Brainstorming"
@@ -2189,13 +2256,9 @@ msgstr ""
 "Only invited users can see project tile and content and can participate "
 "(private)."
 
-#: meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html:4
+#: meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html:7
 msgid "New Module"
 msgstr "New Module"
-
-#: meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html:7
-msgid "Choose Participation Module"
-msgstr "Choose Participation Module"
 
 #: meinberlin/apps/dashboard/views.py:52
 msgid "The module was created"
@@ -2319,32 +2382,10 @@ msgstr ""
 msgid "Embed Code"
 msgstr "Embed Code"
 
-#: meinberlin/apps/exports/mixins.py:24
-msgid "Moderator feedback"
-msgstr "Moderator feedback"
-
-#: meinberlin/apps/exports/mixins.py:41
-#: meinberlin/apps/moderatorremark/models.py:18
-#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:5
-#: meinberlin/apps/moderatorremark/templates/meinberlin_moderatorremark/includes/popover_remark.html:21
-msgid "Remark"
-msgstr "Remark"
-
-#: meinberlin/apps/exports/mixins.py:53
-msgid "replies to comment"
-msgstr "replies to comment"
-
-#: meinberlin/apps/exports/mixins.py:65
-msgid "comment on reference"
-msgstr "comment on reference"
-
-#: meinberlin/apps/exports/mixins.py:78
-msgid "Creator"
-msgstr "Creator"
-
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:5
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:23
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:35
+#: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:47
 msgid "Export"
 msgstr "Export"
 
@@ -2359,6 +2400,10 @@ msgid "here you can export all ideas"
 msgstr "here you can export all ideas"
 
 #: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:31
+msgid "here you can export all answers"
+msgstr "here you can export all answers"
+
+#: meinberlin/apps/exports/templates/meinberlin_exports/export_dashboard.html:43
 msgid "here you can export all comments"
 msgstr "here you can export all comments"
 
@@ -2414,7 +2459,7 @@ msgid "Linkages are handled on a different platform."
 msgstr "Linkages are handled on a different platform."
 
 #: meinberlin/apps/ideas/models.py:35 meinberlin/apps/plans/models.py:87
-#: meinberlin/apps/topicprio/models.py:32
+#: meinberlin/apps/topicprio/models.py:43
 msgid "Add image"
 msgstr "Add image"
 
@@ -2696,7 +2741,7 @@ msgstr ""
 "accept the {}terms of use{} and the {}privacy policy{}."
 
 #: meinberlin/apps/mapideas/forms.py:23
-#: meinberlin/apps/maptopicprio/forms.py:25
+#: meinberlin/apps/maptopicprio/forms.py:28
 msgid "Please locate your proposal on the map."
 msgstr "Please locate your proposal on the map."
 
@@ -2762,11 +2807,11 @@ msgstr "You can choose a preset for further customization."
 msgid "Places"
 msgstr "Places"
 
-#: meinberlin/apps/maptopicprio/forms.py:33
+#: meinberlin/apps/maptopicprio/forms.py:35
 msgid "Locate the place on a map"
 msgstr "Locate the place on a map"
 
-#: meinberlin/apps/maptopicprio/forms.py:34
+#: meinberlin/apps/maptopicprio/forms.py:36
 msgid "Place label"
 msgstr "Place label"
 
@@ -3069,7 +3114,7 @@ msgstr "Plans"
 msgid "Edit Plan"
 msgstr "Edit Plan"
 
-#: meinberlin/apps/plans/exports.py:51
+#: meinberlin/apps/plans/exports.py:50
 msgid "Project Links"
 msgstr "Project Links"
 
@@ -3156,7 +3201,7 @@ msgstr "Status"
 #: meinberlin/apps/plans/models.py:108
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:68
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:51
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:92
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:97
 msgid "Participation"
 msgstr "Participation"
 
@@ -3277,18 +3322,6 @@ msgstr ""
 #: meinberlin/apps/platformemails/views.py:47
 msgid "Platform email has been saved and will be sent to the recipients."
 msgstr "Platform email has been saved and will be sent to the recipients."
-
-#: meinberlin/apps/polls/phases.py:15
-msgid "Please take part in our poll!"
-msgstr "Please take part in our poll!"
-
-#: meinberlin/apps/polls/phases.py:16
-msgid ""
-"Help us by answering the questions below. There is space for your comments "
-"at the end of the questionnaire."
-msgstr ""
-"Help us by answering the questions below. There is space for your comments "
-"at the end of the questionnaire."
 
 #: meinberlin/apps/projectcontainers/dashboard.py:16
 msgid "Edit container settings"
@@ -3672,15 +3705,15 @@ msgstr "This project is in not published yet."
 msgid "to project collection %(name)s"
 msgstr "to project collection %(name)s"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:82
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:87
 msgid "About the Project"
 msgstr "About the Project"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:146
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:151
 msgid "Responsible body"
 msgstr "Responsible body"
 
-#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:221
+#: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:226
 msgid "No results yet."
 msgstr "No results yet."
 
@@ -3930,122 +3963,122 @@ msgstr "Account Settings"
 msgid "Platform Email"
 msgstr "Platform Email"
 
-#: meinberlin/config/settings/base.py:307
-#: meinberlin/config/settings/base.py:317
-#: meinberlin/config/settings/base.py:328
-#: meinberlin/config/settings/base.py:343
+#: meinberlin/config/settings/base.py:309
+#: meinberlin/config/settings/base.py:319
+#: meinberlin/config/settings/base.py:330
+#: meinberlin/config/settings/base.py:345
 msgid "Rich text editor"
 msgstr "Rich text editor"
 
-#: meinberlin/config/settings/base.py:487
+#: meinberlin/config/settings/base.py:488
 msgid "Pin without icon"
 msgstr "Pin without icon"
 
-#: meinberlin/config/settings/base.py:488
+#: meinberlin/config/settings/base.py:489
 msgid "Diamond"
 msgstr "Diamond"
 
-#: meinberlin/config/settings/base.py:489
+#: meinberlin/config/settings/base.py:490
 msgid "Triangle up"
 msgstr "Triangle up"
 
-#: meinberlin/config/settings/base.py:490
+#: meinberlin/config/settings/base.py:491
 msgid "Triangle down"
 msgstr "Triangle down"
 
-#: meinberlin/config/settings/base.py:491
+#: meinberlin/config/settings/base.py:492
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: meinberlin/config/settings/base.py:492
+#: meinberlin/config/settings/base.py:493
 msgid "Semi circle"
 msgstr "Semi circle"
 
-#: meinberlin/config/settings/base.py:493
+#: meinberlin/config/settings/base.py:494
 msgid "Hexagon"
 msgstr "Hexagon"
 
-#: meinberlin/config/settings/base.py:494
+#: meinberlin/config/settings/base.py:495
 msgid "Rhomboid"
 msgstr "Rhomboid"
 
-#: meinberlin/config/settings/base.py:495
+#: meinberlin/config/settings/base.py:496
 msgid "Star"
 msgstr "Star"
 
-#: meinberlin/config/settings/base.py:496
+#: meinberlin/config/settings/base.py:497
 msgid "Square"
 msgstr "Square"
 
-#: meinberlin/config/settings/base.py:497
+#: meinberlin/config/settings/base.py:498
 msgid "Octothorpe"
 msgstr "Octothorpe"
 
-#: meinberlin/config/settings/base.py:498
+#: meinberlin/config/settings/base.py:499
 msgid "Rectangle"
 msgstr "Rectangle"
 
-#: meinberlin/config/settings/base.py:499
+#: meinberlin/config/settings/base.py:500
 msgid "Circle"
 msgstr "Circle"
 
-#: meinberlin/config/settings/base.py:500
+#: meinberlin/config/settings/base.py:501
 msgid "Right triangle"
 msgstr "Right triangle"
 
-#: meinberlin/config/settings/base.py:501
+#: meinberlin/config/settings/base.py:502
 msgid "Zigzag"
 msgstr "Zigzag"
 
-#: meinberlin/config/settings/base.py:510
+#: meinberlin/config/settings/base.py:511
 msgid "Anti-discrimination"
 msgstr "Anti-discrimination"
 
-#: meinberlin/config/settings/base.py:511
+#: meinberlin/config/settings/base.py:512
 msgid "Work & economy"
 msgstr "Work & economy"
 
-#: meinberlin/config/settings/base.py:512
+#: meinberlin/config/settings/base.py:513
 msgid "Building & living"
 msgstr "Building & living"
 
-#: meinberlin/config/settings/base.py:513
+#: meinberlin/config/settings/base.py:514
 msgid "Education & research"
 msgstr "Education & research"
 
-#: meinberlin/config/settings/base.py:514
+#: meinberlin/config/settings/base.py:515
 msgid "Children, youth & family"
 msgstr "Children, youth & family"
 
-#: meinberlin/config/settings/base.py:515
+#: meinberlin/config/settings/base.py:516
 msgid "Finances"
 msgstr "Finances"
 
-#: meinberlin/config/settings/base.py:516
+#: meinberlin/config/settings/base.py:517
 msgid "Health & sports"
 msgstr "Health & sports"
 
-#: meinberlin/config/settings/base.py:517
+#: meinberlin/config/settings/base.py:518
 msgid "Integration"
 msgstr "Integration"
 
-#: meinberlin/config/settings/base.py:518
+#: meinberlin/config/settings/base.py:519
 msgid "Culture & leisure"
 msgstr "Culture & leisure"
 
-#: meinberlin/config/settings/base.py:519
+#: meinberlin/config/settings/base.py:520
 msgid "Neighborhood & participation"
 msgstr "Neighborhood & participation"
 
-#: meinberlin/config/settings/base.py:520
+#: meinberlin/config/settings/base.py:521
 msgid "Urban development"
 msgstr "Urban development"
 
-#: meinberlin/config/settings/base.py:521
+#: meinberlin/config/settings/base.py:522
 msgid "Environment & public green space"
 msgstr "Environment & public green space"
 
-#: meinberlin/config/settings/base.py:522
+#: meinberlin/config/settings/base.py:523
 msgid "Traffic"
 msgstr "Traffic"
 
@@ -4104,13 +4137,23 @@ msgid_plural "Participation Modules"
 msgstr[0] "Participation Module"
 msgstr[1] "Participation Modules"
 
-#: meinberlin/templates/a4dashboard/includes/nav_modules.html:7
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:14
 msgid "Create Module"
 msgstr "Create Module"
 
-#: meinberlin/templates/a4dashboard/includes/nav_modules.html:13
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:21
 msgid "You have not set up a participation module yet."
 msgstr "You have not set up a participation module yet."
+
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:29
+msgid "Choose Participation Module"
+msgstr "Choose Participation Module"
+
+#: meinberlin/templates/a4dashboard/includes/nav_modules.html:30
+#: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:67
+#: meinberlin/templates/a4dashboard/includes/progress.html:30
+msgid "Close"
+msgstr "Close"
 
 #: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:6
 #: meinberlin/templates/a4dashboard/includes/nav_project.html:6
@@ -4147,11 +4190,6 @@ msgstr "Delete module"
 #: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:66
 msgid "Are you sure you want to delete your module?"
 msgstr "Are you sure you want to delete your module?"
-
-#: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:67
-#: meinberlin/templates/a4dashboard/includes/progress.html:30
-msgid "Close"
-msgstr "Close"
 
 #: meinberlin/templates/a4dashboard/includes/nav_project.html:13
 msgid "Project ready for publication"
@@ -4522,27 +4560,27 @@ msgstr "Hello"
 msgid "meinBerlin is a participation platform operated by"
 msgstr "meinBerlin is a participation platform operated by"
 
-#: meinberlin/templates/header.html:7
+#: meinberlin/templates/header.html:13
 msgid "Menu"
 msgstr "Menu"
 
-#: meinberlin/templates/header.html:13
+#: meinberlin/templates/header.html:19
 msgid "Home"
 msgstr "Home"
 
-#: meinberlin/templates/header.html:17
+#: meinberlin/templates/header.html:23
 msgid "Project overview"
 msgstr "Project overview"
 
-#: meinberlin/templates/header.html:34
+#: meinberlin/templates/header.html:46
 msgid "User Menu"
 msgstr "User Menu"
 
-#: meinberlin/templates/header.html:44
+#: meinberlin/templates/header.html:56
 msgid "Help"
 msgstr "Help"
 
-#: meinberlin/templates/header.html:49
+#: meinberlin/templates/header.html:61
 msgid "Give Feedback"
 msgstr "Give Feedback"
 
@@ -4595,6 +4633,28 @@ msgid ""
 msgstr ""
 "You are about to use your %(provider_name)s account to login to\n"
 "%(site_name)s. As a final step, please complete the following form:"
+
+#~ msgid "Voting phase"
+#~ msgstr "Voting phase"
+
+#~ msgid "Cast votes and discuss the poll."
+#~ msgstr "Cast votes and discuss the poll."
+
+#~ msgid "replies to comment"
+#~ msgstr "replies to comment"
+
+#~ msgid "comment on reference"
+#~ msgstr "comment on reference"
+
+#~ msgid "Please take part in our poll!"
+#~ msgstr "Please take part in our poll!"
+
+#~ msgid ""
+#~ "Help us by answering the questions below. There is space for your "
+#~ "comments at the end of the questionnaire."
+#~ msgstr ""
+#~ "Help us by answering the questions below. There is space for your "
+#~ "comments at the end of the questionnaire."
 
 #~ msgid "replies to"
 #~ msgstr "replies to"

--- a/locale/en_GB/LC_MESSAGES/djangojs.po
+++ b/locale/en_GB/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-27 15:55+0200\n"
+"POT-Creation-Date: 2021-07-05 17:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,7 +49,6 @@ msgstr[0] "view one reply"
 msgstr[1] "view %s replies"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:30
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:9
 msgid "Answer"
 msgstr "Answer"
 
@@ -89,13 +88,18 @@ msgstr "Do you really want to delete this comment?"
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:238
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:14
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:66
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:71
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:146
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:151
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:56
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:61
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:133
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:138
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:100
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:105
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:71
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:76
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:151
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:156
 msgid "Delete"
 msgstr "Delete"
 
@@ -354,123 +358,125 @@ msgstr "Follow"
 msgid "Following"
 msgstr "Following"
 
-#: adhocracy4/polls/static/polls/ChoiceForm.jsx:6
-#: meinberlin/apps/polls/assets/ChoiceForm.jsx:23
-#: meinberlin/apps/polls/assets/ChoiceForm.jsx:28
+#: adhocracy4/polls/assets/EditPollChoice.jsx:24
+#: adhocracy4/polls/assets/EditPollChoice.jsx:30
+#: meinberlin/apps/polls/assets/ChoiceForm.jsx:24
+#: meinberlin/apps/polls/assets/ChoiceForm.jsx:30
 msgid "remove"
 msgstr "remove"
 
-#: adhocracy4/polls/static/polls/PollManagement.jsx:179
-#: meinberlin/apps/polls/assets/PollManagement.jsx:188
-msgid "The poll has been updated."
-msgstr "The poll has been updated."
-
-#: adhocracy4/polls/static/polls/PollManagement.jsx:180
-#: meinberlin/apps/polls/assets/PollManagement.jsx:205
-msgid "The poll could not be updated."
-msgstr "The poll could not be updated."
-
-#: adhocracy4/polls/static/polls/PollManagement.jsx:216
-#: meinberlin/apps/polls/assets/PollManagement.jsx:247
-msgid "Add a new question"
-msgstr "Add a new question"
-
-#: adhocracy4/polls/static/polls/PollManagement.jsx:217
-#: meinberlin/apps/documents/assets/DocumentManagement.jsx:324
-#: meinberlin/apps/polls/assets/PollManagement.jsx:253
-msgid "Save"
-msgstr "Save"
-
-#: adhocracy4/polls/static/polls/Question.jsx:9
-#: meinberlin/apps/polls/assets/Question.jsx:204
-msgid "Your choice"
-msgstr "Your choice"
-
-#: adhocracy4/polls/static/polls/Question.jsx:10
-msgid "Multiple answers are possible for this question"
-msgstr "Multiple answers are possible for this question"
-
-#: adhocracy4/polls/static/polls/Question.jsx:36
-#: meinberlin/apps/polls/assets/Question.jsx:52
-msgid "Vote counted"
-msgstr "Vote counted"
-
-#: adhocracy4/polls/static/polls/Question.jsx:37
-#: meinberlin/apps/polls/assets/Question.jsx:62
-msgid "Vote has not been counted due to a server error."
-msgstr "Vote has not been counted due to a server error."
-
-#: adhocracy4/polls/static/polls/Question.jsx:104
-#: meinberlin/apps/polls/assets/Question.jsx:110
-msgid "Vote"
-msgstr "Vote"
-
-#: adhocracy4/polls/static/polls/Question.jsx:105
-#: meinberlin/apps/polls/assets/Question.jsx:116
-msgid "Please login to vote"
-msgstr "Please login to vote"
-
-#: adhocracy4/polls/static/polls/Question.jsx:140
-#: meinberlin/apps/polls/assets/Question.jsx:171
-msgid "To poll"
-msgstr "To poll"
-
-#: adhocracy4/polls/static/polls/Question.jsx:142
-#: meinberlin/apps/polls/assets/Question.jsx:174
-msgid "Change vote"
-msgstr "Change vote"
-
-#: adhocracy4/polls/static/polls/Question.jsx:145
-#: meinberlin/apps/polls/assets/Question.jsx:178
-msgid "Show preliminary results"
-msgstr "Show preliminary results"
-
-#: adhocracy4/polls/static/polls/Question.jsx:157
-msgid "vote"
-msgid_plural "votes"
-msgstr[0] "vote"
-msgstr[1] "votes"
-
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:8
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:16
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:19
 #: meinberlin/apps/livequestions/assets/QuestionForm.jsx:69
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:15
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:16
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:19
 msgid "Question"
 msgstr "Question"
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:10
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:36
-msgid "Users can select more than one answer."
-msgstr "Users can select more than one answer."
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:34
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:113
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:39
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:118
+msgid "Add Helptext"
+msgstr "Add Helptext"
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:11
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:68
-msgid "Add a new choice"
-msgstr "Add a new choice"
-
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:12
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:43
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:48
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:123
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:128
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:32
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:37
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:110
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:115
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:77
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:82
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:48
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:53
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:128
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:133
 msgid "Move up"
 msgstr "Move up"
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:13
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:55
+#: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:60
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:135
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:140
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:44
 #: meinberlin/apps/documents/assets/ChapterNavItem.jsx:49
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:122
 #: meinberlin/apps/documents/assets/ParagraphForm.jsx:127
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:89
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:94
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:60
+#: meinberlin/apps/polls/assets/OpenQuestionForm.jsx:65
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:140
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:145
 msgid "Move down"
 msgstr "Move down"
 
-#: adhocracy4/polls/static/polls/QuestionForm.jsx:54
-#: meinberlin/apps/polls/assets/QuestionForm.jsx:44
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:44
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:49
+msgid "Users can select more than one answer."
+msgstr "Users can select more than one answer."
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:59
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:64
+msgid "Users can answer openly."
+msgstr "Users can answer openly."
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:67
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:72
 msgid "Choice"
 msgstr "Choice"
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:89
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:90
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:94
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:95
+msgid "Other"
+msgstr "Other"
+
+#: adhocracy4/polls/assets/EditPollQuestion.jsx:106
+#: meinberlin/apps/polls/assets/QuestionForm.jsx:111
+msgid "Add a new choice"
+msgstr "Add a new choice"
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:162
+#: meinberlin/apps/polls/assets/PollManagement.jsx:161
+msgid "The poll has been updated."
+msgstr "The poll has been updated."
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:176
+#: meinberlin/apps/polls/assets/PollManagement.jsx:175
+msgid "The poll could not be updated."
+msgstr "The poll could not be updated."
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:195
+#: meinberlin/apps/polls/assets/PollManagement.jsx:194
+msgid "Add a new question"
+msgstr "Add a new question"
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:201
+#: meinberlin/apps/polls/assets/PollManagement.jsx:200
+msgid "predefined answers"
+msgstr "predefined answers"
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:206
+#: meinberlin/apps/polls/assets/PollManagement.jsx:205
+msgid "open answers"
+msgstr "open answers"
+
+#: adhocracy4/polls/assets/EditPollQuestions.jsx:278
+#: meinberlin/apps/documents/assets/DocumentManagement.jsx:324
+#: meinberlin/apps/polls/assets/PollManagement.jsx:277
+msgid "Save"
+msgstr "Save"
+
+#: adhocracy4/polls/assets/HelptextForm.jsx:11
+#: meinberlin/apps/polls/assets/HelptextForm.jsx:11
+msgid "Helptext"
+msgstr "Helptext"
+
+#: adhocracy4/polls/assets/PollQuestion.jsx:5
+#: meinberlin/apps/polls/assets/Question.jsx:132
+msgid "Multiple answers are possible."
+msgstr "Multiple answers are possible."
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
 msgid "Thank you! We are taking care of it."
@@ -478,7 +484,6 @@ msgstr "Thank you! We are taking care of it."
 
 #: adhocracy4/static/Alert.jsx:5 meinberlin/apps/contrib/assets/Alert.jsx:10
 #: meinberlin/apps/contrib/assets/Alert.jsx:11
-#: meinberlin/apps/dashboard/assets/ajax_modal.js:12
 #: meinberlin/apps/embed/assets/embed.js:59
 #: meinberlin/apps/embed/assets/embed.js:60
 #: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:85
@@ -875,31 +880,31 @@ msgstr "ongoing"
 msgid "done"
 msgstr "done"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:139
+#: meinberlin/apps/plans/assets/PlansList.jsx:86
 #: meinberlin/apps/plans/assets/PopUp.jsx:20
 msgid "More than 1 year remaining"
 msgstr "More than 1 year remaining"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:143
+#: meinberlin/apps/plans/assets/PlansList.jsx:90
 #: meinberlin/apps/plans/assets/PopUp.jsx:24
 msgid "remaining"
 msgstr "remaining"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:245
+#: meinberlin/apps/plans/assets/PlansList.jsx:192
 #: meinberlin/apps/plans/assets/PopUp.jsx:68
 msgid "Participation ended. Read result."
 msgstr "Participation ended. Read result."
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:263
+#: meinberlin/apps/plans/assets/PlansList.jsx:210
 #: meinberlin/apps/plans/assets/PopUp.jsx:88
 msgid "Participation projects: "
 msgstr "Participation projects: "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:272
+#: meinberlin/apps/plans/assets/PlansList.jsx:219
 msgid "Status: "
 msgstr "Status: "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:298
+#: meinberlin/apps/plans/assets/PlansList.jsx:250
 #: meinberlin/apps/plans/assets/PlansMap.jsx:293
 msgid "Nothing to show"
 msgstr "Nothing to show"
@@ -966,9 +971,21 @@ msgstr "show map"
 msgid "Map"
 msgstr "Map"
 
-#: meinberlin/apps/polls/assets/Question.jsx:132
-msgid "Multiple answers are possible."
-msgstr "Multiple answers are possible."
+#: meinberlin/apps/polls/assets/Question.jsx:52
+msgid "Vote counted"
+msgstr "Vote counted"
+
+#: meinberlin/apps/polls/assets/Question.jsx:62
+msgid "Vote has not been counted due to a server error."
+msgstr "Vote has not been counted due to a server error."
+
+#: meinberlin/apps/polls/assets/Question.jsx:110
+msgid "Vote"
+msgstr "Vote"
+
+#: meinberlin/apps/polls/assets/Question.jsx:116
+msgid "Please login to vote"
+msgstr "Please login to vote"
 
 #: meinberlin/apps/polls/assets/Question.jsx:148
 #, javascript-format
@@ -995,6 +1012,22 @@ msgid "1 person has answered."
 msgid_plural "%s people have answered."
 msgstr[0] "1 person has answered."
 msgstr[1] "%s people have answered."
+
+#: meinberlin/apps/polls/assets/Question.jsx:171
+msgid "To poll"
+msgstr "To poll"
+
+#: meinberlin/apps/polls/assets/Question.jsx:174
+msgid "Change vote"
+msgstr "Change vote"
+
+#: meinberlin/apps/polls/assets/Question.jsx:178
+msgid "Show preliminary results"
+msgstr "Show preliminary results"
+
+#: meinberlin/apps/polls/assets/Question.jsx:204
+msgid "Your choice"
+msgstr "Your choice"
 
 #: meinberlin/assets/js/unload_warning.js:16
 msgid "If you leave this page changes you made will not be saved."
@@ -1049,6 +1082,14 @@ msgstr ""
 #: dsgvo-video-embed/js/dsgvo-video-embed.js:20
 msgid "More information can be found in the privacy policy of Vimeo under: "
 msgstr "More information can be found in the privacy policy of Vimeo under: "
+
+#~ msgid "Multiple answers are possible for this question"
+#~ msgstr "Multiple answers are possible for this question"
+
+#~ msgid "vote"
+#~ msgid_plural "votes"
+#~ msgstr[0] "vote"
+#~ msgstr[1] "votes"
 
 #~ msgid "Show List"
 #~ msgstr "Show List"


### PR DESCRIPTION
I only added the translations, I don't want to forget. Maybe we can add the translations, we already have by everyone adding translations they know where to find (and being careful to not do that at the same time :p).

I get this warning when I makemessages for the js files, but they still seem to be fine and I couldn't find why it's there:
```
/home/katharina/a4-meinberlin/venv/bin/python manage.py makemessages -d djangojs
/home/katharina/a4-meinberlin/node_modules/adhocracy4/adhocracy4/polls/assets/PollOpenQuestion.jsx:22: warning: RegExp literal terminated too early
/home/katharina/adhocracy4/adhocracy4/polls/assets/PollOpenQuestion.jsx:22: warning: RegExp literal terminated too early
processing locale en_GB
processing locale de_DE
```