### PR TITLE
apps/budgeting: add ordering filter to API

### DIFF
--- a/meinberlin/apps/budgeting/api.py
+++ b/meinberlin/apps/budgeting/api.py
@@ -1,5 +1,7 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins
 from rest_framework import viewsets
+from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination
 
 from adhocracy4.api.mixins import ModuleMixin
@@ -29,6 +31,12 @@ class ProposalViewSet(ModuleMixin,
     pagination_class = BudgetPagination
     serializer_class = ProposalSerializer
     permission_classes = (ViewSetRulesPermission,)
+    filter_backends = (DjangoFilterBackend,
+                       OrderingFilter,)
+    # filter_fields = ('is_archived',)
+    ordering_fields = ('created',
+                       'comment_count',
+                       'positive_rating_count',)
 
     def get_permission_object(self):
         return self.module


### PR DESCRIPTION
to get the same results as in the original list, please add
ordering=-created or ordering=-comment_count or ordering=-positive_rating_count
as parameter to the API url.

You can already merge and use this. I will open a new PR for the other filter stuff, because I have to fix all the rest API filtering where we use `filter_fields`.