### PR TITLE
assets/js: fix initialisation of blueprint-picker - fixes #4022

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,7 +47,10 @@ module.exports = {
     // these do not rely on adhocracy and adding the depend causes console error
     // error possibly due to needing to be loaded at specific time
     blueprint_picker: {
-      import: './meinberlin/assets/js/blueprint-picker.js'
+      import: [
+        './meinberlin/assets/js/blueprint-picker.js'
+      ],
+      dependOn: 'adhocracy4'
     },
     documents: {
       import: './meinberlin/apps/documents/assets/react_documents_init.js'


### PR DESCRIPTION
I could not figure out, why it needs adhocracy4 as dependency. Maybe because otherwise jQuery is not there? But the unload warning works without it...