### PR TITLE
Ks 2021 11 add token form to proposal list view

### DIFF
--- a/meinberlin/apps/budgeting/rules.py
+++ b/meinberlin/apps/budgeting/rules.py
@@ -1,6 +1,7 @@
 import rules
 
 from adhocracy4.modules import predicates as module_predicates
+from adhocracy4.phases import predicates as phase_predicates
 
 from . import models
 
@@ -37,4 +38,9 @@ rules.add_perm(
     'meinberlin_budgeting.moderate_proposal',
     module_predicates.is_context_moderator |
     module_predicates.is_context_initiator
+)
+
+rules.add_perm(
+    'meinberlin_budgeting.vote_proposal',
+    phase_predicates.phase_allows_vote(models.Proposal)
 )

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -1,5 +1,5 @@
 {% extends extends %}
-{% load i18n discovery_tags static maps_tags react_proposals %}
+{% load i18n discovery_tags static maps_tags react_proposals widget_tweaks rules %}
 
 {% block extra_js %}
     <script type="text/javascript" src="{% static 'a4maps_display_points.js' %}"></script>
@@ -17,6 +17,23 @@
         <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="btn btn--full u-spacer-bottom btn--huge">
             {% trans 'Submit proposal' %}
         </a>
+    {% endif %}
+    {% has_perm 'meinberlin_budgeting.vote_proposal' request.user module as vote_allowed %}
+    {% if vote_allowed %}
+        {% if request.session.voting_token %}
+            You are using token {{ request.session.voting_token }}
+        {% else %}
+            <form class="" action="{{ request.path }}" method="post">
+                <div class="form-group">
+                    {% csrf_token %}
+                    <div class="widget widget--{{ form.token|widget_type }}">
+                        {{ token_form.token }}
+                    </div>
+                    {{ token_form.token.errors }}
+                    <button type="submit" class="btn btn--full u-spacer-bottom btn--huge">{% trans 'Enter code' %}</button>
+                </div>
+            </form>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/meinberlin/apps/budgeting/templatetags/react_proposals.py
+++ b/meinberlin/apps/budgeting/templatetags/react_proposals.py
@@ -4,14 +4,21 @@ from django import template
 from django.urls import reverse
 from django.utils.html import format_html
 
+from adhocracy4.phases.predicates import has_feature_active
+from meinberlin.apps.budgeting.models import Proposal
+
 register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def react_proposals(context, obj):
-    proposals_api_url = reverse('proposals-list', kwargs={'module_pk': obj.pk})
+def react_proposals(context, module):
+    proposals_api_url = reverse('proposals-list',
+                                kwargs={'module_pk': module.pk})
     attributes = {'proposals_api_url': proposals_api_url,
-                  'is_voting_phase': 'voting' in obj.active_phase.type}
+                  'is_voting_phase': has_feature_active(module,
+                                                        Proposal,
+                                                        'vote')
+                  }
 
     return format_html(
         '<div data-mb-widget="proposals" '

--- a/meinberlin/apps/votes/forms.py
+++ b/meinberlin/apps/votes/forms.py
@@ -1,0 +1,25 @@
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from meinberlin.apps.votes.models import VotingToken
+
+
+class TokenForm(forms.Form):
+
+    token = forms.CharField(max_length=40)
+
+    def __init__(self, *args, **kwargs):
+        self.module_id = kwargs.pop('module_id')
+        super().__init__(*args, **kwargs)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if 'token' in self.cleaned_data:
+            token_queryset = VotingToken.objects.filter(
+                token=self.cleaned_data['token'],
+                module_id=self.module_id
+            )
+            if not token_queryset:
+                self.add_error('token', _('This token is not valid'))
+
+        return cleaned_data

--- a/meinberlin/apps/votes/models.py
+++ b/meinberlin/apps/votes/models.py
@@ -1,4 +1,5 @@
 import secrets
+import string
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -13,7 +14,8 @@ from adhocracy4.phases.predicates import has_feature_active
 
 
 def get_token():
-    return secrets.token_urlsafe(16)
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for i in range(12))
 
 
 class VotingToken(models.Model):
@@ -77,6 +79,11 @@ class VotingToken(models.Model):
 
     def is_valid_for_item(self, item):
         return item.module == self.module and self.is_valid(item.__class__)
+
+    def __str__(self):
+        return '{}-{}-{}'.format(self.token[0:4],
+                                 self.token[4:8],
+                                 self.token[8:12])
 
 
 class TokenVote(base.TimeStampedModel):

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@testing-library/react-native": "^8.0.0",
     "acorn": "8.6.0",
-    "adhocracy4": "liqd/adhocracy4#9f13ad262c2286db31c6ec095a49ee3a819fd1c7",
+    "adhocracy4": "liqd/adhocracy4#447210dd1fb6204bdc75261c1bfaa62de4dee3b6",
     "autoprefixer": "10.4.0",
     "axios": "0.24.0",
     "babel-loader": "8.2.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@9f13ad262c2286db31c6ec095a49ee3a819fd1c7#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@447210dd1fb6204bdc75261c1bfaa62de4dee3b6#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0


### PR DESCRIPTION
This adds a form for the voting token to the proposal list. When the token is there, it simply displayed for now, we will then need a react component for showing the left votes (I will next add that to the api). 
Oh, and we also need a widget for the token, so that it can be entered with 3 x 4 characters.