### PR TITLE
[#4987]budgeting: add proposal serializer and api

### DIFF
--- a/meinberlin/apps/budgeting/api.py
+++ b/meinberlin/apps/budgeting/api.py
@@ -1,0 +1,29 @@
+from rest_framework import mixins
+from rest_framework import viewsets
+
+from adhocracy4.api.mixins import ModuleMixin
+from adhocracy4.api.permissions import ViewSetRulesPermission
+
+from .models import Proposal
+from .serializers import ProposalSerializer
+
+
+class ProposalViewSet(ModuleMixin,
+                      mixins.ListModelMixin,
+                      viewsets.GenericViewSet,
+                      ):
+
+    serializer_class = ProposalSerializer
+    permission_classes = (ViewSetRulesPermission,)
+
+    def get_permission_object(self):
+        return self.module
+
+    def get_queryset(self):
+        proposals = Proposal.objects\
+            .filter(module=self.module) \
+            .annotate_comment_count() \
+            .annotate_positive_rating_count() \
+            .annotate_negative_rating_count() \
+            .order_by('created')
+        return proposals

--- a/meinberlin/apps/budgeting/serializers.py
+++ b/meinberlin/apps/budgeting/serializers.py
@@ -1,0 +1,61 @@
+from rest_framework import serializers
+
+from adhocracy4.categories.models import Category
+
+from .models import Proposal
+
+
+class CategoryField(serializers.Field):
+
+    def to_internal_value(self, category):
+        if category:
+            return Category.objects.get(pk=category)
+        else:
+            return None
+
+    def to_representation(self, category):
+        return {'id': category.pk, 'name': category.name}
+
+
+class ProposalSerializer(serializers.ModelSerializer):
+
+    creator = serializers.SerializerMethodField()
+    comment_count = serializers.SerializerMethodField()
+    positive_rating_count = serializers.SerializerMethodField()
+    negative_rating_count = serializers.SerializerMethodField()
+    category = CategoryField()
+    url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Proposal
+        fields = ('budget', 'category', 'comment_count', 'created', 'creator',
+                  'is_archived', 'name', 'negative_rating_count',
+                  'positive_rating_count', 'url')
+        read_only_fields = ('budget', 'category', 'comment_count', 'created',
+                            'creator', 'is_archived', 'name',
+                            'negative_rating_count', 'positive_rating_count',
+                            'url')
+
+    def get_creator(self, proposal):
+        return proposal.creator.username
+
+    def get_comment_count(self, proposal):
+        if hasattr(proposal, 'comment_count'):
+            return proposal.comment_count
+        else:
+            return 0
+
+    def get_positive_rating_count(self, proposal):
+        if hasattr(proposal, 'positive_rating_count'):
+            return proposal.positive_rating_count
+        else:
+            return 0
+
+    def get_negative_rating_count(self, proposal):
+        if hasattr(proposal, 'negative_rating_count'):
+            return proposal.negative_rating_count
+        else:
+            return 0
+
+    def get_url(self, proposal):
+        return proposal.get_absolute_url()

--- a/meinberlin/config/urls.py
+++ b/meinberlin/config/urls.py
@@ -23,6 +23,7 @@ from adhocracy4.polls.routers import QuestionDefaultRouter
 from adhocracy4.ratings.api import RatingViewSet
 from adhocracy4.reports.api import ReportViewSet
 from meinberlin.apps.bplan.api import BplanViewSet
+from meinberlin.apps.budgeting.api import ProposalViewSet
 from meinberlin.apps.contrib import views as contrib_views
 from meinberlin.apps.contrib.sitemaps.adhocracy4_sitemap import \
     Adhocracy4Sitemap
@@ -60,6 +61,7 @@ module_router = a4routers.ModuleDefaultRouter()
 # FIXME: rename to 'chapters'
 module_router.register(r'documents', DocumentViewSet, basename='chapters')
 module_router.register(r'questions', LiveQuestionViewSet, basename='questions')
+module_router.register(r'proposals', ProposalViewSet, basename='proposals')
 
 likes_router = LikesDefaultRouter()
 likes_router.register(r'likes', LikesViewSet, basename='likes')


### PR DESCRIPTION
The url to get the proposals is `reverse('proposals-list', kwargs={'module_pk': $module_pk})` or `/api/modules/$module_pk/proposals/` which we then probably need to add to context of ProposalListView