### PR TITLE
webpack: use new inbuilt asset modules instead of file-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dsgvo-video-embed": "git+https://github.com/liqd/dsgvo-video-embed.git",
     "es6-promise": "4.2.8",
     "feature-detect": "1.0.0",
-    "file-loader": "6.2.0",
     "file-saver": "2.0.5",
     "immutability-helper": "3.1.1",
     "jquery": "3.6.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -174,16 +174,16 @@ module.exports = {
       },
       {
         test: /fonts\/.*\.(svg|woff2?|ttf|eot)(\?.*)?$/,
-        loader: 'file-loader',
-        options: {
-          name: 'fonts/[name].[ext]'
+        type: 'asset/resource',
+        generator: {
+          filename: 'fonts/[name][ext]'
         }
       },
       {
         test: /\.svg$|\.png$/,
-        loader: 'file-loader',
-        options: {
-          name: 'images/[name].[ext]'
+        type: 'asset/resource',
+        generator: {
+          filename: 'images/[name][ext]'
         }
       }
     ]


### PR DESCRIPTION
recommended with the css-mini-extract-plugin, one external dependency less