### PR TITLE
Kl 2021 11 more propsal api filters

### DIFF
--- a/meinberlin/apps/budgeting/api.py
+++ b/meinberlin/apps/budgeting/api.py
@@ -6,6 +6,7 @@ from rest_framework.pagination import PageNumberPagination
 
 from adhocracy4.api.mixins import ModuleMixin
 from adhocracy4.api.permissions import ViewSetRulesPermission
+from meinberlin.apps.contrib.filters import IdeaCategoryFilterBackend
 
 from .models import Proposal
 from .serializers import ProposalSerializer
@@ -32,8 +33,9 @@ class ProposalViewSet(ModuleMixin,
     serializer_class = ProposalSerializer
     permission_classes = (ViewSetRulesPermission,)
     filter_backends = (DjangoFilterBackend,
-                       OrderingFilter,)
-    # filter_fields = ('is_archived',)
+                       OrderingFilter,
+                       IdeaCategoryFilterBackend,)
+    filter_fields = ('is_archived', 'category',)
     ordering_fields = ('created',
                        'comment_count',
                        'positive_rating_count',)

--- a/meinberlin/apps/contrib/filters.py
+++ b/meinberlin/apps/contrib/filters.py
@@ -1,4 +1,5 @@
 from django.utils.translation import gettext_lazy as _
+from rest_framework.filters import BaseFilterBackend
 
 from adhocracy4.filters.filters import DistinctOrderingFilter
 from adhocracy4.filters.widgets import DropdownLinkWidget
@@ -19,3 +20,15 @@ class OrderingFilter(mixins.DynamicChoicesMixin,
             kwargs['widget'] = OrderingWidget
         kwargs['empty_label'] = None
         super().__init__(*args, **kwargs)
+
+
+class IdeaCategoryFilterBackend(BaseFilterBackend):
+    """Filter ideas for the categories in API."""
+
+    def filter_queryset(self, request, queryset, view):
+
+        if 'category' in request.GET:
+            category = request.GET['category']
+            return queryset.filter(category=category)
+
+        return queryset

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -52,18 +52,19 @@ INSTALLED_APPS = (
     'wagtail.core',
     'wagtail.contrib.styleguide',
 
-    'taggit',  # wagtail dependency
-    'widget_tweaks',
-    'rest_framework',
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-    'rules.apps.AutodiscoverRulesConfig',
-    'easy_thumbnails',
+    'background_task',
+    'capture_tag',
     'ckeditor',
     'ckeditor_uploader',
-    'capture_tag',
-    'background_task',
+    'django_filters',
+    'easy_thumbnails',
+    'rest_framework',
+    'rules.apps.AutodiscoverRulesConfig',
+    'taggit',  # wagtail dependency
+    'widget_tweaks',
 
     'adhocracy4.actions',
     'adhocracy4.administrative_districts',


### PR DESCRIPTION
This does the filtering. But we need to know which categories to display (and their icons). 
What is the best way to add that? I think previously we either added that to the template tag or to the serializer. But I guess the best option would be to add it to the response.data of the API, which should be possible? What do you think @Rineee ?