### PR TITLE
apps/votes: added widget to voting form

### DIFF
--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -32,11 +32,11 @@
                 <form class="" action="{{ request.path }}" method="post">
                     <div class="form-group">
                         {% csrf_token %}
-                        <div class="widget widget--{{ form.token|widget_type }}">
+                        <div class="widget--{{ token_form.token|widget_type }}">
                             {{ token_form.token }}
+                            <button type="submit" class="btn">{% trans 'Enter code' %}</button>
                         </div>
                         {{ token_form.token.errors }}
-                        <button type="submit" class="btn btn--full u-spacer-bottom btn--huge">{% trans 'Enter code' %}</button>
                     </div>
                 </form>
             {% endif %}

--- a/meinberlin/apps/votes/forms.py
+++ b/meinberlin/apps/votes/forms.py
@@ -4,9 +4,31 @@ from django.utils.translation import gettext_lazy as _
 from meinberlin.apps.votes.models import VotingToken
 
 
-class TokenForm(forms.Form):
+class VotingTokenWidget(forms.MultiWidget):
 
-    token = forms.CharField(max_length=40)
+    def __init__(self, attrs=None):
+        widgets = (
+            forms.TextInput(attrs={'minlength': '4',
+                                   'maxlength': '4'}),
+            forms.TextInput(attrs={'minlength': '4',
+                                   'maxlength': '4'}),
+            forms.TextInput(attrs={'minlength': '4',
+                                   'maxlength': '4'}),
+        )
+        super(VotingTokenWidget, self).__init__(widgets, attrs)
+
+    def decompress(self, value):
+        if value:
+            return [value[i:i + 4] for i in range(0, len(value), 4)]
+        return [None, None, None]
+
+    def value_from_datadict(self, data, files, name):
+        values = super().value_from_datadict(data, files, name)
+        return "".join(values)
+
+
+class TokenForm(forms.Form):
+    token = forms.CharField(widget=VotingTokenWidget())
 
     def __init__(self, *args, **kwargs):
         self.module_id = kwargs.pop('module_id')

--- a/meinberlin/assets/scss/_form.scss
+++ b/meinberlin/assets/scss/_form.scss
@@ -137,3 +137,17 @@ div.cke_focus {
         margin-right: 0.5 * $em-spacer;
     }
 }
+
+.widget--votingtokenwidget {
+    input {
+        margin-bottom: $spacer;
+    }
+
+    @media screen and (min-width: $breakpoint-xs) {
+        display: flex;
+
+        input {
+            margin-right: $spacer;
+        }
+    }
+}


### PR DESCRIPTION
This produces three instead of one input field for the voting token. Each field requires 4 characters.

Still to do

- [x] Form styling 
- [x] The form validation is in contradiction and requires changes, see https://github.com/liqd/a4-meinberlin/pull/4033#discussion_r763040554

@phillimorland would you check out the styling when you get the chance? 
@Rineee I added comments for the form validation that I can't get to work well, maybe you can check if you have time? I think the decompress and value_from_dict functions work.