### PR TITLE
apps/contrib: make sure ordering filter also works on annotated field…

### DIFF
--- a/meinberlin/apps/budgeting/views.py
+++ b/meinberlin/apps/budgeting/views.py
@@ -6,7 +6,6 @@ from adhocracy4.categories import filters as category_filters
 from adhocracy4.exports.views import DashboardExportView
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.projects.mixins import DisplayProjectOrModuleMixin
-from meinberlin.apps.contrib import filters
 from meinberlin.apps.ideas import views as idea_views
 from meinberlin.apps.projects.views import ArchivedWidget
 from meinberlin.apps.votes.forms import TokenForm
@@ -29,7 +28,7 @@ class ProposalFilterSet(a4_filters.DefaultsFilterSet):
         'is_archived': 'false'
     }
     category = category_filters.CategoryFilter()
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=get_ordering_choices
     )
     is_archived = django_filters.BooleanFilter(
@@ -54,10 +53,7 @@ class ProposalListView(idea_views.AbstractIdeaListView,
 
     def get_queryset(self):
         return super().get_queryset()\
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
     def get_context_data(self, **kwargs):
         if 'token_form' not in kwargs:

--- a/meinberlin/apps/contrib/filters.py
+++ b/meinberlin/apps/contrib/filters.py
@@ -1,25 +1,4 @@
-from django.utils.translation import gettext_lazy as _
 from rest_framework.filters import BaseFilterBackend
-
-from adhocracy4.filters.filters import DistinctOrderingFilter
-from adhocracy4.filters.widgets import DropdownLinkWidget
-
-from . import mixins
-
-
-class OrderingWidget(DropdownLinkWidget):
-    label = _('Ordering')
-    right = True
-
-
-class OrderingFilter(mixins.DynamicChoicesMixin,
-                     DistinctOrderingFilter):
-
-    def __init__(self, *args, **kwargs):
-        if 'widget' not in kwargs:
-            kwargs['widget'] = OrderingWidget
-        kwargs['empty_label'] = None
-        super().__init__(*args, **kwargs)
 
 
 class IdeaCategoryFilterBackend(BaseFilterBackend):

--- a/meinberlin/apps/contrib/mixins.py
+++ b/meinberlin/apps/contrib/mixins.py
@@ -8,39 +8,6 @@ RIGHT_OF_USE_LABEL = _('I hereby confirm that the copyrights for this '
                        'are not violated. ')
 
 
-class DynamicChoicesMixin(object):
-    """Dynamic choices mixin.
-
-    Add callable functionality to filters that support the ``choices``
-    argument. If the ``choices`` is callable, then it **must** accept the
-    ``view`` object as a single argument.
-    The ``view`` object may be None if the parent FilterSet is not class based.
-
-    This is useful for dymanic ``choices`` determined properties on the
-    ``view`` object.
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.choices = kwargs.pop('choices')
-        super().__init__(*args, **kwargs)
-
-    def get_choices(self, view):
-        choices = self.choices
-
-        if callable(choices):
-            return choices(view)
-        return choices
-
-    @property
-    def field(self):
-        choices = self.get_choices(getattr(self, 'view', None))
-
-        if choices is not None:
-            self.extra['choices'] = choices
-
-        return super(DynamicChoicesMixin, self).field
-
-
 class ImageRightOfUseMixin(forms.ModelForm):
     right_of_use = forms.BooleanField(required=False, label=RIGHT_OF_USE_LABEL)
 

--- a/meinberlin/apps/ideas/views.py
+++ b/meinberlin/apps/ideas/views.py
@@ -13,7 +13,6 @@ from adhocracy4.filters.filters import FreeTextFilter
 from adhocracy4.projects.mixins import DisplayProjectOrModuleMixin
 from adhocracy4.projects.mixins import ProjectMixin
 from adhocracy4.rules import mixins as rules_mixins
-from meinberlin.apps.contrib import filters
 from meinberlin.apps.contrib import forms as contrib_forms
 from meinberlin.apps.contrib.views import CanonicalURLDetailView
 from meinberlin.apps.moderatorfeedback.forms import ModeratorStatementForm
@@ -42,7 +41,7 @@ class IdeaFilterSet(a4_filters.DefaultsFilterSet):
         'ordering': '-created'
     }
     category = category_filters.CategoryFilter()
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=get_ordering_choices
     )
     search = FreeTextFilter(
@@ -68,10 +67,7 @@ class IdeaListView(AbstractIdeaListView,
 
     def get_queryset(self):
         return super().get_queryset()\
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
 
 class AbstractIdeaDetailView(ProjectMixin,

--- a/meinberlin/apps/kiezkasse/views.py
+++ b/meinberlin/apps/kiezkasse/views.py
@@ -5,7 +5,6 @@ from adhocracy4.categories import filters as category_filters
 from adhocracy4.exports.views import DashboardExportView
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.projects.mixins import DisplayProjectOrModuleMixin
-from meinberlin.apps.contrib import filters
 from meinberlin.apps.ideas import views as idea_views
 
 from . import forms
@@ -25,7 +24,7 @@ class ProposalFilterSet(a4_filters.DefaultsFilterSet):
         'ordering': '-created'
     }
     category = category_filters.CategoryFilter()
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=get_ordering_choices
     )
 
@@ -48,10 +47,7 @@ class ProposalListView(idea_views.AbstractIdeaListView,
 
     def get_queryset(self):
         return super().get_queryset() \
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
 
 class ProposalDetailView(idea_views.AbstractIdeaDetailView):

--- a/meinberlin/apps/mapideas/views.py
+++ b/meinberlin/apps/mapideas/views.py
@@ -5,7 +5,6 @@ from adhocracy4.categories import filters as category_filters
 from adhocracy4.exports.views import DashboardExportView
 from adhocracy4.filters import filters as a4_filters
 from adhocracy4.projects.mixins import DisplayProjectOrModuleMixin
-from meinberlin.apps.contrib import filters
 from meinberlin.apps.ideas import views as idea_views
 
 from . import forms
@@ -25,7 +24,7 @@ class MapIdeaFilterSet(a4_filters.DefaultsFilterSet):
         'ordering': '-created'
     }
     category = category_filters.CategoryFilter()
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=get_ordering_choices
     )
 
@@ -47,10 +46,7 @@ class MapIdeaListView(idea_views.AbstractIdeaListView,
 
     def get_queryset(self):
         return super().get_queryset()\
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
 
 class MapIdeaDetailView(idea_views.AbstractIdeaDetailView):

--- a/meinberlin/apps/maptopicprio/views.py
+++ b/meinberlin/apps/maptopicprio/views.py
@@ -8,7 +8,6 @@ from adhocracy4.filters import filters as a4_filters
 from adhocracy4.filters import views as filter_views
 from adhocracy4.projects.mixins import DisplayProjectOrModuleMixin
 from adhocracy4.projects.mixins import ProjectMixin
-from meinberlin.apps.contrib import filters
 from meinberlin.apps.ideas import views as idea_views
 
 from . import forms
@@ -28,7 +27,7 @@ class MapTopicFilterSet(a4_filters.DefaultsFilterSet):
         'ordering': '-created'
     }
     category = category_filters.CategoryFilter()
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=get_ordering_choices
     )
 
@@ -45,7 +44,7 @@ class MapTopicCreateFilterSet(a4_filters.DefaultsFilterSet):
 
     category = category_filters.CategoryFilter()
 
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=(
             ('name', _('Alphabetical')),
         )
@@ -76,10 +75,7 @@ class MapTopicListView(idea_views.AbstractIdeaListView,
 
     def get_queryset(self):
         return super().get_queryset()\
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
 
 class MapTopicListDashboardView(ProjectMixin,
@@ -93,10 +89,7 @@ class MapTopicListDashboardView(ProjectMixin,
 
     def get_queryset(self):
         return super().get_queryset()\
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
     def get_permission_object(self):
         return self.project

--- a/meinberlin/apps/topicprio/views.py
+++ b/meinberlin/apps/topicprio/views.py
@@ -10,7 +10,6 @@ from adhocracy4.filters import widgets as filters_widgets
 from adhocracy4.filters.filters import FreeTextFilter
 from adhocracy4.projects.mixins import DisplayProjectOrModuleMixin
 from adhocracy4.projects.mixins import ProjectMixin
-from meinberlin.apps.contrib import filters
 from meinberlin.apps.ideas import views as idea_views
 
 from . import forms
@@ -26,7 +25,7 @@ class TopicFilterSet(a4_filters.DefaultsFilterSet):
         'ordering': 'name'
     }
     category = category_filters.CategoryFilter()
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=(
             ('name', _('Alphabetical')),
             ('-positive_rating_count', _('Most popular')),
@@ -50,10 +49,7 @@ class TopicListView(idea_views.AbstractIdeaListView,
 
     def get_queryset(self):
         return super().get_queryset()\
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
 
 class TopicDetailView(idea_views.AbstractIdeaDetailView):
@@ -71,7 +67,7 @@ class TopicCreateFilterSet(a4_filters.DefaultsFilterSet):
 
     category = category_filters.CategoryFilter()
 
-    ordering = filters.OrderingFilter(
+    ordering = a4_filters.DynamicChoicesOrderingFilter(
         choices=(
             ('name', _('Alphabetical')),
         )
@@ -93,10 +89,7 @@ class TopicListDashboardView(ProjectMixin,
 
     def get_queryset(self):
         return super().get_queryset()\
-            .filter(module=self.module) \
-            .annotate_positive_rating_count() \
-            .annotate_negative_rating_count() \
-            .annotate_comment_count()
+            .filter(module=self.module)
 
     def get_permission_object(self):
         return self.project

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@testing-library/react-native": "^8.0.0",
     "acorn": "8.6.0",
-    "adhocracy4": "liqd/adhocracy4#447210dd1fb6204bdc75261c1bfaa62de4dee3b6",
+    "adhocracy4": "liqd/adhocracy4#83a7756ffbec42b5afac595073816aeaf0d930bf",
     "autoprefixer": "10.4.0",
     "axios": "0.24.0",
     "babel-loader": "8.2.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@447210dd1fb6204bdc75261c1bfaa62de4dee3b6#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@83a7756ffbec42b5afac595073816aeaf0d930bf#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0


### PR DESCRIPTION
…s comment_count and positive_rating_count

fixes #3976
I checked all views using the contrib OrderingFilter: the positive rating and the comment count are the only annotated fields used for ordering

Maybe this should go into a4? But then we would need to check all projects for the use of annotated fields for ordering and add these.
And I am not sure, if we should open a Django bug. It used to work and does not seem like a very off-usecase. (On the other hand the distinct ordering is also not an off usecase and did not make it into django-filters.)