### PR TITLE
apps/polls: also fill weight field for choices

### DIFF
--- a/meinberlin/apps/polls/migrations/0006_copy_poll_data_to_a4_polls.py
+++ b/meinberlin/apps/polls/migrations/0006_copy_poll_data_to_a4_polls.py
@@ -27,10 +27,11 @@ def copy_data(apps, schema_editor):
                 multiple_choice = mb_question.multiple_choice,
                 poll = poll)
             mb_choices = MBChoice.objects.filter(question=mb_question)
-            for mb_choice in mb_choices:
+            for i, mb_choice in enumerate(mb_choices):
                 choice = Choice.objects.create(
                     label = mb_choice.label,
-                    question = question)
+                    question = question,
+                    weight = i)
                 mb_votes = MBVote.objects.filter(choice=mb_choice)
                 for mb_vote in mb_votes:
                     Vote.objects.create(


### PR DESCRIPTION
The order of the choices stays the same like that.
We have to change it in this migration, because we cannot make sure, that this is run before
the migration in a4 adding the weight to the poll. And for projects where this migration is already run, it is no problem that it changed.

I also got the error locally when I used an older database. This fixed it and the order of the choices stayed the same.