### PR TITLE
Kl 2021 09 more publish tests

### DIFF
--- a/meinberlin/apps/dashboard/views.py
+++ b/meinberlin/apps/dashboard/views.py
@@ -205,6 +205,23 @@ class ModuleDeleteView(PermissionRequiredMixin,
     success_message = _('The module has been deleted')
 
     def delete(self, request, *args, **kwargs):
+        module = self.get_object()
+        # only unpublished modules can be deleted
+        if not module.is_draft:
+            messages.error(request,
+                           _('Module added to a project cannot be '
+                             'deleted.'))
+            # try to stay on same page
+            if 'referrer' in request.POST:
+                redirect = request.POST['referrer']
+            elif 'HTTP_REFERER' in self.request.META:
+                redirect = request.META['HTTP_REFERER']
+            else:
+                redirect = reverse('a4dashboard:project-edit', kwargs={
+                    'project_slug': module.project.slug
+                })
+            return HttpResponseRedirect(redirect)
+
         messages.success(self.request, self.success_message)
         return super().delete(request, *args, **kwargs)
 

--- a/meinberlin/apps/dashboard/views.py
+++ b/meinberlin/apps/dashboard/views.py
@@ -11,6 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from django.views.generic.detail import SingleObjectMixin
 
+from adhocracy4.dashboard import get_project_dashboard
 from adhocracy4.dashboard import mixins
 from adhocracy4.dashboard import signals
 from adhocracy4.dashboard import views as a4dashboard_views
@@ -147,6 +148,16 @@ class ModulePublishView(SingleObjectMixin,
         module = self.get_object()
         if not module.is_draft:
             messages.info(self.request, _('Module is already added'))
+            return
+
+        dashboard = get_project_dashboard(module.project)
+        num_valid, num_required = dashboard.get_module_progress(module)
+        is_complete = (num_valid == num_required)
+
+        if not is_complete:
+            messages.error(self.request,
+                           _('Module cannot be added. '
+                             'Required fields are missing.'))
             return
 
         module.is_draft = False

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -214,6 +214,7 @@ class DashboardPlanDeleteView(a4dashboard_mixins.DashboardBaseMixin,
 
 
 class PlanPublishView(SingleObjectMixin,
+                      rules_mixins.PermissionRequiredMixin,
                       generic.View):
     permission_required = 'meinberlin_plans.change_plan'
     model = Plan

--- a/tests/dashboard/test_dashboard_views_module_delete.py
+++ b/tests/dashboard/test_dashboard_views_module_delete.py
@@ -1,6 +1,7 @@
 import pytest
 from django.urls import reverse
 
+from adhocracy4.modules.models import Module
 from adhocracy4.test.helpers import redirect_target
 
 
@@ -22,4 +23,90 @@ def test_module_delete_perms(client, phase, user, user2):
     organisation.initiators.add(user2)
     client.login(username=user2, password='password')
     response = client.post(module_delete_url)
+    assert redirect_target(response) == 'project-edit'
+
+
+@pytest.mark.django_db
+def test_module_delete(client, phase, user2):
+    module = phase.module
+    module.is_draft = False
+    module.save()
+    organisation = module.project.organisation
+    organisation.initiators.add(user2)
+    assert Module.objects.all().count() == 1
+
+    module_delete_url = reverse('a4dashboard:module-delete', kwargs={
+        'slug': module.slug})
+
+    # deleting published modules has no effect
+    client.login(username=user2, password='password')
+    response = client.post(module_delete_url)
+    assert response.status_code == 302
+    assert Module.objects.all().count() == 1
+
+    # unpublish module
+    module.is_draft = True
+    module.save()
+
+    client.login(username=user2, password='password')
+    response = client.post(module_delete_url)
+    assert redirect_target(response) == 'project-edit'
+    assert Module.objects.all().count() == 0
+
+
+@pytest.mark.django_db
+def test_module_delete_redirect(client, module_factory, user2):
+    module = module_factory(is_draft=True)
+    organisation = module.project.organisation
+    organisation.initiators.add(user2)
+    module_2 = module_factory(project=module.project, is_draft=True)
+    module_3 = module_factory(project=module.project, is_draft=True)
+
+    module_delete_url = reverse('a4dashboard:module-delete', kwargs={
+        'slug': module.slug})
+    module_delete_url_2 = reverse('a4dashboard:module-delete', kwargs={
+        'slug': module_2.slug})
+    module_delete_url_3 = reverse('a4dashboard:module-delete', kwargs={
+        'slug': module_3.slug})
+
+    client.login(username=user2, password='password')
+
+    referrer = reverse('a4dashboard:dashboard-information-edit', kwargs={
+        'project_slug': module.project.slug})
+
+    response = client.post(module_delete_url, {'referrer': referrer})
+    assert response.status_code == 302
+    assert response['location'] == referrer
+
+    response = client.post(module_delete_url_2, {}, HTTP_REFERER=referrer)
+    assert response.status_code == 302
+    assert response['location'] == referrer
+
+    response = client.post(module_delete_url_3, {})
+    assert redirect_target(response) == 'project-edit'
+
+
+@pytest.mark.django_db
+def test_module_unsuccessful_delete_redirect(client, module_factory, user2):
+    module = module_factory(is_draft=False)
+    organisation = module.project.organisation
+    organisation.initiators.add(user2)
+
+    module_delete_url = reverse('a4dashboard:module-delete', kwargs={
+        'slug': module.slug})
+
+    client.login(username=user2, password='password')
+
+    referrer = reverse('a4dashboard:dashboard-information-edit', kwargs={
+        'project_slug': module.project.slug})
+
+    response = client.post(module_delete_url, {'referrer': referrer})
+    assert response.status_code == 302
+    assert response['location'] == referrer
+
+    response = client.post(module_delete_url, {}, HTTP_REFERER=referrer)
+    assert response.status_code == 302
+    assert response['location'] == referrer
+
+    response = client.post(module_delete_url, {})
     assert redirect_target(response) == 'project-edit'

--- a/tests/dashboard/test_dashboard_views_module_publish.py
+++ b/tests/dashboard/test_dashboard_views_module_publish.py
@@ -25,3 +25,115 @@ def test_module_publish_perms(client, phase, user, user2):
     client.login(username=user2, password='password')
     response = client.post(module_publish_url, data)
     assert redirect_target(response) == 'project-edit'
+
+
+@pytest.mark.django_db
+def test_module_publish(client, phase, user2):
+    module = phase.module
+    module.is_draft = True
+    module.description = ''
+    module.save()
+    organisation = module.project.organisation
+    organisation.initiators.add(user2)
+
+    module_publish_url = reverse('a4dashboard:module-publish', kwargs={
+        'module_slug': module.slug})
+
+    data = {'action': 'publish'}
+
+    # publishing incomplete modules has no effect
+    client.login(username=user2, password='password')
+    response = client.post(module_publish_url, data)
+    assert redirect_target(response) == 'project-edit'
+
+    module.refresh_from_db()
+    assert module.is_draft is True
+
+    # complete module and publish it
+    module.description = 'module description'
+    module.save()
+
+    client.login(username=user2, password='password')
+    response = client.post(module_publish_url, data)
+    assert redirect_target(response) == 'project-edit'
+
+    module.refresh_from_db()
+    assert module.is_draft is False
+
+
+@pytest.mark.django_db
+def test_module_unpublish(client, module_factory, user2):
+    module = module_factory()
+    module.is_draft = False
+    module.save()
+    project = module.project
+    project.is_draft = False
+    project.save()
+    organisation = project.organisation
+    organisation.initiators.add(user2)
+
+    module_publish_url = reverse('a4dashboard:module-publish', kwargs={
+        'module_slug': module.slug})
+
+    data = {'action': 'unpublish'}
+
+    # unpublishing modules from published projects has no effect
+    client.login(username=user2, password='password')
+    response = client.post(module_publish_url, data)
+    assert redirect_target(response) == 'project-edit'
+
+    module.refresh_from_db()
+    assert module.is_draft is False
+
+    # unpublish project
+    project.is_draft = True
+    project.save()
+
+    # unpublishing modules that are the single module to that project
+    # has no effect
+    client.login(username=user2, password='password')
+    response = client.post(module_publish_url, data)
+    assert redirect_target(response) == 'project-edit'
+
+    module.refresh_from_db()
+    assert module.is_draft is False
+
+    # add another published module
+    module_factory(project=project, is_draft=False)
+
+    client.login(username=user2, password='password')
+    response = client.post(module_publish_url, data)
+    assert redirect_target(response) == 'project-edit'
+
+    module.refresh_from_db()
+    assert module.is_draft is True
+
+    # unpublishing draft modules has no effect
+    client.login(username=user2, password='password')
+    response = client.post(module_publish_url, data)
+    assert redirect_target(response) == 'project-edit'
+
+    module.refresh_from_db()
+    assert module.is_draft is True
+
+
+@pytest.mark.django_db
+def test_module_publish_redirect(client, module, user2):
+    module_publish_url = reverse('a4dashboard:module-publish', kwargs={
+        'module_slug': module.slug})
+
+    organisation = module.project.organisation
+    organisation.initiators.add(user2)
+
+    client.login(username=user2, password='password')
+
+    response = client.post(module_publish_url, {'referrer': 'refurl'})
+    assert response.status_code == 302
+    assert response['location'] == 'refurl'
+
+    response = client.post(module_publish_url, {}, HTTP_REFERER='refurl')
+    assert response.status_code == 302
+    assert response['location'] == 'refurl'
+
+    response = client.post(module_publish_url, {})
+    assert redirect_target(response) == 'project-edit'

--- a/tests/plans/test_dashboard_views_publish.py
+++ b/tests/plans/test_dashboard_views_publish.py
@@ -1,0 +1,63 @@
+import pytest
+from django.urls import reverse
+
+from adhocracy4.test.helpers import redirect_target
+
+
+@pytest.mark.django_db
+def test_plan_publish_perms(client, plan, user, user2):
+    publish_url = reverse('a4dashboard:plan-publish', kwargs={
+        'pk': plan.pk})
+
+    data = {'action': 'publish'}
+
+    response = client.post(publish_url, data)
+    assert redirect_target(response) == 'account_login'
+
+    client.login(username=user, password='password')
+    response = client.post(publish_url, data)
+    assert response.status_code == 403
+
+    organisation = plan.organisation
+    organisation.initiators.add(user2)
+    client.login(username=user2, password='password')
+    response = client.post(publish_url, data)
+    assert redirect_target(response) == 'plan-update'
+
+
+@pytest.mark.django_db
+def test_plan_publish(client, plan_factory, user2):
+    plan = plan_factory(is_draft=True)
+    organisation = plan.organisation
+    organisation.initiators.add(user2)
+
+    publish_url = reverse('a4dashboard:plan-publish', kwargs={
+        'pk': plan.pk})
+
+    data = {'action': 'publish'}
+
+    client.login(username=user2, password='password')
+    response = client.post(publish_url, data)
+    assert redirect_target(response) == 'plan-update'
+
+    plan.refresh_from_db()
+    assert plan.is_draft is False
+
+
+@pytest.mark.django_db
+def test_plan_unpublish(client, plan_factory, user2):
+    plan = plan_factory(is_draft=False)
+    organisation = plan.organisation
+    organisation.initiators.add(user2)
+
+    publish_url = reverse('a4dashboard:plan-publish', kwargs={
+        'pk': plan.pk})
+
+    data = {'action': 'unpublish'}
+
+    client.login(username=user2, password='password')
+    response = client.post(publish_url, data)
+    assert redirect_target(response) == 'plan-update'
+
+    plan.refresh_from_db()
+    assert plan.is_draft is True


### PR DESCRIPTION
How to do the delete stuff, I found here: https://stackoverflow.com/questions/54467081/how-to-send-error-message-from-django-deleteview
To test the delete locally on the site instead of in the tests, change the [if around the module delete button](https://github.com/liqd/a4-meinberlin/blob/488edf5ecb1bee5be7067eb49211bf8a6277ef52/meinberlin/templates/a4dashboard/includes/nav_modules_item.html#L54) to `{% if True %}`