### PR TITLE
meinberlin/apps/contrib /ideas /mapideas: added updated and created t…

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html
@@ -43,5 +43,5 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    {% html_date object.created class='list-item__date' %}
+    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
 </li>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -50,7 +50,7 @@
             <div class="item-detail__meta lr-bar">
                 <div class="lr-bar__left">
                     <strong class="item-detail__creator">{{ object.creator.username }}</strong>
-                    {% trans 'updated on ' %}{% if object.modified %}{{ object.modified|date }}{% else %}{{ object.created|date }}{% endif %}
+                    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
                 </div>
                 <div class="lr-bar__right">
                     <strong>{% trans 'Reference No.' %}:</strong>

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -40,5 +40,5 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    {% trans 'updated on ' %}{% if object.modified %}{{ object.modified|date }}{% else %}{{ object.created|date }}{% endif %}
+    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
 </li>

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
@@ -42,5 +42,5 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    {% html_date object.created class='list-item__date' %}
+    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
 </li>

--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -89,7 +89,7 @@
 
                         <dl>
                             <dt>{% trans 'Reference No.' %}</dt>
-                            <dd>{{ object.reference_number }}, {% trans 'updated on ' %}{% if object.modified %}{{ object.modified|date }}{% else %}{{ object.created|date }}{% endif %}</dd>
+                            <dd>{{ object.reference_number }}, {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}</dd>
                         </dl>
                     </ul>
                     {% if object.description_image %}


### PR DESCRIPTION
…ext to ideas and proposals

To-do/check:

- [x] Budgeting proposal list item only in jsx ==> after merging new main, it's also in list view
- [x] published plans cannot show date created. They show modified as soon as they are published ==> date created also shown in draft for completeness

**1st commit:**
Ideas for the following modules now have date created & date modified:

- **Kiezkasse**
- **Brainstorming with map**
- **Brainstorming**
- **Idea collection**
- **Idea collection with map**
- **Bürger*innenhaushalt/Budget Proposals** (1/2/3 Phases)
- **Plans** in draft (created date if not modified), modified date in published

Needed for Finalization:

Requested feedback from design on whether the have the referenz number on the left side when it overlaps with the date when screen is small:
normal:
![image](https://user-images.githubusercontent.com/17978375/144448551-22ce6836-6f3d-41a9-bc5c-27861a5fa59b.png)

small:
![image](https://user-images.githubusercontent.com/17978375/144448424-39fafbe8-86e1-4636-a69e-d143887f0e70.png)
