### PR TITLE
config/settings/base.py: rm embed from config of default ckeditor

### DIFF
--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -312,7 +312,6 @@ CKEDITOR_CONFIGS = {
             ['Bold', 'Italic', 'Underline'],
             ['NumberedList', 'BulletedList'],
             ['Link', 'Unlink'],
-            ['Embed', 'EmbedBase']
         ],
         'removePlugins': 'stylesheetparser',
         'extraAllowedContent': 'iframe[*]',


### PR DESCRIPTION
fixes #3878