### PR TITLE
meinberlin/apps/ideas and /contrib: added last edited text and date t…

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -50,7 +50,7 @@
             <div class="item-detail__meta lr-bar">
                 <div class="lr-bar__left">
                     <strong class="item-detail__creator">{{ object.creator.username }}</strong>
-                    {% html_date object.created %}
+                    {% trans 'updated on ' %}{% if object.modified %}{{ object.modified|date }}{% else %}{{ object.created|date }}{% endif %}
                 </div>
                 <div class="lr-bar__right">
                     <strong>{% trans 'Reference No.' %}:</strong>

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -40,5 +40,5 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    {% html_date object.created class='list-item__date' %}
+    {% trans 'updated on ' %}{% if object.modified %}{{ object.modified|date }}{% else %}{{ object.created|date }}{% endif %}
 </li>


### PR DESCRIPTION
…o idea detail and list

**Notes and questions:**
1. The wording is based on the wording in the plan detail page, i.e. it always says "edited on [Date]" even if it has just been created. 

@fuzzylogic2000 Should this be different here maybe, i.e. switch to _created_ instead of _edited_ or is it more important that it's consistently the same as in plans? Maybe a question for Caro before it is implemented everywhere.

2. This change of the item-detail affects the map-idea detail, idea-detail, and maptopic detail pages. While the list item of the plain idea already has the change, the other list items do not.