### PR TITLE
meinberlin/templates: added general error message on top of all forms

### DIFF
--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_create_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_create_form.html
@@ -17,6 +17,10 @@
 
         <h1>{% trans 'Submit a new proposal for this project'%}</h1>
 
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         {% include "meinberlin_budgeting/includes/proposal_form.html" with proposal=proposal cancel=module.get_detail_url %}
     </div>
 </div>

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_update_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_update_form.html
@@ -23,6 +23,10 @@
 
         <h1>{% trans 'Edit proposal' %}</h1>
 
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         {% include "meinberlin_budgeting/includes/proposal_form.html" with proposal=proposal cancel=object.get_absolute_url %}
     </div>
 </div>

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_create_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_create_form.html
@@ -17,6 +17,11 @@
         </nav>
 
         <h1>{% trans 'Submit a new idea for this project'%}</h1>
+
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         <div class="u-bottom-divider">
             <h3>{{ module.name }}</h3>
             {% if module.description %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_update_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_update_form.html
@@ -23,6 +23,10 @@
 
         <h1>{% trans 'Edit idea' %}</h1>
 
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         {% include "meinberlin_ideas/includes/idea_form.html" with idea=idea cancel=object.get_absolute_url %}
     </div>
 </div>

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_create_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_create_form.html
@@ -17,6 +17,10 @@
 
         <h1>{% trans 'Submit a new proposal for this project'%}</h1>
 
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         {% include "meinberlin_kiezkasse/includes/proposal_form.html" with proposal=proposal cancel=module.get_detail_url %}
     </div>
 </div>

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_update_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_update_form.html
@@ -23,6 +23,10 @@
 
         <h1>{% trans 'Edit proposal' %}</h1>
 
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         {% include "meinberlin_kiezkasse/includes/proposal_form.html" with proposal=proposal cancel=object.get_absolute_url %}
     </div>
 </div>

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_create_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_create_form.html
@@ -16,6 +16,11 @@
         </nav>
 
         <h1>{% trans 'Submit a new idea for this project'%}</h1>
+
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         <div class="u-bottom-divider">
             <h3>{{ module.name }}</h3>
             {% if module.description %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_update_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_update_form.html
@@ -23,6 +23,10 @@
 
         <h1>{% trans 'Edit idea' %}</h1>
 
+        {% if form.errors %}
+            <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+        {% endif %}
+
         {% include "meinberlin_mapideas/includes/mapidea_form.html" with cancel=object.get_absolute_url %}
     </div>
 </div>

--- a/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_create_form.html
+++ b/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_create_form.html
@@ -7,6 +7,10 @@
 <div class="l-wrapper">
     <h1 class="u-first-heading">{% trans 'Add a new place'%}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% url 'a4dashboard:maptopic-list' module_slug=module.slug as cancel %}
     {% include "meinberlin_maptopicprio/includes/maptopic_form.html" with cancel=cancel %}
 </div>

--- a/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_update_form.html
+++ b/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_update_form.html
@@ -7,6 +7,10 @@
 <div class="l-wrapper">
     <h1 class="u-first-heading">{% trans 'Edit place' %}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% url 'a4dashboard:maptopic-list' module_slug=module.slug as cancel %}
     {% include "meinberlin_maptopicprio/includes/maptopic_form.html" with cancel=cancel %}
 </div>

--- a/meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_create_form.html
+++ b/meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_create_form.html
@@ -6,6 +6,10 @@
 <div class="l-wrapper">
     <h1 class="u-first-heading">{% trans 'Add a new offline event'%}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% url 'a4dashboard:offlineevent-list' project_slug=project.slug as cancel %}
     {% include "meinberlin_offlineevents/includes/offlineevent_form.html" with cancel=cancel %}
 </div>

--- a/meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_update_form.html
+++ b/meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/offlineevent_update_form.html
@@ -7,6 +7,10 @@
 <div class="l-wrapper">
     <h1 class="u-first-heading">{% trans 'Edit offline event' %}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% url 'a4dashboard:offlineevent-list' project_slug=project.slug as cancel %}
     {% include "meinberlin_offlineevents/includes/offlineevent_form.html" with cancel=cancel %}
 </div>

--- a/meinberlin/apps/plans/templates/meinberlin_plans/includes/plan_form.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/includes/plan_form.html
@@ -3,6 +3,10 @@
     {% csrf_token %}
     {{ form.media }}
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     <h2 class="form__subheading"> {% trans 'Description of the plan' %}</h2>
     <p class="form-hint form-hint--margin">
         {% trans 'The description of the plan is divided into title, profile, header image and description text.' %}

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_create_form.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_create_form.html
@@ -7,6 +7,10 @@
 <div class="l-wrapper">
     <h1 class="u-first-heading">{% trans 'Add a new topic'%}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% url 'a4dashboard:topic-list' module_slug=module.slug as cancel %}
     {% include "meinberlin_topicprio/includes/topic_form.html" with cancel=cancel %}
 </div>

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_update_form.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_update_form.html
@@ -7,6 +7,10 @@
 <div class="l-wrapper">
     <h1 class="u-first-heading">{% trans 'Edit topic' %}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% url 'a4dashboard:topic-list' module_slug=module.slug as cancel %}
     {% include "meinberlin_topicprio/includes/topic_form.html" with cancel=cancel %}
 </div>

--- a/meinberlin/templates/a4dashboard/base_form_module.html
+++ b/meinberlin/templates/a4dashboard/base_form_module.html
@@ -6,6 +6,10 @@
 {% block dashboard_project_content %}
     <h1 class="u-first-heading">{{ view.title }}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% for error in form.non_field_errors %}
         <span>{{ error }}</span>
     {% endfor %}

--- a/meinberlin/templates/a4dashboard/base_form_project.html
+++ b/meinberlin/templates/a4dashboard/base_form_project.html
@@ -6,6 +6,10 @@
 {% block dashboard_project_content %}
     <h1 class="u-first-heading">{{ view.title }}</h1>
 
+    {% if form.errors %}
+        <div class="errorlist">{% trans 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
+
     {% for error in form.non_field_errors %}
         <span>{{ error }}</span>
     {% endfor %}


### PR DESCRIPTION
A general error message at the top of the form was added to all the forms **except** the Bplans, because this form doesn't use the errorlist box on fields:
![image](https://user-images.githubusercontent.com/17978375/143443136-41bcab91-ea1a-4de6-92f3-fef7a32eaf3c.png)

, but instead the 'Missing field for publication'-icons: 
![image](https://user-images.githubusercontent.com/17978375/143443366-ecc9aa55-441a-4b46-939b-fdfa8fde995d.png)

This solution is based on the a+ use of the top error fields with the exception of the ideas form, which has a missing top error message:

![2021-11-25Missing_upper_error_message_a+](https://user-images.githubusercontent.com/17978375/143443559-6336de4f-d507-4d1c-b1fb-17cf4c2b897a.png)

The mB idea form has this missing message.

**QUESTION**: does this implementation make sense? It seems there are about 3 different ways that error messages are displayed for the user in mB.

This PR still needs translation once everything else is reviewed.