### PR TITLE
meinberlin/apps/bplan: added start and enddate of plan to required fo…

### DIFF
--- a/meinberlin/apps/bplan/forms.py
+++ b/meinberlin/apps/bplan/forms.py
@@ -28,7 +28,8 @@ class BplanProjectForm(ExternalProjectForm):
                   'tile_image_copyright', 'is_archived', 'office_worker_email',
                   'start_date', 'end_date']
         required_for_project_publish = ['name', 'url', 'description',
-                                        'office_worker_email']
+                                        'office_worker_email',
+                                        'start_date', 'end_date']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
…r publication

fixes #3991

In Bplans the required field start-date & end-date of project are not marked as required for publication:
![Untitled](https://user-images.githubusercontent.com/17978375/143890456-786b2f26-862f-4754-8808-03a9bf0cac0c.png)

see also [bplan form on DEV](https://meinberlin-dev.liqd.net/dashboard/projects/sabinas-bebauungsplan/bplan/)

So that the form_field.html in the a4dashboard can render these accordingly, these fields need to be added to the form meta class of bplans.
