### PR TITLE
apps/projects plans /contrib /ideas /mapideas /cms: added missing html_tag for…

### DIFF
--- a/meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html
+++ b/meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html
@@ -2,14 +2,30 @@
 {% load static contrib_tags %}
 
 {% if item.district %}
-<a href="{% url 'meinberlin_plans:plan-list' %}?district={{ item.district.name }}" class="storefront__item storefront__district tile__md">
-    <h2 class="storefront__district-text">{% blocktrans with district=item.district %}What is happening in <strong>{{ district }}</strong>?{% endblocktrans %}</h2>
+<a
+    href="{% url 'meinberlin_plans:plan-list' %}?district={{ item.district.name }}"
+    class="storefront__item storefront__district tile__md"
+>
+    <h2 class="storefront__district-text">
+        {% blocktrans with district=item.district %}
+            What is happening in <strong>{{ district }}</strong>?
+        {% endblocktrans %}
+    </h2>
+    <h2 class="storefront__district-text">
+        {% blocktrans with district=item.district %}
+            What is happening in <strong>{{ district }}</strong>?
+        {% endblocktrans %}
+    </h2>
     <button class="btn btn-primary">
-        {% blocktrans count counter=item.district_project_count %}display {{ counter }} project{% plural %}display {{ counter }} projects{% endblocktrans %}
+        {% blocktrans count counter=item.district_project_count %}
+            display {{ counter }} project{% plural %}display {{ counter }} projects
+        {% endblocktrans %}
     </button>
 </a>
 {% elif item.project and not item.quote %}
-<a href="{{ item.project_url }}" {% if item.item_type == 'external' %}target="_blank"{% endif %} class="storefront__item storefront__proj tile__md">
+<a href="{{ item.project_url }}"
+   {% if item.item_type == 'external' %}target="_blank"{% endif %}
+    class="storefront__item storefront__proj tile__md">
     {% if item.project.module_running_days_left < 3 %}
     <div>
       <div class="storefront__ending-icon">
@@ -25,8 +41,16 @@
         {% endif %}
     </div>
     {% endif %}
-    <p class="storefront__sm-text">{% if item.project.administrative_district %}{{ item.project.administrative_district }}{% else %}{% trans 'City wide' %}{% endif %}</p>
-    <h2 class="storefront__proj-text {% if item.project.name|length > 95 %} storefront__proj-text-wide {% endif %}">{{ item.project.name }}</h2>
+    <p class="storefront__sm-text">
+        {% if item.project.administrative_district %}
+            {{ item.project.administrative_district }}
+        {% else %}
+            {% trans 'City wide' %}
+        {% endif %}
+    </p>
+    <h2 class="storefront__proj-text {% if item.project.name|length > 95 %} storefront__proj-text-wide {% endif %}">
+        {{ item.project.name }}
+    </h2>
     {% if item.project.running_modules %}
     <div class="status-item status-item__position-storefront status__active">
         <div class="status-bar__active">
@@ -34,7 +58,9 @@
         </div>
         <span class="status-bar__status"><i class="fas fa-clock"></i>
           {% if item.project.module_running_days_left < 365 %}
-          {% blocktrans with time_left=item.project.module_running_time_left %} {{ time_left }} remaining {% endblocktrans %}
+            {% blocktrans with time_left=item.project.module_running_time_left %}
+                {{ time_left }} remaining
+            {% endblocktrans %}
           {% else %}
           <span>{% trans 'more than 1 year remaining' %}</span>
           {% endif %}
@@ -56,11 +82,18 @@
     {% endif %}
 </a>
 {% elif item.project and item.quote %}
-<a href="{{ item.project_url }}" {% if item.item_type == 'external' %}target="_blank"{% endif %} class="storefront__item storefront__proj-quote tile__md">
+<a href="{{ item.project_url }}"
+   {% if item.item_type == 'external' %}target="_blank"{% endif %}
+    class="storefront__item storefront__proj-quote tile__md"
+>
     <blockquote class="storefront__quote-text">
         „{{ item.quote|truncatechars:150 }}“
     </blockquote>
-    <div class="storefront__opinion-text">{% blocktrans with name=item.project.name|truncatechars:60 %} What is your opinion on this: {{ name }}?{% endblocktrans %}</div>
+    <div class="storefront__opinion-text">
+        {% blocktrans with name=item.project.name|truncatechars:60 %}
+            What is your opinion on this: {{ name }}?
+        {% endblocktrans %}
+    </div>
 </a>
 {% elif not item.project and item.quote %}
 <div class="storefront__item storefront__quote tile__md">

--- a/meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html
+++ b/meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html
@@ -43,7 +43,10 @@
 
     {% elif item.item_type != 'external' and item.project.future_modules %}
     <div class="status-item status-item__position-storefront status__future">
-      <span class="status-bar__status"><i class="fas fa-clock" ></i>{% blocktrans with date=item.project.future_modules.first.module_start|date:"d.m.Y" %} Participation: from {{ date }}{% endblocktrans %}</span>
+      <span class="status-bar__status"><i class="fas fa-clock" ></i>
+          {% trans 'Participation: from ' %}
+          {% html_date item.project.future_modules.first.module_start class='list-item__date' %}
+      </span>
     </div>
 
     {% elif item.project.has_finished %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html
@@ -29,13 +29,21 @@
             <span class="label label--big">{{ object.category }}</span>
         {% endif %}
         {% if object.point_label %}
-            <span class="label label--big"><i class="fas fa-map-marker-alt" aria-hidden="true"></i> {{ object.point_label }}</span>
+            <span class="label label--big">
+                <i class="fas fa-map-marker-alt" aria-hidden="true"></i>
+                {{ object.point_label }}
+            </span>
         {% endif %}
         {% if object.budget > 0 %}
             <span class="label label--big">{{ object.budget|intcomma }}€</span>
         {% endif %}
         {% if object.moderator_feedback %}
-            <span class="label label--big label--{{object.moderator_feedback|classify|lower }} list-item__label--moderator-feedback">
+            <span class=
+                      "label
+                      label--big
+                      label--{{object.moderator_feedback|classify|lower }}
+                      list-item__label--moderator-feedback"
+            >
                 {{ object.get_moderator_feedback_display }}
             </span>
         {% endif %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html
@@ -43,5 +43,9 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
+    {% if object.modified %}
+        {% trans 'updated on ' %}{% html_date object.modified class='list-item__date' %}
+    {% else %}
+        {% trans 'created on ' %}{% html_date object.created class='list-item__date' %}
+    {% endif %}
 </li>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -50,7 +50,11 @@
             <div class="item-detail__meta lr-bar">
                 <div class="lr-bar__left">
                     <strong class="item-detail__creator">{{ object.creator.username }}</strong>
-                    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
+                    {% if object.modified %}
+                        {% trans 'updated on ' %}{% html_date object.modified class='list-item__date' %}
+                    {% else %}
+                        {% trans 'created on ' %}{% html_date object.created class='list-item__date' %}
+                    {% endif %}
                 </div>
                 <div class="lr-bar__right">
                     <strong>{% trans 'Reference No.' %}:</strong>

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -31,7 +31,12 @@
             <span class="label label--big">{{ object.category }}</span>
         {% endif %}
         {% if object.moderator_feedback %}
-            <span class="label label--big label--{{ object.moderator_feedback|classify|lower }} list-item__label--moderator-feedback">
+            <span class=
+                      "label
+                      label--big
+                      label--{{ object.moderator_feedback|classify|lower }}
+                      list-item__label--moderator-feedback"
+            >
                 {{ object.get_moderator_feedback_display }}
             </span>
         {% endif %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html
@@ -40,5 +40,9 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
+    {% if object.modified %}
+        {% trans 'updated on ' %}{% html_date object.modified class='list-item__date' %}
+    {% else %}
+        {% trans 'created on ' %}{% html_date object.created class='list-item__date' %}
+    {% endif %}
 </li>

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
@@ -42,5 +42,9 @@
     <span class="list-item__author">
         {{ object.creator.username }}
     </span>
-    {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}
+    {% if object.modified %}
+        {% trans 'updated on ' %}{% html_date object.modified class='list-item__date' %}
+    {% else %}
+        {% trans 'created on ' %} {% html_date object.created class='list-item__date' %}
+    {% endif %}
 </li>

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html
@@ -31,10 +31,18 @@
             <span class="label label--big">{{ object.category }}</span>
         {% endif %}
         {% if object.point_label %}
-            <span class="label label--big"><i class="fas fa-map-marker-alt" aria-hidden="true"></i> {{ object.point_label }}</span>
+            <span class="label label--big">
+                <i class="fas fa-map-marker-alt" aria-hidden="true"></i>
+                {{ object.point_label }}
+            </span>
         {% endif %}
         {% if object.moderator_feedback %}
-            <span class="label label--big label--{{ object.moderator_feedback|classify|lower }} list-item__label--moderator-feedback">
+            <span class=
+                      "label
+                      label--big
+                      label--{{ object.moderator_feedback|classify|lower }}
+                      list-item__label--moderator-feedback"
+            >
                 {{ object.get_moderator_feedback_display }}
             </span>
         {% endif %}

--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -62,7 +62,12 @@
 
                         {% if object.topic_names %}
                         <dl>
-                            <dt>{% trans 'Topic' %}</dt><dd>{{ object.topic_names.0 }}{% if object.topic_names.1 %}, {{ object.topic_names.1 }}{% endif %}</dd>
+                            <dt>{% trans 'Topic' %}</dt>
+                            <dd>{{ object.topic_names.0 }}
+                                {% if object.topic_names.1 %}
+                                    ,{{ object.topic_names.1 }}
+                                {% endif %}
+                            </dd>
                         </dl>
                         {% endif %}
 
@@ -81,8 +86,11 @@
                         <dl>
                             <dt>{% trans 'Participation' %}</dt>
                             <dd>
-                                    {{ object.get_participation_display }}{% if object.participation == object.PARTICIPATION_YES and object.published_projects.count %},
-                                    <a href='#participation-plans'>{% trans 'see participation plans' %}</a>
+                                {{ object.get_participation_display }}
+                                {% if object.participation == object.PARTICIPATION_YES and object.published_projects.count %},
+                                    <a href='#participation-plans'>
+                                        {% trans 'see participation plans' %}
+                                    </a>
                                 {% endif%}
                             </dd>
                         </dl>
@@ -101,7 +109,9 @@
                     {% if object.description_image %}
                         <div class="item-detail__background-image" style="background-image: url({% thumbnail object.description_image 'item_image' %})">
                         {% if object.description_image_copyright %}
-                            <span class="item-detail__copyright copyright">© {{ object.description_image_copyright }}</span>
+                            <span class="item-detail__copyright copyright">
+                                © {{ object.description_image_copyright }}
+                            </span>
                         {% endif %}
                         </div>
                     {% endif %}
@@ -114,29 +124,39 @@
                         {% endif %}
                     </div>
                 </div>
-                {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url or object.organisation.address or object.organisation.url %}
+                {% if object.contact_name or
+                    object.contact_address_text or
+                    object.contact_email or
+                    object.contact_phone or
+                    object.contact_url or
+                    object.organisation.address or
+                    object.organisation.url %}
                     <div class="l-tiles-2 u-spacer-bottom">
-                    {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url %}
+                    {% if object.contact_name or
+                        object.contact_address_text or
+                        object.contact_email or
+                        object.contact_phone or
+                        object.contact_url %}
                         <div>
                             <h3>{% trans 'Contact for questions' %}</h3>
                             {% if object.contact_name %}
-                            <p>{{ object.contact_name }}</p>
+                                <p>{{ object.contact_name }}</p>
                             {% endif %}
                             {% if object.contact_address_text %}
-                            <p>{{ object.contact_address_text|linebreaks }}</p>
+                                <p>{{ object.contact_address_text|linebreaks }}</p>
                             {% endif %}
                             {% if object.contact_phone %}
-                            <p><strong>{% trans 'Telephone' %}: </strong>{{ object.contact_phone }}</p>
+                                <p><strong>{% trans 'Telephone' %}: </strong>{{ object.contact_phone }}</p>
                             {% endif %}
                             {% if object.contact_email %}
-                            <a class="btn btn--secondary" href="mailto:{{ object.contact_email }}">
-                                {% trans 'Email' %}
-                            </a>
+                                <a class="btn btn--secondary" href="mailto:{{ object.contact_email }}">
+                                    {% trans 'Email' %}
+                                </a>
                             {% endif %}
                             {% if object.contact_url %}
-                            <a class="btn btn--secondary" target="_blank" href="{{ object.contact_url }}">
-                                {% trans 'Website' %}
-                            </a>
+                                <a class="btn btn--secondary" target="_blank" href="{{ object.contact_url }}">
+                                    {% trans 'Website' %}
+                                </a>
                             {% endif %}
                         </div>
                     {% endif %}
@@ -145,13 +165,13 @@
                         <div>
                             <h3>{% trans 'Responsible body' %}</h3>
                             {% if object.organisation.address %}
-                            <p>{{ object.organisation.name }}</p>
-                            <p>{{ object.organisation.address|linebreaks }}</p>
+                                <p>{{ object.organisation.name }}</p>
+                                <p>{{ object.organisation.address|linebreaks }}</p>
                             {% endif %}
                             {% if object.organisation.url %}
-                            <a class="btn btn--secondary" target="_blank" href="{{ object.organisation.url }}">
-                                {% trans 'Website' %}
-                            </a>
+                                <a class="btn btn--secondary" target="_blank" href="{{ object.organisation.url }}">
+                                    {% trans 'Website' %}
+                                </a>
                             {% endif %}
                         </div>
                     {% endif %}
@@ -181,7 +201,9 @@
                                         href="{% url 'a4dashboard:plan-update' organisation_slug=object.organisation.slug pk=object.pk %}"
                                         class="dropdown-item"
                                         data-embed-target="external"
-                                    >{% trans 'Edit' %}</a>
+                                    >
+                                        {% trans 'Edit' %}
+                                    </a>
                                 </li>
                             </div>
                         </div>
@@ -196,11 +218,12 @@
     {% if object.published_projects %}
     <div class="item-detail-2__project-list">
         <div class="l-wrapper">
-            <h3 class="item-detail-2__project-title" id="participation-plans">{% trans "Participation projects" %}</h3>
+            <h3 class="item-detail-2__project-title" id="participation-plans">
+                {% trans "Participation projects" %}
+            </h3>
             <ul class="u-list-reset participation-tile__list">
             {% for project in object.published_projects %}
-
-                    {% include "meinberlin_projects/includes/project_tile.html" with project=project %}
+                {% include "meinberlin_projects/includes/project_tile.html" with project=project %}
             {% endfor %}
             </ul>
         </div>

--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static rules wagtailcore_tags maps_tags thumbnail ckeditor_tags %}
+{% load i18n static rules wagtailcore_tags maps_tags thumbnail ckeditor_tags contrib_tags %}
 
 {% block title %}{{ object.title }} &mdash; {{ block.super }}{% endblock %}
 
@@ -89,7 +89,13 @@
 
                         <dl>
                             <dt>{% trans 'Reference No.' %}</dt>
-                            <dd>{{ object.reference_number }}, {% if object.modified %}{% trans 'updated on ' %}{{ object.modified|date }}{% else %}{% trans 'created on ' %}{{ object.created|date }}{% endif %}</dd>
+                            <dd>{{ object.reference_number }},
+                                {% if object.modified %}
+                                    {% trans 'updated on ' %}{% html_date object.modified class='list-item__date' %}
+                                {% else %}
+                                    {% trans 'created on ' %}{% html_date object.created class='list-item__date' %}
+                                {% endif %}
+                            </dd>
                         </dl>
                     </ul>
                     {% if object.description_image %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n contrib_tags %}
 
 {% if invites|length %}
     <table>
@@ -13,7 +13,7 @@
         {% for invite in invites %}
             <tr>
                 <td>{{ invite.email }}</td>
-                <td>{{ invite.created }}</td>
+                <td>{% html_date invite.created class='list-item__date' %}</td>
                 <td class="td--action">
                     <form method="post">
                         {% csrf_token %}


### PR DESCRIPTION
… accessibility to dates

Fixes #4017

In order to find out which templates should use the **html_tag** for dates, the code was searched for the date filter. 
6 of the 7 templates changed had very similar lines that were changed. Only one was changed from a `blocktrans` to `trans` because  adding the **html_tag** to the the blocktrans would break it. 