### PR TITLE
templates: blocktrans blocks refactored in all apps where these were not in 1 line

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -310,7 +310,7 @@ msgstr "hier können Sie alle Ideen exportieren"
 #: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
 #: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
 msgid "here you can export all subjects"
-msgstr ""
+msgstr "hier können Sie alle Themen exportieren"
 
 #: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
 #: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
@@ -1955,7 +1955,7 @@ msgstr "Vorschlag anlegen"
 
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:40
 msgid "Enter code"
-msgstr ""
+msgstr "Schlüssel eingeben"
 
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:59
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:34
@@ -2116,7 +2116,7 @@ msgstr "Gesamtstädtisch"
 #: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:55
 #, python-format
 msgid "%(time_left)s remaining"
-msgstr ""
+msgstr "noch %(time_left)s"
 
 #: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:57
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:67
@@ -2126,7 +2126,7 @@ msgstr "noch länger als 1 Jahr"
 #: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:64
 #, python-format
 msgid "Participation: from %(date)s"
-msgstr ""
+msgstr "Beteiligung: ab %(date)s"
 
 #: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:69
 msgid "Participation ended. Read result."
@@ -2135,7 +2135,7 @@ msgstr "Beteiligung beendet. Ergebnis lesen."
 #: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:82
 #, python-format
 msgid "What is your opinion on this: %(name)s?"
-msgstr ""
+msgstr "Was ist Ihre Meinung zum Projekt: %(name)s?"
 
 #: meinberlin/apps/contrib/django_standard_messages.py:6
 msgid "You have signed out."
@@ -2937,6 +2937,9 @@ msgid ""
 "accordingly. The questions can be filtered by affiliation and evaluated in "
 "the statistics."
 msgstr ""
+"Hier können Sie Zugehörigkeiten vorgeben. Nutzer*innen müssen Fragen "
+"entsprechend einordnen. Die Fragen können nach Zugehörigkeiten gefiltert "
+"und in der Statistik ausgewertet werden."
 
 #: meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html:20
 msgid "Add affiliation"
@@ -3721,6 +3724,8 @@ msgid ""
 "Please select the plan your project belongs to. Your project will be shown "
 "in the list of plans accordingly."
 msgstr ""
+"Bitte geben Sie an, zu welchem Vorhaben das Projekt gehört. Das Projekt "
+"wird entsprechend in der Vorhabenliste angezeigt."
 
 #: meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html:10
 #, python-format
@@ -3728,6 +3733,8 @@ msgid ""
 "No plan has been created yet. You can do that <a href=\"%(plan_create_url)s"
 "\">here</a>."
 msgstr ""
+"Es wurde noch kein Vorhaben angelegt, dies können Sie <a href="
+"\"%(plan_create_url)s\">hier</a> tun."
 
 #: meinberlin/apps/plans/views.py:164
 msgid "The plan was created"
@@ -3976,7 +3983,7 @@ msgstr "Beteiligungsprojekte: "
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:65
 #, python-format
 msgid "%(time_left)s remaining "
-msgstr ""
+msgstr "noch %(time_left)s"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_timeline-carousel.html:12
 msgid "Timeline item"
@@ -4143,6 +4150,10 @@ msgid ""
 "and follow the invitation link again. If you decline the invitation the link "
 "is not valid anymore."
 msgstr ""
+"Wenn Sie akzeptieren, treten Sie dem Projekt mit Ihrem Nutzernamen "
+"\"%(user)s\" bei. Wenn Sie dem Projekt mit einem anderen Profil "
+"beitreten möchten, melden Sie sich ab und folgen Sie dem Einladungslink
+"erneut. Wenn Sie die Einladung ablehnen, verliert der Link seine Gültigkeit."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:23
 #: meinberlin/templates/a4modules/module_detail.html:24
@@ -4244,6 +4255,11 @@ msgid ""
 "find the Service <strong>mein.Berlin</strong> and finally click on "
 "<strong>Hier starten</strong> to return to the meinBerlin platform.</p>"
 msgstr ""
+"<p>Um sich mit dem Service-Konto bei meinBerlin anzumelden, werden Sie "
+"auf die Service-Konto Seite weitergeleitet.</p><p>Dort müssen Sie sich "
+"anmelden, den Dienst <strong>mein.Berlin</strong> auswählen und auf "
+"<strong>Hier starten</strong> klicken um zur meinBerlin-Platform "
+"zurückzukehren.</p>"
 
 #: meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html:13
 msgid "Service-Konto Login"
@@ -4402,18 +4418,22 @@ msgstr "Plattform-Mail"
 
 #: meinberlin/apps/votes/forms.py:23
 msgid "This token is not valid"
-msgstr ""
+msgstr "Dieser Abstimmungsschlüssel ist ungültig"
 
 #: meinberlin/apps/votes/models.py:36
 msgid ""
 "Designates whether this token should be treated as active. Unselect this "
 "instead of deleting tokens."
 msgstr ""
+"Legt fest, ob dieser Schlüssel aktiviert ist. Entfernen Sie "
+"die Auswahl, anstatt den Schlüssel zu löschen."
 
 #: meinberlin/apps/votes/models.py:112
 msgid ""
 "This token is not valid. It might be expired or not valid for this project."
 msgstr ""
+"Dieser Schlüssel ist ungültig. Er ist entweder abgelaufen oder nicht "
+"gültig für dieses Projekt."
 
 #: meinberlin/config/settings/base.py:314
 #: meinberlin/config/settings/base.py:327
@@ -4568,6 +4588,8 @@ msgid ""
 "contribution has to be assigned to one of them. This way, content can be "
 "classified."
 msgstr ""
+"Hier können Sie Kategorien anlegen. Dadurch können alle Beiträge einer "
+"Kategorie zugeordnet und entsprechend gefiltert werden."
 
 #: meinberlin/templates/a4dashboard/base_dashboard.html:16
 msgid "Organisations"
@@ -4584,6 +4606,9 @@ msgid ""
 "phases. The name and description of the phase(s) should encourage the users "
 "to participate and let them know how they can participate."
 msgstr ""
+"Je nach ausgewähltem Modul hat der Beteiligungsprozess eine oder zwei "
+"Phasen. Name und Beschreibung der Phase(n) sollten die Nutzer*innen zur "
+"Teilnahme anregen und sie wissen lassen, wie sie sich beteiligen können."
 
 #: meinberlin/templates/a4dashboard/includes/nav_modules.html:4
 msgid "Participation Module"
@@ -4606,7 +4631,7 @@ msgstr "Beteiligungsmodul wählen"
 #: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:6
 #: meinberlin/templates/a4dashboard/includes/nav_project.html:6
 msgid "Toggle menu"
-msgstr ""
+msgstr "Toggle Menü"
 
 #: meinberlin/templates/a4dashboard/includes/nav_modules_item.html:13
 msgid "Module ready for addition"
@@ -4779,6 +4804,8 @@ msgid ""
 "In this section, you can create labels. If you create any, each contribution "
 "can be assigned to one or more of them. This way, content can be classified."
 msgstr ""
+"Hier können Sie Kategorien anlegen. Dadurch können alle Beiträge einer "
+"Kategorie zugeordnet und entsprechend gefiltert werden."
 
 #: meinberlin/templates/a4modules/includes/module_detail_phase.html:50
 msgid ""
@@ -4859,6 +4886,8 @@ msgid ""
 "Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
 "address for user %(user_display)s."
 msgstr ""
+"Bitte bestätigen Sie, dass <a href=\"mailto:%(email)s\">%(email)s</a> "
+"eine E-Mail Adresse der Nutzer*in %(user_display)s ist."
 
 #: meinberlin/templates/account/email_confirm.html:15
 msgid "Confirm"
@@ -4870,6 +4899,8 @@ msgid ""
 "This email confirmation link expired or is invalid. Please <a href="
 "\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
+"Der Link zur E-Mail Bestätigung ist abgelaufen oder ist ungültig. Bitte "
+"<a href=\"%(email_url)s\">fordern Sie eine neue Bestätigungsemail an</a>."
 
 #: meinberlin/templates/account/login.html:9
 #, python-format
@@ -4963,6 +4994,8 @@ msgstr "Ihr Passwort wurde geändert."
 msgid ""
 "Already have an account? Then please <a href=\"%(login_url)s\">login</a>."
 msgstr ""
+"Haben Sie schon ein Nutzerkonto? Dann <a href=\"%(login_url)s\">melden "
+"Sie sich bitte an</a>."
 
 #: meinberlin/templates/account/signup.html:11
 msgid ""
@@ -4984,6 +5017,13 @@ msgid ""
 "target=\"_blank\">terms of use</a> and the <a href=\"%(privacy_policy)s\" "
 "target=\"_blank\">privacy policy</a>."
 msgstr ""
+"Hiermit willige ich ausdrücklich in die Erhebung und Verarbeitung "
+"(Speicherung) meiner Daten und willige ausdrücklich in die Verarbeitung "
+"und Veröffentlichung meiner Ideen, Kommentare und Beiträge, wie in der "
+"Datenschutzerklärung beschrieben, ein. Zudem bestätige ich, dass ich die "
+"<a href=\"%(terms_of_use_url)s\" target=\"_blank\">Nutzungsbedingungen</"
+"a> und die <a href=\"%(privacy_policy)s\" target=\"_blank\"> "
+"Datenschutzerklärung</a> gelesen habe und akzeptiere."
 
 #: meinberlin/templates/base_errors.html:4
 msgid "Error"
@@ -5071,6 +5111,9 @@ msgid ""
 "You are about to use your %(provider_name)s account to login to "
 "%(site_name)s. As a final step, please complete the following form:"
 msgstr ""
+"Sie sind dabei sich mit Ihrem %(provider_name)s-Konto auf %(site_name)s "
+"anzumelden. Füllen Sie bitte das folgende Formular als letzten Schritt "
+"aus:"
 
 #~ msgid " %(time_left)s remaining "
 #~ msgstr " noch %(time_left)s"

--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-08 13:56+0100\n"
+"POT-Creation-Date: 2021-12-13 14:40+0100\n"
 "PO-Revision-Date: 2017-10-16 13:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,7 +20,6 @@ msgstr ""
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
-#: meinberlin/templates/a4categories/includes/module_categories_form.html:3
 msgid ""
 "In this section, you can create\n"
 "categories. If you create any, each contribution has to be assigned\n"
@@ -31,7 +30,7 @@ msgstr ""
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
-#: meinberlin/templates/a4categories/includes/module_categories_form.html:21
+#: meinberlin/templates/a4categories/includes/module_categories_form.html:19
 msgid "Add category"
 msgstr "Kategorie hinzufügen"
 
@@ -261,7 +260,7 @@ msgstr "privat"
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_dashboard_list_item.html:19
 #: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/includes/offlineevent_list_item.html:20
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:52
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:178
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:195
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:28
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:73
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_dashboard_list_item.html:19
@@ -383,7 +382,6 @@ msgstr ""
 
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-#: meinberlin/templates/a4labels/includes/module_labels_form.html:3
 msgid ""
 "In this section, you can create\n"
 "labels. If you create any, each contribution can be assigned\n"
@@ -394,7 +392,7 @@ msgstr ""
 
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-#: meinberlin/templates/a4labels/includes/module_labels_form.html:21
+#: meinberlin/templates/a4labels/includes/module_labels_form.html:19
 msgid "Add label"
 msgstr "Merkmal hinzufügen"
 
@@ -582,7 +580,7 @@ msgstr ""
 
 #: adhocracy4/dashboard/forms.py:86
 #: meinberlin/apps/plans/templates/meinberlin_plans/includes/plan_form.html:32
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:115
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:131
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:126
 msgid "Contact for questions"
 msgstr "Kontakt für Rückfragen"
@@ -718,9 +716,9 @@ msgid "Labels"
 msgstr "Merkmale"
 
 #: adhocracy4/exports/mixins/items.py:46
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:60
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:91
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:99
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
 msgid "Reference No."
 msgstr "Referenznr."
@@ -730,7 +728,7 @@ msgid "Moderator feedback"
 msgstr "Rückmeldung der Moderation"
 
 #: adhocracy4/exports/mixins/items.py:67
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:122
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:126
 msgid "Official Statement"
 msgstr "Offizielle Rückmeldung"
 
@@ -1130,7 +1128,7 @@ msgid "Postal address"
 msgstr "Postadresse"
 
 #: adhocracy4/projects/models.py:54
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:127
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:143
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
 msgid "Email"
@@ -1145,8 +1143,8 @@ msgid "Phone"
 msgstr "Telefon"
 
 #: adhocracy4/projects/models.py:72
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:132
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:147
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:148
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:163
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:143
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:158
 msgid "Website"
@@ -1950,30 +1948,30 @@ msgstr ""
 "Bei der Validierung Ihrer Daten ist ein Fehler aufgetreten. Bitte überprüfen "
 "Sie Ihre Eingabe."
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:18
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:19
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:18
 msgid "Submit proposal"
 msgstr "Vorschlag anlegen"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:33
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:40
 msgid "Enter code"
 msgstr ""
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:51
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:59
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:34
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:34
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:25
 msgid "Zoom in"
 msgstr "hineinzoomen"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:52
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:60
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:35
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:35
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:26
 msgid "Zoom out"
 msgstr "auszoomen"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:77
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:85
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html:29
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:52
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:60
@@ -2092,19 +2090,20 @@ msgstr[1] "Projekte, zu denen wir Ihre Meinung wissen möchten!"
 msgid "Scroll down"
 msgstr "Runterscrollen"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:6
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:10
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:13
 #, python-format
 msgid "What is happening in <strong>%(district)s</strong>?"
 msgstr "Was passiert gerade in <strong>%(district)s</strong>?"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:8
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:16
 #, python-format
 msgid "display %(counter)s project"
 msgid_plural "display %(counter)s projects"
 msgstr[0] "%(counter)s Projekt anzeigen"
 msgstr[1] "%(counter)s Projekte anzeigen"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:28
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:42
 #: meinberlin/apps/plans/exports.py:64 meinberlin/apps/plans/forms.py:50
 #: meinberlin/apps/plans/templatetags/react_map_teaser.py:18
 #: meinberlin/apps/plans/views.py:87 meinberlin/apps/projects/admin.py:65
@@ -2114,30 +2113,29 @@ msgstr[1] "%(counter)s Projekte anzeigen"
 msgid "City wide"
 msgstr "Gesamtstädtisch"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:37
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:65
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:55
 #, python-format
-msgid " %(time_left)s remaining "
-msgstr " noch %(time_left)s"
+msgid "%(time_left)s remaining"
+msgstr ""
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:39
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:57
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:67
 msgid "more than 1 year remaining"
 msgstr "noch länger als 1 Jahr"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:46
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:64
 #, python-format
-msgid " Participation: from %(date)s"
-msgstr " Beteiligung: ab %(date)s"
+msgid "Participation: from %(date)s"
+msgstr ""
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:51
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:69
 msgid "Participation ended. Read result."
 msgstr "Beteiligung beendet. Ergebnis lesen."
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:60
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:82
 #, python-format
-msgid " What is your opinion on this: %(name)s?"
-msgstr "Was ist Ihre Meinung zum Projekt: %(name)s?"
+msgid "What is your opinion on this: %(name)s?"
+msgstr ""
 
 #: meinberlin/apps/contrib/django_standard_messages.py:6
 msgid "You have signed out."
@@ -2275,42 +2273,42 @@ msgstr "Positive Bewertungen"
 msgid "Negative Ratings"
 msgstr "Negative Bewertungen"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:46
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:53
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:43
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:45
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:50
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:54
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:44
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:49
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:102
 msgid "updated on "
 msgstr "bearbeitet am "
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:46
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:53
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:43
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:45
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:52
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:46
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:51
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:104
 msgid "created on "
 msgstr "erstellt am "
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:82
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:91
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:161
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:170
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:86
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:95
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:177
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:186
 msgid "Actions"
 msgstr "Aktionen"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:96
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:100
 msgid "edit"
 msgstr "bearbeiten"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:98
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:102
 msgid "delete"
 msgstr "löschen"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:102
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:106
 msgid "give feedback"
 msgstr "zurück melden"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:107
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:111
 msgid "report"
 msgstr "melden"
 
@@ -2935,16 +2933,12 @@ msgstr ""
 
 #: meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html:3
 msgid ""
-"Here you can specify affiliations. Users must classify\n"
-"    questions accordingly. The questions can be filtered by affiliation and "
-"evaluated in the\n"
-"    statistics."
+"Here you can specify affiliations. Users must classify questions "
+"accordingly. The questions can be filtered by affiliation and evaluated in "
+"the statistics."
 msgstr ""
-"Hier können Sie Zugehörigkeiten vorgeben. Nutzer*innen müssen Fragen "
-"entsprechend einordnen. Die Fragen können nach Zugehörigkeiten gefiltert und "
-"in der Statistik ausgewertet werden."
 
-#: meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html:22
+#: meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html:20
 msgid "Add affiliation"
 msgstr "Zugehörigkeit hinzufügen"
 
@@ -3468,7 +3462,7 @@ msgstr ""
 "Projekte nach Bezirk gefiltert werden. "
 
 #: meinberlin/apps/plans/models.py:94
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:77
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:82
 msgid "Cost"
 msgstr "Kosten"
 
@@ -3537,7 +3531,7 @@ msgid "In the project overview projects can be filtered by status."
 msgstr "In der Projektübersicht können Projekte nach Status gefiltert werden."
 
 #: meinberlin/apps/plans/models.py:148
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:82
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:87
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:51
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:97
 msgid "Participation"
@@ -3552,7 +3546,7 @@ msgstr ""
 "werden."
 
 #: meinberlin/apps/plans/models.py:158
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:71
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:76
 msgid "Duration"
 msgstr "Laufzeit"
 
@@ -3673,21 +3667,21 @@ msgstr "Ort"
 msgid "Topic"
 msgstr "Thema"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:85
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
 msgid "see participation plans"
 msgstr "siehe Beteiligung"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:123
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:139
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:134
 msgid "Telephone"
 msgstr "Telefon"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:140
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:156
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:151
 msgid "Responsible body"
 msgstr "Verantwortliche Stelle"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:193
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:212
 #: meinberlin/templates/a4dashboard/base_project_list.html:7
 #: meinberlin/templates/a4dashboard/base_project_list.html:16
 #: meinberlin/templates/a4dashboard/project_list.html:9
@@ -3724,26 +3718,16 @@ msgstr "Schließen"
 
 #: meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html:3
 msgid ""
-"\n"
 "Please select the plan your project belongs to. Your project will be shown "
-"in the list of plans accordingly.\n"
+"in the list of plans accordingly."
 msgstr ""
-"\n"
-"Bitte geben Sie an, zu welchem Vorhaben das Projekt gehört. Das Projekt wird "
-"entsprechend in der Vorhabenliste angezeigt.\n"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html:12
+#: meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html:10
 #, python-format
 msgid ""
-"\n"
-"    No plan has been created yet. You can do that <a href="
-"\"%(plan_create_url)s\">here</a>.\n"
-"    "
+"No plan has been created yet. You can do that <a href=\"%(plan_create_url)s"
+"\">here</a>."
 msgstr ""
-"\n"
-"    Es wurde noch kein Vorhaben angelegt, dies können Sie <a href="
-"\"%(plan_create_url)s\">hier</a> tun.\n"
-"    "
 
 #: meinberlin/apps/plans/views.py:164
 msgid "The plan was created"
@@ -3989,6 +3973,11 @@ msgstr "jetzt lesen"
 msgid "Participation projects: "
 msgstr "Beteiligungsprojekte: "
 
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:65
+#, python-format
+msgid "%(time_left)s remaining "
+msgstr ""
+
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_timeline-carousel.html:12
 msgid "Timeline item"
 msgstr "Zeitleistenkachel"
@@ -4099,8 +4088,8 @@ msgstr "Weiter zur Anmeldung"
 #: meinberlin/apps/users/templates/meinberlin_users/indicator.html:55
 #: meinberlin/templates/account/signup.html:4
 #: meinberlin/templates/account/signup.html:7
-#: meinberlin/templates/account/signup.html:45
-#: meinberlin/templates/socialaccount/signup.html:38
+#: meinberlin/templates/account/signup.html:42
+#: meinberlin/templates/socialaccount/signup.html:35
 msgid "Register"
 msgstr "Registrieren"
 
@@ -4113,12 +4102,12 @@ msgstr ""
 "akzeptieren können sie das Projekt moderieren."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_form.html:15
-#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:18
+#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:15
 msgid "Accept"
 msgstr "Akzeptieren"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_form.html:16
-#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:19
+#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:16
 msgid "Decline"
 msgstr "Ablehnen"
 
@@ -4148,21 +4137,12 @@ msgstr "Wollen Sie dem Projekt \"%(project)s\" beitreten?"
 #: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:11
 #, python-format
 msgid ""
-"\n"
-"                You were invited by the initiator of the project. If you "
-"accept you will be able to participate in the project with your username "
-"\"%(user)s\".\n"
-"                If you want to join with a different profile please login "
-"with your other profile and follow the invitation link again. If you decline "
-"the invitation the link is not valid anymore.\n"
-"                "
+"You were invited by the initiator of the project. If you accept you will be "
+"able to participate in the project with your username \"%(user)s\". If you "
+"want to join with a different profile please login with your other profile "
+"and follow the invitation link again. If you decline the invitation the link "
+"is not valid anymore."
 msgstr ""
-"\n"
-"Wenn Sie akzeptieren, treten Sie dem Projekt mit Ihrem Nutzernamen \"%(user)s"
-"\" bei.\n"
-"Wenn Sie dem Projekt mit einem anderen Profil beitreten möchten, melden Sie "
-"sich ab und folgen Sie dem Einladungslink erneut. Wenn Sie die Einladung "
-"ablehnen, verliert der Link seine Gültigkeit."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:23
 #: meinberlin/templates/a4modules/module_detail.html:24
@@ -4259,24 +4239,13 @@ msgstr "Mit dem Service-Konto anmelden"
 
 #: meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html:10
 msgid ""
-"\n"
-"            <p>To sign in via Service-Konto on meinBerlin you will be "
-"redirected to the Service-Konto.</p>\n"
-"            <p>\n"
-"                There you have to sign in with your credentials first, find "
-"the Service <strong>mein.Berlin</strong> and\n"
-"                finally click on <strong>Hier starten</strong> to return to "
-"the meinBerlin platform.\n"
-"            </p>\n"
-"        "
+"<p>To sign in via Service-Konto on meinBerlin you will be redirected to the "
+"Service-Konto.</p><p>There you have to sign in with your credentials first, "
+"find the Service <strong>mein.Berlin</strong> and finally click on "
+"<strong>Hier starten</strong> to return to the meinBerlin platform.</p>"
 msgstr ""
-"\n"
-"<p>Um sich mit dem Service-Konto bei meinBerlin anzumelden, werden Sie auf "
-"die Service-Konto Seite weitergeleitet.</p><p>Dort müssen Sie sich anmelden, "
-"den Dienst <strong>mein.Berlin</strong> auswählen und auf <strong>Hier "
-"starten</strong> klicken um zur meinBerlin-Platform zurückzukehren.</p>"
 
-#: meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html:19
+#: meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html:13
 msgid "Service-Konto Login"
 msgstr "Service-Konto Login"
 
@@ -4593,6 +4562,13 @@ msgstr "Interner Serverfehler."
 msgid "Back to meinBerlin."
 msgstr "Zurück zu meinBerlin"
 
+#: meinberlin/templates/a4categories/includes/module_categories_form.html:3
+msgid ""
+"In this section, you can create categories. If you create any, each "
+"contribution has to be assigned to one of them. This way, content can be "
+"classified."
+msgstr ""
+
 #: meinberlin/templates/a4dashboard/base_dashboard.html:16
 msgid "Organisations"
 msgstr "Organisationen"
@@ -4604,14 +4580,10 @@ msgstr "Alle Beteiligungsprojekte"
 
 #: meinberlin/templates/a4dashboard/includes/module_phases_form.html:6
 msgid ""
-"Depending on the selected module, the participation\n"
-"    process has one or two phases. The name and description of the phase(s)\n"
-"    should encourage the users to participate and let them know how\n"
-"    they can participate."
+"Depending on the selected module, the participation process has one or two "
+"phases. The name and description of the phase(s) should encourage the users "
+"to participate and let them know how they can participate."
 msgstr ""
-"Je nach ausgewähltem Modul hat der Beteiligungsprozess eine oder zwei "
-"Phasen. Name und Beschreibung der Phase(n) sollten die Nutzer*innen zur "
-"Teilnahme anregen und sie wissen lassen, wie sie sich beteiligen können."
 
 #: meinberlin/templates/a4dashboard/includes/nav_modules.html:4
 msgid "Participation Module"
@@ -4802,6 +4774,12 @@ msgstr ""
 "Ihr Bild wird hochgeladen bzw. entfernt, sobald Sie Ihre Änderungen  am Ende "
 "gespeichert haben."
 
+#: meinberlin/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create labels. If you create any, each contribution "
+"can be assigned to one or more of them. This way, content can be classified."
+msgstr ""
+
 #: meinberlin/templates/a4modules/includes/module_detail_phase.html:50
 msgid ""
 "This project is not publicly visible. Only invited users can see content and "
@@ -4878,26 +4856,20 @@ msgstr "Bitte bestätigen Sie Ihre E-Mail Adresse."
 #: meinberlin/templates/account/email_confirm.html:11
 #, python-format
 msgid ""
-"Please\n"
-"            confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an\n"
-"            email address for user %(user_display)s."
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
+"address for user %(user_display)s."
 msgstr ""
-"Bitte bestätigen Sie, dass <a href=\"mailto:%(email)s\">%(email)s</a> eine E-"
-"Mail Adresse der Nutzer*in %(user_display)s ist."
 
-#: meinberlin/templates/account/email_confirm.html:17
+#: meinberlin/templates/account/email_confirm.html:15
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: meinberlin/templates/account/email_confirm.html:21
+#: meinberlin/templates/account/email_confirm.html:19
 #, python-format
 msgid ""
-"This email confirmation link expired or is invalid.\n"
-"            Please <a href=\"%(email_url)s\">issue a new email confirmation\n"
-"                request</a>."
+"This email confirmation link expired or is invalid. Please <a href="
+"\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
-"Der Link zur E-Mail Bestätigung ist abgelaufen oder ist ungültig. Bitte <a "
-"href=\"%(email_url)s\">fordern Sie eine neue Bestätigungsemail an</a>."
 
 #: meinberlin/templates/account/login.html:9
 #, python-format
@@ -4989,13 +4961,10 @@ msgstr "Ihr Passwort wurde geändert."
 #: meinberlin/templates/account/signup.html:9
 #, python-format
 msgid ""
-"Already have an account? Then please\n"
-"        <a href=\"%(login_url)s\">login</a>."
+"Already have an account? Then please <a href=\"%(login_url)s\">login</a>."
 msgstr ""
-"Haben Sie schon ein Nutzerkonto? Dann <a href=\"%(login_url)s\">melden Sie "
-"sich bitte an</a>."
 
-#: meinberlin/templates/account/signup.html:12
+#: meinberlin/templates/account/signup.html:11
 msgid ""
 "If you register on mein.berlin.de, you can write ideas and comments for "
 "ongoing participation processes and rate the contributors of other users."
@@ -5004,27 +4973,17 @@ msgstr ""
 "Kommentare für laufende Beteiligungsverfahren schreiben und die Beiträge "
 "anderer Nutzer*innen bewerten."
 
-#: meinberlin/templates/account/signup.html:31
-#: meinberlin/templates/socialaccount/signup.html:28
+#: meinberlin/templates/account/signup.html:30
+#: meinberlin/templates/socialaccount/signup.html:27
 #, python-format
 msgid ""
-"\n"
-"                 I hereby expressly consent to the collection and processing "
-"(storage) of my data and expressly consent to the processing and publication "
-"of my ideas, comments and contributions as described in the privacy policy. "
-"I also confirm that I have read and accept the <a href=\"%(terms_of_use_url)s"
-"\" target=\"_blank\">terms of use</a> and the <a href=\"%(privacy_policy)s\" "
-"target=\"_blank\">privacy policy</a>.\n"
-"                "
+"I hereby expressly consent to the collection and processing (storage) of my "
+"data and expressly consent to the processing and publication of my ideas, "
+"comments and contributions as described in the privacy policy. I also "
+"confirm that I have read and accept the <a href=\"%(terms_of_use_url)s\" "
+"target=\"_blank\">terms of use</a> and the <a href=\"%(privacy_policy)s\" "
+"target=\"_blank\">privacy policy</a>."
 msgstr ""
-"\n"
-"Hiermit willige ich ausdrücklich in die Erhebung und Verarbeitung "
-"(Speicherung) meiner Daten und willige ausdrücklich in die Verarbeitung und "
-"Veröffentlichung meiner Ideen, Kommentare und Beiträge, wie in der "
-"Datenschutzerklärung beschrieben, ein. Zudem bestätige ich, dass ich die <a "
-"href=\"%(terms_of_use_url)s\" target=\"_blank\">Nutzungsbedingungen</a> und "
-"die <a href=\"%(privacy_policy)s\" target=\"_blank\"> Datenschutzerklärung</"
-"a> gelesen habe und akzeptiere.               "
 
 #: meinberlin/templates/base_errors.html:4
 msgid "Error"
@@ -5109,11 +5068,147 @@ msgstr "Anmelden"
 #: meinberlin/templates/socialaccount/signup.html:10
 #, python-format
 msgid ""
-"You are about to use your %(provider_name)s account to login to\n"
+"You are about to use your %(provider_name)s account to login to "
 "%(site_name)s. As a final step, please complete the following form:"
 msgstr ""
-"Sie sind dabei sich mit Ihrem %(provider_name)s-Konto auf %(site_name)s "
-"anzumelden. Füllen Sie bitte das folgende Formular als letzten Schritt aus:"
+
+#~ msgid " %(time_left)s remaining "
+#~ msgstr " noch %(time_left)s"
+
+#~ msgid " Participation: from %(date)s"
+#~ msgstr " Beteiligung: ab %(date)s"
+
+#~ msgid " What is your opinion on this: %(name)s?"
+#~ msgstr "Was ist Ihre Meinung zum Projekt: %(name)s?"
+
+#~ msgid ""
+#~ "Here you can specify affiliations. Users must classify\n"
+#~ "    questions accordingly. The questions can be filtered by affiliation "
+#~ "and evaluated in the\n"
+#~ "    statistics."
+#~ msgstr ""
+#~ "Hier können Sie Zugehörigkeiten vorgeben. Nutzer*innen müssen Fragen "
+#~ "entsprechend einordnen. Die Fragen können nach Zugehörigkeiten gefiltert "
+#~ "und in der Statistik ausgewertet werden."
+
+#~ msgid ""
+#~ "\n"
+#~ "Please select the plan your project belongs to. Your project will be "
+#~ "shown in the list of plans accordingly.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Bitte geben Sie an, zu welchem Vorhaben das Projekt gehört. Das Projekt "
+#~ "wird entsprechend in der Vorhabenliste angezeigt.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "    No plan has been created yet. You can do that <a href="
+#~ "\"%(plan_create_url)s\">here</a>.\n"
+#~ "    "
+#~ msgstr ""
+#~ "\n"
+#~ "    Es wurde noch kein Vorhaben angelegt, dies können Sie <a href="
+#~ "\"%(plan_create_url)s\">hier</a> tun.\n"
+#~ "    "
+
+#~ msgid ""
+#~ "\n"
+#~ "                You were invited by the initiator of the project. If you "
+#~ "accept you will be able to participate in the project with your username "
+#~ "\"%(user)s\".\n"
+#~ "                If you want to join with a different profile please login "
+#~ "with your other profile and follow the invitation link again. If you "
+#~ "decline the invitation the link is not valid anymore.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "Wenn Sie akzeptieren, treten Sie dem Projekt mit Ihrem Nutzernamen "
+#~ "\"%(user)s\" bei.\n"
+#~ "Wenn Sie dem Projekt mit einem anderen Profil beitreten möchten, melden "
+#~ "Sie sich ab und folgen Sie dem Einladungslink erneut. Wenn Sie die "
+#~ "Einladung ablehnen, verliert der Link seine Gültigkeit."
+
+#~ msgid ""
+#~ "\n"
+#~ "            <p>To sign in via Service-Konto on meinBerlin you will be "
+#~ "redirected to the Service-Konto.</p>\n"
+#~ "            <p>\n"
+#~ "                There you have to sign in with your credentials first, "
+#~ "find the Service <strong>mein.Berlin</strong> and\n"
+#~ "                finally click on <strong>Hier starten</strong> to return "
+#~ "to the meinBerlin platform.\n"
+#~ "            </p>\n"
+#~ "        "
+#~ msgstr ""
+#~ "\n"
+#~ "<p>Um sich mit dem Service-Konto bei meinBerlin anzumelden, werden Sie "
+#~ "auf die Service-Konto Seite weitergeleitet.</p><p>Dort müssen Sie sich "
+#~ "anmelden, den Dienst <strong>mein.Berlin</strong> auswählen und auf "
+#~ "<strong>Hier starten</strong> klicken um zur meinBerlin-Platform "
+#~ "zurückzukehren.</p>"
+
+#~ msgid ""
+#~ "Depending on the selected module, the participation\n"
+#~ "    process has one or two phases. The name and description of the "
+#~ "phase(s)\n"
+#~ "    should encourage the users to participate and let them know how\n"
+#~ "    they can participate."
+#~ msgstr ""
+#~ "Je nach ausgewähltem Modul hat der Beteiligungsprozess eine oder zwei "
+#~ "Phasen. Name und Beschreibung der Phase(n) sollten die Nutzer*innen zur "
+#~ "Teilnahme anregen und sie wissen lassen, wie sie sich beteiligen können."
+
+#~ msgid ""
+#~ "Please\n"
+#~ "            confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is "
+#~ "an\n"
+#~ "            email address for user %(user_display)s."
+#~ msgstr ""
+#~ "Bitte bestätigen Sie, dass <a href=\"mailto:%(email)s\">%(email)s</a> "
+#~ "eine E-Mail Adresse der Nutzer*in %(user_display)s ist."
+
+#~ msgid ""
+#~ "This email confirmation link expired or is invalid.\n"
+#~ "            Please <a href=\"%(email_url)s\">issue a new email "
+#~ "confirmation\n"
+#~ "                request</a>."
+#~ msgstr ""
+#~ "Der Link zur E-Mail Bestätigung ist abgelaufen oder ist ungültig. Bitte "
+#~ "<a href=\"%(email_url)s\">fordern Sie eine neue Bestätigungsemail an</a>."
+
+#~ msgid ""
+#~ "Already have an account? Then please\n"
+#~ "        <a href=\"%(login_url)s\">login</a>."
+#~ msgstr ""
+#~ "Haben Sie schon ein Nutzerkonto? Dann <a href=\"%(login_url)s\">melden "
+#~ "Sie sich bitte an</a>."
+
+#~ msgid ""
+#~ "\n"
+#~ "                 I hereby expressly consent to the collection and "
+#~ "processing (storage) of my data and expressly consent to the processing "
+#~ "and publication of my ideas, comments and contributions as described in "
+#~ "the privacy policy. I also confirm that I have read and accept the <a "
+#~ "href=\"%(terms_of_use_url)s\" target=\"_blank\">terms of use</a> and the "
+#~ "<a href=\"%(privacy_policy)s\" target=\"_blank\">privacy policy</a>.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "Hiermit willige ich ausdrücklich in die Erhebung und Verarbeitung "
+#~ "(Speicherung) meiner Daten und willige ausdrücklich in die Verarbeitung "
+#~ "und Veröffentlichung meiner Ideen, Kommentare und Beiträge, wie in der "
+#~ "Datenschutzerklärung beschrieben, ein. Zudem bestätige ich, dass ich die "
+#~ "<a href=\"%(terms_of_use_url)s\" target=\"_blank\">Nutzungsbedingungen</"
+#~ "a> und die <a href=\"%(privacy_policy)s\" target=\"_blank\"> "
+#~ "Datenschutzerklärung</a> gelesen habe und akzeptiere.               "
+
+#~ msgid ""
+#~ "You are about to use your %(provider_name)s account to login to\n"
+#~ "%(site_name)s. As a final step, please complete the following form:"
+#~ msgstr ""
+#~ "Sie sind dabei sich mit Ihrem %(provider_name)s-Konto auf %(site_name)s "
+#~ "anzumelden. Füllen Sie bitte das folgende Formular als letzten Schritt "
+#~ "aus:"
 
 #~ msgid "deleted by creator"
 #~ msgstr "Vom Ersteller gelöscht"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-08 13:56+0100\n"
+"POT-Creation-Date: 2021-12-13 14:40+0100\n"
 "PO-Revision-Date: 2017-05-30 12:06+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -665,7 +665,6 @@ msgstr "Vielen Dank! Wir werden uns darum kümmern."
 #: meinberlin/apps/contrib/assets/Alert.jsx:11
 #: meinberlin/apps/embed/assets/embed.js:59
 #: meinberlin/apps/embed/assets/embed.js:60
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:85
 #: meinberlin/apps/plans/assets/FilterNav.jsx:213
 msgid "Close"
 msgstr "Schließen"
@@ -683,11 +682,19 @@ msgid_plural "you have %s votes left"
 msgstr[0] ""
 msgstr[1] ""
 
-#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:40
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:12
+msgid "modified on"
+msgstr ""
+
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:13
+msgid "created on"
+msgstr ""
+
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:44
 msgid "Voted"
 msgstr ""
 
-#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:41
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:45
 msgid "Give my vote"
 msgstr ""
 
@@ -932,75 +939,6 @@ msgstr "Beantwortete Fragen"
 #: meinberlin/apps/livequestions/assets/StatisticsBox.jsx:45
 msgid "Affiliation Of Answered Questions"
 msgstr "Zugehörigkeit der beantworteten Fragen"
-
-#: meinberlin/apps/maps/assets/map-address.js:87
-msgid "No matches found within the project area"
-msgstr "Keine Treffer im Bereich des Projekts gefunden"
-
-#: meinberlin/apps/maps/assets/map-address.js:90
-msgid "Did you mean:"
-msgstr "Meinten Sie:"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:67
-msgid "Export polygon as GeoJSON"
-msgstr "Polygon als GeoJSON exportierten"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:68
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:78
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:90
-msgid "Import polygon via file upload"
-msgstr "Polygon aus Datei importieren"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:92
-msgid ""
-"Upload a polygon from a GeoJSON (.geojson) or a zipped Shapefile (.zip)."
-msgstr ""
-"Laden Sie eine GeoJSON Datei (.geojson) oder ein gepacktes Shapefile (.zip) "
-"hoch."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:93
-msgid ""
-"Note that uploading Shapefiles is not supported with Internet Explorer 10"
-msgstr ""
-"Beachten Sie, dass der Import von Shapefiles mit dem Internet Explorer 10 "
-"nicht unterstützt wird"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:94
-msgid "Attention importing a file will delete the existing polygons."
-msgstr ""
-"Achtung der Import einer Datei wird alle vorher ausgewählten Polygone "
-"entfernen."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:99
-msgid "Upload"
-msgstr "Hochladen"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:106
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:140
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:142
-msgid "The uploaded file is not a valid shapefile."
-msgstr "Die hochgeladene Datei ist kein gültiges Shapefile."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:144
-msgid "The uploaded file could not be imported."
-msgstr "Die hochgeladene Datei kann nicht importiert werden."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:158
-msgid "The uploaded file is not a valid geojson file."
-msgstr "Die hochgeladene Datei ist keine gültiges GeoJSON Datei."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:163
-msgid "Invalid file format."
-msgstr "Ungültiges Dateiformat."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:280
-msgid "Do you want to load this preset and delete all the existing polygons?"
-msgstr ""
-"Möchten Sie diesen Kartenausschnitt auswählen und alle vorher ausgewählten "
-"entfernen?"
 
 #: meinberlin/apps/plans/assets/FilterNav.jsx:126
 #: meinberlin/apps/plans/assets/FilterNav.jsx:242
@@ -1256,3 +1194,56 @@ msgid "More information can be found in the privacy policy of Vimeo under: "
 msgstr ""
 "Weitere Informationen finden Sie in der Datenschutzerklärung von Vimeo "
 "unter: "
+
+#~ msgid "No matches found within the project area"
+#~ msgstr "Keine Treffer im Bereich des Projekts gefunden"
+
+#~ msgid "Did you mean:"
+#~ msgstr "Meinten Sie:"
+
+#~ msgid "Export polygon as GeoJSON"
+#~ msgstr "Polygon als GeoJSON exportierten"
+
+#~ msgid "Import polygon via file upload"
+#~ msgstr "Polygon aus Datei importieren"
+
+#~ msgid ""
+#~ "Upload a polygon from a GeoJSON (.geojson) or a zipped Shapefile (.zip)."
+#~ msgstr ""
+#~ "Laden Sie eine GeoJSON Datei (.geojson) oder ein gepacktes Shapefile (."
+#~ "zip) hoch."
+
+#~ msgid ""
+#~ "Note that uploading Shapefiles is not supported with Internet Explorer 10"
+#~ msgstr ""
+#~ "Beachten Sie, dass der Import von Shapefiles mit dem Internet Explorer 10 "
+#~ "nicht unterstützt wird"
+
+#~ msgid "Attention importing a file will delete the existing polygons."
+#~ msgstr ""
+#~ "Achtung der Import einer Datei wird alle vorher ausgewählten Polygone "
+#~ "entfernen."
+
+#~ msgid "Upload"
+#~ msgstr "Hochladen"
+
+#~ msgid "Cancel"
+#~ msgstr "Abbrechen"
+
+#~ msgid "The uploaded file is not a valid shapefile."
+#~ msgstr "Die hochgeladene Datei ist kein gültiges Shapefile."
+
+#~ msgid "The uploaded file could not be imported."
+#~ msgstr "Die hochgeladene Datei kann nicht importiert werden."
+
+#~ msgid "The uploaded file is not a valid geojson file."
+#~ msgstr "Die hochgeladene Datei ist keine gültiges GeoJSON Datei."
+
+#~ msgid "Invalid file format."
+#~ msgstr "Ungültiges Dateiformat."
+
+#~ msgid ""
+#~ "Do you want to load this preset and delete all the existing polygons?"
+#~ msgstr ""
+#~ "Möchten Sie diesen Kartenausschnitt auswählen und alle vorher "
+#~ "ausgewählten entfernen?"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -684,38 +684,38 @@ msgstr[1] ""
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:12
 msgid "modified on"
-msgstr ""
+msgstr "geändert am"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:13
 msgid "created on"
-msgstr ""
+msgstr "erstellt am"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:44
 msgid "Voted"
-msgstr ""
+msgstr "Gewählt"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:45
 msgid "Give my vote"
-msgstr ""
+msgstr "Meine Stimme geben"
 
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:11
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:15
 msgid "Positive Ratings"
-msgstr ""
+msgstr "Positive Bewertungen"
 
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:21
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:25
 msgid "Negative Ratings"
-msgstr ""
+msgstr "Negative Bewertungen"
 
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:31
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:36
 msgid "Comments"
-msgstr ""
+msgstr "Kommentare"
 
 #: meinberlin/apps/budgeting/assets/Pagination.jsx:15
 msgid "Page navigation"
-msgstr ""
+msgstr "Seitennummerierung"
 
 #: meinberlin/apps/captcha/assets/captcheck.js:30
 msgid "Image mode"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-08 13:56+0100\n"
+"POT-Creation-Date: 2021-12-13 14:40+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
-#: meinberlin/templates/a4categories/includes/module_categories_form.html:3
 msgid ""
 "In this section, you can create\n"
 "categories. If you create any, each contribution has to be assigned\n"
@@ -30,7 +29,7 @@ msgstr ""
 "to one of them. This way, content can be classified."
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
-#: meinberlin/templates/a4categories/includes/module_categories_form.html:21
+#: meinberlin/templates/a4categories/includes/module_categories_form.html:19
 msgid "Add category"
 msgstr "Add category"
 
@@ -227,7 +226,7 @@ msgstr "private"
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_dashboard_list_item.html:19
 #: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/includes/offlineevent_list_item.html:20
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:52
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:178
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:195
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:28
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:73
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_dashboard_list_item.html:19
@@ -327,7 +326,6 @@ msgstr ""
 "            "
 
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-#: meinberlin/templates/a4labels/includes/module_labels_form.html:3
 msgid ""
 "In this section, you can create\n"
 "labels. If you create any, each contribution can be assigned\n"
@@ -338,7 +336,7 @@ msgstr ""
 "to one or more of them. This way, content can be classified."
 
 #: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-#: meinberlin/templates/a4labels/includes/module_labels_form.html:21
+#: meinberlin/templates/a4labels/includes/module_labels_form.html:19
 msgid "Add label"
 msgstr "Add label"
 
@@ -510,7 +508,7 @@ msgstr "Only invited users can participate (private)."
 
 #: adhocracy4/dashboard/forms.py:86
 #: meinberlin/apps/plans/templates/meinberlin_plans/includes/plan_form.html:32
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:115
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:131
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:126
 msgid "Contact for questions"
 msgstr "Contact for questions"
@@ -639,9 +637,9 @@ msgid "Labels"
 msgstr "Labels"
 
 #: adhocracy4/exports/mixins/items.py:46
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:60
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:91
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:99
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
 msgid "Reference No."
 msgstr "Reference No."
@@ -651,7 +649,7 @@ msgid "Moderator feedback"
 msgstr "Moderator feedback"
 
 #: adhocracy4/exports/mixins/items.py:67
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:122
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:126
 msgid "Official Statement"
 msgstr "Official Statement"
 
@@ -1017,7 +1015,7 @@ msgid "Postal address"
 msgstr "Postal address"
 
 #: adhocracy4/projects/models.py:54
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:127
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:143
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
 msgid "Email"
@@ -1032,8 +1030,8 @@ msgid "Phone"
 msgstr "Phone"
 
 #: adhocracy4/projects/models.py:72
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:132
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:147
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:148
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:163
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:143
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:158
 msgid "Website"
@@ -1824,30 +1822,30 @@ msgstr ""
 "An error occurred while evaluating your data. Please check the data you "
 "entered again."
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:18
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:19
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:18
 msgid "Submit proposal"
 msgstr "Submit proposal"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:33
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:40
 msgid "Enter code"
 msgstr "Enter code"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:51
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:59
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:34
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:34
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:25
 msgid "Zoom in"
 msgstr "Zoom in"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:52
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:60
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:35
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:35
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:26
 msgid "Zoom out"
 msgstr "Zoom out"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:77
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:85
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html:29
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:52
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:60
@@ -1966,19 +1964,20 @@ msgstr[1] "projects you can participate in!"
 msgid "Scroll down"
 msgstr "Scroll down"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:6
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:10
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:13
 #, python-format
 msgid "What is happening in <strong>%(district)s</strong>?"
 msgstr "What is happening in <strong>%(district)s</strong>?"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:8
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:16
 #, python-format
 msgid "display %(counter)s project"
 msgid_plural "display %(counter)s projects"
 msgstr[0] "display %(counter)s project"
 msgstr[1] "display %(counter)s projects"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:28
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:42
 #: meinberlin/apps/plans/exports.py:64 meinberlin/apps/plans/forms.py:50
 #: meinberlin/apps/plans/templatetags/react_map_teaser.py:18
 #: meinberlin/apps/plans/views.py:87 meinberlin/apps/projects/admin.py:65
@@ -1988,30 +1987,29 @@ msgstr[1] "display %(counter)s projects"
 msgid "City wide"
 msgstr "City wide"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:37
-#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:65
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:55
 #, python-format
-msgid " %(time_left)s remaining "
-msgstr " %(time_left)s remaining "
+msgid "%(time_left)s remaining"
+msgstr "%(time_left)s remaining"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:39
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:57
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:67
 msgid "more than 1 year remaining"
 msgstr "more than 1 year remaining"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:46
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:64
 #, python-format
-msgid " Participation: from %(date)s"
-msgstr " Participation: from %(date)s"
+msgid "Participation: from %(date)s"
+msgstr "Participation: from %(date)s"
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:51
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:69
 msgid "Participation ended. Read result."
 msgstr "Participation ended. Read result."
 
-#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:60
+#: meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html:82
 #, python-format
-msgid " What is your opinion on this: %(name)s?"
-msgstr " What is your opinion on this: %(name)s?"
+msgid "What is your opinion on this: %(name)s?"
+msgstr "What is your opinion on this: %(name)s?"
 
 #: meinberlin/apps/contrib/django_standard_messages.py:6
 msgid "You have signed out."
@@ -2147,42 +2145,42 @@ msgstr "Positive Ratings"
 msgid "Negative Ratings"
 msgstr "Negative Ratings"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:46
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:53
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:43
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:45
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:50
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:54
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:44
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:49
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:102
 msgid "updated on "
 msgstr "updated on "
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:46
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:53
-#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:43
-#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:45
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/proposal_list_item.html:52
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
+#: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:46
+#: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:51
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:104
 msgid "created on "
 msgstr "created on "
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:82
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:91
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:161
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:170
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:86
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:95
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:177
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:186
 msgid "Actions"
 msgstr "Actions"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:96
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:100
 msgid "edit"
 msgstr "edit"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:98
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:102
 msgid "delete"
 msgstr "delete"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:102
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:106
 msgid "give feedback"
 msgstr "give feedback"
 
-#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:107
+#: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:111
 msgid "report"
 msgstr "report"
 
@@ -2786,17 +2784,15 @@ msgstr ""
 
 #: meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html:3
 msgid ""
-"Here you can specify affiliations. Users must classify\n"
-"    questions accordingly. The questions can be filtered by affiliation and "
-"evaluated in the\n"
-"    statistics."
+"Here you can specify affiliations. Users must classify questions "
+"accordingly. The questions can be filtered by affiliation and evaluated in "
+"the statistics."
 msgstr ""
-"Here you can specify affiliations. Users must classify\n"
-"    questions accordingly. The questions can be filtered by affiliation and "
-"evaluated in the\n"
-"    statistics."
+"Here you can specify affiliations. Users must classify questions "
+"accordingly. The questions can be filtered by affiliation and evaluated in "
+"the statistics."
 
-#: meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html:22
+#: meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html:20
 msgid "Add affiliation"
 msgstr "Add affiliation"
 
@@ -3311,7 +3307,7 @@ msgstr ""
 "plan. In the project overview projects can be filtered by district."
 
 #: meinberlin/apps/plans/models.py:94
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:77
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:82
 msgid "Cost"
 msgstr "Cost"
 
@@ -3379,7 +3375,7 @@ msgid "In the project overview projects can be filtered by status."
 msgstr "In the project overview projects can be filtered by status."
 
 #: meinberlin/apps/plans/models.py:148
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:82
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:87
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:51
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:97
 msgid "Participation"
@@ -3394,7 +3390,7 @@ msgstr ""
 "status."
 
 #: meinberlin/apps/plans/models.py:158
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:71
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:76
 msgid "Duration"
 msgstr "Duration"
 
@@ -3515,21 +3511,21 @@ msgstr "Location"
 msgid "Topic"
 msgstr "Topic"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:85
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
 msgid "see participation plans"
 msgstr "see participation plans"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:123
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:139
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:134
 msgid "Telephone"
 msgstr "Telephone"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:140
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:156
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:151
 msgid "Responsible body"
 msgstr "Responsible body"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:193
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:212
 #: meinberlin/templates/a4dashboard/base_project_list.html:7
 #: meinberlin/templates/a4dashboard/base_project_list.html:16
 #: meinberlin/templates/a4dashboard/project_list.html:9
@@ -3566,26 +3562,20 @@ msgstr "Close"
 
 #: meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html:3
 msgid ""
-"\n"
 "Please select the plan your project belongs to. Your project will be shown "
-"in the list of plans accordingly.\n"
+"in the list of plans accordingly."
 msgstr ""
-"\n"
 "Please select the plan your project belongs to. Your project will be shown "
-"in the list of plans accordingly.\n"
+"in the list of plans accordingly."
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html:12
+#: meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html:10
 #, python-format
 msgid ""
-"\n"
-"    No plan has been created yet. You can do that <a href="
-"\"%(plan_create_url)s\">here</a>.\n"
-"    "
+"No plan has been created yet. You can do that <a href=\"%(plan_create_url)s"
+"\">here</a>."
 msgstr ""
-"\n"
-"    No plan has been created yet. You can do that <a href="
-"\"%(plan_create_url)s\">here</a>.\n"
-"    "
+"No plan has been created yet. You can do that <a href=\"%(plan_create_url)s"
+"\">here</a>."
 
 #: meinberlin/apps/plans/views.py:164
 msgid "The plan was created"
@@ -3828,6 +3818,11 @@ msgstr "Read now"
 msgid "Participation projects: "
 msgstr "Participation projects: "
 
+#: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:65
+#, python-format
+msgid "%(time_left)s remaining "
+msgstr "%(time_left)s remaining "
+
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_timeline-carousel.html:12
 msgid "Timeline item"
 msgstr "Timeline item"
@@ -3938,8 +3933,8 @@ msgstr "Proceed to login"
 #: meinberlin/apps/users/templates/meinberlin_users/indicator.html:55
 #: meinberlin/templates/account/signup.html:4
 #: meinberlin/templates/account/signup.html:7
-#: meinberlin/templates/account/signup.html:45
-#: meinberlin/templates/socialaccount/signup.html:38
+#: meinberlin/templates/account/signup.html:42
+#: meinberlin/templates/socialaccount/signup.html:35
 msgid "Register"
 msgstr "Register"
 
@@ -3952,12 +3947,12 @@ msgstr ""
 "able to moderate the project."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_form.html:15
-#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:18
+#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:15
 msgid "Accept"
 msgstr "Accept"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_form.html:16
-#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:19
+#: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:16
 msgid "Decline"
 msgstr "Decline"
 
@@ -3986,23 +3981,17 @@ msgstr "Do you want to join %(project)s?"
 #: meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html:11
 #, python-format
 msgid ""
-"\n"
-"                You were invited by the initiator of the project. If you "
-"accept you will be able to participate in the project with your username "
-"\"%(user)s\".\n"
-"                If you want to join with a different profile please login "
-"with your other profile and follow the invitation link again. If you decline "
-"the invitation the link is not valid anymore.\n"
-"                "
+"You were invited by the initiator of the project. If you accept you will be "
+"able to participate in the project with your username \"%(user)s\". If you "
+"want to join with a different profile please login with your other profile "
+"and follow the invitation link again. If you decline the invitation the link "
+"is not valid anymore."
 msgstr ""
-"\n"
-"                You were invited by the initiator of the project. If you "
-"accept you will be able to participate in the project with your username "
-"\"%(user)s\".\n"
-"                If you want to join with a different profile please login "
-"with your other profile and follow the invitation link again. If you decline "
-"the invitation the link is not valid anymore.\n"
-"                "
+"You were invited by the initiator of the project. If you accept you will be "
+"able to participate in the project with your username \"%(user)s\". If you "
+"want to join with a different profile please login with your other profile "
+"and follow the invitation link again. If you decline the invitation the link "
+"is not valid anymore."
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:23
 #: meinberlin/templates/a4modules/module_detail.html:24
@@ -4098,29 +4087,17 @@ msgstr "Login via Service-Konto"
 
 #: meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html:10
 msgid ""
-"\n"
-"            <p>To sign in via Service-Konto on meinBerlin you will be "
-"redirected to the Service-Konto.</p>\n"
-"            <p>\n"
-"                There you have to sign in with your credentials first, find "
-"the Service <strong>mein.Berlin</strong> and\n"
-"                finally click on <strong>Hier starten</strong> to return to "
-"the meinBerlin platform.\n"
-"            </p>\n"
-"        "
+"<p>To sign in via Service-Konto on meinBerlin you will be redirected to the "
+"Service-Konto.</p><p>There you have to sign in with your credentials first, "
+"find the Service <strong>mein.Berlin</strong> and finally click on "
+"<strong>Hier starten</strong> to return to the meinBerlin platform.</p>"
 msgstr ""
-"\n"
-"            <p>To sign in via Service-Konto on meinBerlin you will be "
-"redirected to the Service-Konto.</p>\n"
-"            <p>\n"
-"                There you have to sign in with your credentials first, find "
-"the Service <strong>mein.Berlin</strong> and\n"
-"                finally click on <strong>Hier starten</strong> to return to "
-"the meinBerlin platform.\n"
-"            </p>\n"
-"        "
+"<p>To sign in via Service-Konto on meinBerlin you will be redirected to the "
+"Service-Konto.</p><p>There you have to sign in with your credentials first, "
+"find the Service <strong>mein.Berlin</strong> and finally click on "
+"<strong>Hier starten</strong> to return to the meinBerlin platform.</p>"
 
-#: meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html:19
+#: meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html:13
 msgid "Service-Konto Login"
 msgstr "Service-Konto Login"
 
@@ -4433,6 +4410,16 @@ msgstr "Internal server error."
 msgid "Back to meinBerlin."
 msgstr "Back to meinBerlin."
 
+#: meinberlin/templates/a4categories/includes/module_categories_form.html:3
+msgid ""
+"In this section, you can create categories. If you create any, each "
+"contribution has to be assigned to one of them. This way, content can be "
+"classified."
+msgstr ""
+"In this section, you can create categories. If you create any, each "
+"contribution has to be assigned to one of them. This way, content can be "
+"classified."
+
 #: meinberlin/templates/a4dashboard/base_dashboard.html:16
 msgid "Organisations"
 msgstr "Organisations"
@@ -4444,15 +4431,13 @@ msgstr "All participation projects"
 
 #: meinberlin/templates/a4dashboard/includes/module_phases_form.html:6
 msgid ""
-"Depending on the selected module, the participation\n"
-"    process has one or two phases. The name and description of the phase(s)\n"
-"    should encourage the users to participate and let them know how\n"
-"    they can participate."
+"Depending on the selected module, the participation process has one or two "
+"phases. The name and description of the phase(s) should encourage the users "
+"to participate and let them know how they can participate."
 msgstr ""
-"Depending on the selected module, the participation\n"
-"    process has one or two phases. The name and description of the phase(s)\n"
-"    should encourage the users to participate and let them know how\n"
-"    they can participate."
+"Depending on the selected module, the participation process has one or two "
+"phases. The name and description of the phase(s) should encourage the users "
+"to participate and let them know how they can participate."
 
 #: meinberlin/templates/a4dashboard/includes/nav_modules.html:4
 msgid "Participation Module"
@@ -4641,6 +4626,14 @@ msgstr ""
 "Your image will be uploaded/removed once you save your changes at the end of "
 "this page."
 
+#: meinberlin/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create labels. If you create any, each contribution "
+"can be assigned to one or more of them. This way, content can be classified."
+msgstr ""
+"In this section, you can create labels. If you create any, each contribution "
+"can be assigned to one or more of them. This way, content can be classified."
+
 #: meinberlin/templates/a4modules/includes/module_detail_phase.html:50
 msgid ""
 "This project is not publicly visible. Only invited users can see content and "
@@ -4716,28 +4709,24 @@ msgstr "Confirm Email Address"
 #: meinberlin/templates/account/email_confirm.html:11
 #, python-format
 msgid ""
-"Please\n"
-"            confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an\n"
-"            email address for user %(user_display)s."
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
+"address for user %(user_display)s."
 msgstr ""
-"Please\n"
-"            confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an\n"
-"            email address for user %(user_display)s."
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
+"address for user %(user_display)s."
 
-#: meinberlin/templates/account/email_confirm.html:17
+#: meinberlin/templates/account/email_confirm.html:15
 msgid "Confirm"
 msgstr "Confirm"
 
-#: meinberlin/templates/account/email_confirm.html:21
+#: meinberlin/templates/account/email_confirm.html:19
 #, python-format
 msgid ""
-"This email confirmation link expired or is invalid.\n"
-"            Please <a href=\"%(email_url)s\">issue a new email confirmation\n"
-"                request</a>."
+"This email confirmation link expired or is invalid. Please <a href="
+"\"%(email_url)s\">issue a new email confirmation request</a>."
 msgstr ""
-"This email confirmation link expired or is invalid.\n"
-"            Please <a href=\"%(email_url)s\">issue a new email confirmation\n"
-"                request</a>."
+"This email confirmation link expired or is invalid. Please <a href="
+"\"%(email_url)s\">issue a new email confirmation request</a>."
 
 #: meinberlin/templates/account/login.html:9
 #, python-format
@@ -4827,13 +4816,11 @@ msgstr "Your password is now changed."
 #: meinberlin/templates/account/signup.html:9
 #, python-format
 msgid ""
-"Already have an account? Then please\n"
-"        <a href=\"%(login_url)s\">login</a>."
+"Already have an account? Then please <a href=\"%(login_url)s\">login</a>."
 msgstr ""
-"Already have an account? Then please\n"
-"        <a href=\"%(login_url)s\">login</a>."
+"Already have an account? Then please <a href=\"%(login_url)s\">login</a>."
 
-#: meinberlin/templates/account/signup.html:12
+#: meinberlin/templates/account/signup.html:11
 msgid ""
 "If you register on mein.berlin.de, you can write ideas and comments for "
 "ongoing participation processes and rate the contributors of other users."
@@ -4841,27 +4828,23 @@ msgstr ""
 "If you register on mein.berlin.de, you can write ideas and comments for "
 "ongoing participation processes and rate the contributors of other users."
 
-#: meinberlin/templates/account/signup.html:31
-#: meinberlin/templates/socialaccount/signup.html:28
+#: meinberlin/templates/account/signup.html:30
+#: meinberlin/templates/socialaccount/signup.html:27
 #, python-format
 msgid ""
-"\n"
-"                 I hereby expressly consent to the collection and processing "
-"(storage) of my data and expressly consent to the processing and publication "
-"of my ideas, comments and contributions as described in the privacy policy. "
-"I also confirm that I have read and accept the <a href=\"%(terms_of_use_url)s"
-"\" target=\"_blank\">terms of use</a> and the <a href=\"%(privacy_policy)s\" "
-"target=\"_blank\">privacy policy</a>.\n"
-"                "
+"I hereby expressly consent to the collection and processing (storage) of my "
+"data and expressly consent to the processing and publication of my ideas, "
+"comments and contributions as described in the privacy policy. I also "
+"confirm that I have read and accept the <a href=\"%(terms_of_use_url)s\" "
+"target=\"_blank\">terms of use</a> and the <a href=\"%(privacy_policy)s\" "
+"target=\"_blank\">privacy policy</a>."
 msgstr ""
-"\n"
-"                 I hereby expressly consent to the collection and processing "
-"(storage) of my data and expressly consent to the processing and publication "
-"of my ideas, comments and contributions as described in the privacy policy. "
-"I also confirm that I have read and accept the <a href=\"%(terms_of_use_url)s"
-"\" target=\"_blank\">terms of use</a> and the <a href=\"%(privacy_policy)s\" "
-"target=\"_blank\">privacy policy</a>.\n"
-"                "
+"I hereby expressly consent to the collection and processing (storage) of my "
+"data and expressly consent to the processing and publication of my ideas, "
+"comments and contributions as described in the privacy policy. I also "
+"confirm that I have read and accept the <a href=\"%(terms_of_use_url)s\" "
+"target=\"_blank\">terms of use</a> and the <a href=\"%(privacy_policy)s\" "
+"target=\"_blank\">privacy policy</a>."
 
 #: meinberlin/templates/base_errors.html:4
 msgid "Error"
@@ -4945,11 +4928,161 @@ msgstr "Sign Up"
 #: meinberlin/templates/socialaccount/signup.html:10
 #, python-format
 msgid ""
-"You are about to use your %(provider_name)s account to login to\n"
+"You are about to use your %(provider_name)s account to login to "
 "%(site_name)s. As a final step, please complete the following form:"
 msgstr ""
-"You are about to use your %(provider_name)s account to login to\n"
+"You are about to use your %(provider_name)s account to login to "
 "%(site_name)s. As a final step, please complete the following form:"
+
+#~ msgid " %(time_left)s remaining "
+#~ msgstr " %(time_left)s remaining "
+
+#~ msgid " Participation: from %(date)s"
+#~ msgstr " Participation: from %(date)s"
+
+#~ msgid " What is your opinion on this: %(name)s?"
+#~ msgstr " What is your opinion on this: %(name)s?"
+
+#~ msgid ""
+#~ "Here you can specify affiliations. Users must classify\n"
+#~ "    questions accordingly. The questions can be filtered by affiliation "
+#~ "and evaluated in the\n"
+#~ "    statistics."
+#~ msgstr ""
+#~ "Here you can specify affiliations. Users must classify\n"
+#~ "    questions accordingly. The questions can be filtered by affiliation "
+#~ "and evaluated in the\n"
+#~ "    statistics."
+
+#~ msgid ""
+#~ "\n"
+#~ "Please select the plan your project belongs to. Your project will be "
+#~ "shown in the list of plans accordingly.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Please select the plan your project belongs to. Your project will be "
+#~ "shown in the list of plans accordingly.\n"
+
+#~ msgid ""
+#~ "\n"
+#~ "    No plan has been created yet. You can do that <a href="
+#~ "\"%(plan_create_url)s\">here</a>.\n"
+#~ "    "
+#~ msgstr ""
+#~ "\n"
+#~ "    No plan has been created yet. You can do that <a href="
+#~ "\"%(plan_create_url)s\">here</a>.\n"
+#~ "    "
+
+#~ msgid ""
+#~ "\n"
+#~ "                You were invited by the initiator of the project. If you "
+#~ "accept you will be able to participate in the project with your username "
+#~ "\"%(user)s\".\n"
+#~ "                If you want to join with a different profile please login "
+#~ "with your other profile and follow the invitation link again. If you "
+#~ "decline the invitation the link is not valid anymore.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "                You were invited by the initiator of the project. If you "
+#~ "accept you will be able to participate in the project with your username "
+#~ "\"%(user)s\".\n"
+#~ "                If you want to join with a different profile please login "
+#~ "with your other profile and follow the invitation link again. If you "
+#~ "decline the invitation the link is not valid anymore.\n"
+#~ "                "
+
+#~ msgid ""
+#~ "\n"
+#~ "            <p>To sign in via Service-Konto on meinBerlin you will be "
+#~ "redirected to the Service-Konto.</p>\n"
+#~ "            <p>\n"
+#~ "                There you have to sign in with your credentials first, "
+#~ "find the Service <strong>mein.Berlin</strong> and\n"
+#~ "                finally click on <strong>Hier starten</strong> to return "
+#~ "to the meinBerlin platform.\n"
+#~ "            </p>\n"
+#~ "        "
+#~ msgstr ""
+#~ "\n"
+#~ "            <p>To sign in via Service-Konto on meinBerlin you will be "
+#~ "redirected to the Service-Konto.</p>\n"
+#~ "            <p>\n"
+#~ "                There you have to sign in with your credentials first, "
+#~ "find the Service <strong>mein.Berlin</strong> and\n"
+#~ "                finally click on <strong>Hier starten</strong> to return "
+#~ "to the meinBerlin platform.\n"
+#~ "            </p>\n"
+#~ "        "
+
+#~ msgid ""
+#~ "Depending on the selected module, the participation\n"
+#~ "    process has one or two phases. The name and description of the "
+#~ "phase(s)\n"
+#~ "    should encourage the users to participate and let them know how\n"
+#~ "    they can participate."
+#~ msgstr ""
+#~ "Depending on the selected module, the participation\n"
+#~ "    process has one or two phases. The name and description of the "
+#~ "phase(s)\n"
+#~ "    should encourage the users to participate and let them know how\n"
+#~ "    they can participate."
+
+#~ msgid ""
+#~ "Please\n"
+#~ "            confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is "
+#~ "an\n"
+#~ "            email address for user %(user_display)s."
+#~ msgstr ""
+#~ "Please\n"
+#~ "            confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is "
+#~ "an\n"
+#~ "            email address for user %(user_display)s."
+
+#~ msgid ""
+#~ "This email confirmation link expired or is invalid.\n"
+#~ "            Please <a href=\"%(email_url)s\">issue a new email "
+#~ "confirmation\n"
+#~ "                request</a>."
+#~ msgstr ""
+#~ "This email confirmation link expired or is invalid.\n"
+#~ "            Please <a href=\"%(email_url)s\">issue a new email "
+#~ "confirmation\n"
+#~ "                request</a>."
+
+#~ msgid ""
+#~ "Already have an account? Then please\n"
+#~ "        <a href=\"%(login_url)s\">login</a>."
+#~ msgstr ""
+#~ "Already have an account? Then please\n"
+#~ "        <a href=\"%(login_url)s\">login</a>."
+
+#~ msgid ""
+#~ "\n"
+#~ "                 I hereby expressly consent to the collection and "
+#~ "processing (storage) of my data and expressly consent to the processing "
+#~ "and publication of my ideas, comments and contributions as described in "
+#~ "the privacy policy. I also confirm that I have read and accept the <a "
+#~ "href=\"%(terms_of_use_url)s\" target=\"_blank\">terms of use</a> and the "
+#~ "<a href=\"%(privacy_policy)s\" target=\"_blank\">privacy policy</a>.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "                 I hereby expressly consent to the collection and "
+#~ "processing (storage) of my data and expressly consent to the processing "
+#~ "and publication of my ideas, comments and contributions as described in "
+#~ "the privacy policy. I also confirm that I have read and accept the <a "
+#~ "href=\"%(terms_of_use_url)s\" target=\"_blank\">terms of use</a> and the "
+#~ "<a href=\"%(privacy_policy)s\" target=\"_blank\">privacy policy</a>.\n"
+#~ "                "
+
+#~ msgid ""
+#~ "You are about to use your %(provider_name)s account to login to\n"
+#~ "%(site_name)s. As a final step, please complete the following form:"
+#~ msgstr ""
+#~ "You are about to use your %(provider_name)s account to login to\n"
+#~ "%(site_name)s. As a final step, please complete the following form:"
 
 #~ msgid "deleted by creator"
 #~ msgstr "deleted by creator"

--- a/locale/en_GB/LC_MESSAGES/djangojs.po
+++ b/locale/en_GB/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-08 13:56+0100\n"
+"POT-Creation-Date: 2021-12-13 14:40+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -559,7 +559,6 @@ msgstr "Thank you! We are taking care of it."
 #: meinberlin/apps/contrib/assets/Alert.jsx:11
 #: meinberlin/apps/embed/assets/embed.js:59
 #: meinberlin/apps/embed/assets/embed.js:60
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:85
 #: meinberlin/apps/plans/assets/FilterNav.jsx:213
 msgid "Close"
 msgstr "Close"
@@ -577,11 +576,19 @@ msgid_plural "you have %s votes left"
 msgstr[0] "you have 1 vote left"
 msgstr[1] "you have %s votes left"
 
-#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:40
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:12
+msgid "modified on"
+msgstr "modified on"
+
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:13
+msgid "created on"
+msgstr "created on"
+
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:44
 msgid "Voted"
 msgstr "Voted"
 
-#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:41
+#: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:45
 msgid "Give my vote"
 msgstr "Give my vote"
 
@@ -825,69 +832,6 @@ msgstr "Questions Answered"
 #: meinberlin/apps/livequestions/assets/StatisticsBox.jsx:45
 msgid "Affiliation Of Answered Questions"
 msgstr "Affiliation Of Answered Questions"
-
-#: meinberlin/apps/maps/assets/map-address.js:87
-msgid "No matches found within the project area"
-msgstr "No matches found within the project area"
-
-#: meinberlin/apps/maps/assets/map-address.js:90
-msgid "Did you mean:"
-msgstr "Did you mean:"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:67
-msgid "Export polygon as GeoJSON"
-msgstr "Export polygon as GeoJSON"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:68
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:78
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:90
-msgid "Import polygon via file upload"
-msgstr "Import polygon via file upload"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:92
-msgid ""
-"Upload a polygon from a GeoJSON (.geojson) or a zipped Shapefile (.zip)."
-msgstr ""
-"Upload a polygon from a GeoJSON (.geojson) or a zipped Shapefile (.zip)."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:93
-msgid ""
-"Note that uploading Shapefiles is not supported with Internet Explorer 10"
-msgstr ""
-"Note that uploading Shapefiles is not supported with Internet Explorer 10"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:94
-msgid "Attention importing a file will delete the existing polygons."
-msgstr "Attention importing a file will delete the existing polygons."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:99
-msgid "Upload"
-msgstr "Upload"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:106
-msgid "Cancel"
-msgstr "Cancel"
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:140
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:142
-msgid "The uploaded file is not a valid shapefile."
-msgstr "The uploaded file is not a valid shapefile."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:144
-msgid "The uploaded file could not be imported."
-msgstr "The uploaded file could not be imported."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:158
-msgid "The uploaded file is not a valid geojson file."
-msgstr "The uploaded file is not a valid geojson file."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:163
-msgid "Invalid file format."
-msgstr "Invalid file format."
-
-#: meinberlin/apps/maps/assets/map_choose_polygon_with_preset.js:280
-msgid "Do you want to load this preset and delete all the existing polygons?"
-msgstr "Do you want to load this preset and delete all the existing polygons?"
 
 #: meinberlin/apps/plans/assets/FilterNav.jsx:126
 #: meinberlin/apps/plans/assets/FilterNav.jsx:242
@@ -1136,6 +1080,54 @@ msgstr ""
 #: dsgvo-video-embed/js/dsgvo-video-embed.js:20
 msgid "More information can be found in the privacy policy of Vimeo under: "
 msgstr "More information can be found in the privacy policy of Vimeo under: "
+
+#~ msgid "No matches found within the project area"
+#~ msgstr "No matches found within the project area"
+
+#~ msgid "Did you mean:"
+#~ msgstr "Did you mean:"
+
+#~ msgid "Export polygon as GeoJSON"
+#~ msgstr "Export polygon as GeoJSON"
+
+#~ msgid "Import polygon via file upload"
+#~ msgstr "Import polygon via file upload"
+
+#~ msgid ""
+#~ "Upload a polygon from a GeoJSON (.geojson) or a zipped Shapefile (.zip)."
+#~ msgstr ""
+#~ "Upload a polygon from a GeoJSON (.geojson) or a zipped Shapefile (.zip)."
+
+#~ msgid ""
+#~ "Note that uploading Shapefiles is not supported with Internet Explorer 10"
+#~ msgstr ""
+#~ "Note that uploading Shapefiles is not supported with Internet Explorer 10"
+
+#~ msgid "Attention importing a file will delete the existing polygons."
+#~ msgstr "Attention importing a file will delete the existing polygons."
+
+#~ msgid "Upload"
+#~ msgstr "Upload"
+
+#~ msgid "Cancel"
+#~ msgstr "Cancel"
+
+#~ msgid "The uploaded file is not a valid shapefile."
+#~ msgstr "The uploaded file is not a valid shapefile."
+
+#~ msgid "The uploaded file could not be imported."
+#~ msgstr "The uploaded file could not be imported."
+
+#~ msgid "The uploaded file is not a valid geojson file."
+#~ msgstr "The uploaded file is not a valid geojson file."
+
+#~ msgid "Invalid file format."
+#~ msgstr "Invalid file format."
+
+#~ msgid ""
+#~ "Do you want to load this preset and delete all the existing polygons?"
+#~ msgstr ""
+#~ "Do you want to load this preset and delete all the existing polygons?"
 
 #~ msgid "January"
 #~ msgstr "January"

--- a/meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html
+++ b/meinberlin/apps/cms/templates/meinberlin_cms/includes/storefronts.html
@@ -7,19 +7,13 @@
     class="storefront__item storefront__district tile__md"
 >
     <h2 class="storefront__district-text">
-        {% blocktrans with district=item.district %}
-            What is happening in <strong>{{ district }}</strong>?
-        {% endblocktrans %}
+        {% blocktrans with district=item.district %}What is happening in <strong>{{ district }}</strong>?{% endblocktrans %}
     </h2>
     <h2 class="storefront__district-text">
-        {% blocktrans with district=item.district %}
-            What is happening in <strong>{{ district }}</strong>?
-        {% endblocktrans %}
+        {% blocktrans with district=item.district %}What is happening in <strong>{{ district }}</strong>?{% endblocktrans %}
     </h2>
     <button class="btn btn-primary">
-        {% blocktrans count counter=item.district_project_count %}
-            display {{ counter }} project{% plural %}display {{ counter }} projects
-        {% endblocktrans %}
+        {% blocktrans count counter=item.district_project_count %}display {{ counter }} project{% plural %}display {{ counter }} projects{% endblocktrans %}
     </button>
 </a>
 {% elif item.project and not item.quote %}
@@ -58,9 +52,7 @@
         </div>
         <span class="status-bar__status"><i class="fas fa-clock"></i>
           {% if item.project.module_running_days_left < 365 %}
-            {% blocktrans with time_left=item.project.module_running_time_left %}
-                {{ time_left }} remaining
-            {% endblocktrans %}
+            {% blocktrans with time_left=item.project.module_running_time_left %}{{ time_left }} remaining{% endblocktrans %}
           {% else %}
           <span>{% trans 'more than 1 year remaining' %}</span>
           {% endif %}
@@ -69,10 +61,7 @@
 
     {% elif item.item_type != 'external' and item.project.future_modules %}
     <div class="status-item status-item__position-storefront status__future">
-      <span class="status-bar__status"><i class="fas fa-clock" ></i>
-          {% trans 'Participation: from ' %}
-          {% html_date item.project.future_modules.first.module_start class='list-item__date' %}
-      </span>
+      <span class="status-bar__status"><i class="fas fa-clock" ></i>{% blocktrans with date=item.project.future_modules.first.module_start|date:"d.m.Y" %}Participation: from {{ date }}{% endblocktrans %}</span>
     </div>
 
     {% elif item.project.has_finished %}
@@ -90,9 +79,7 @@
         „{{ item.quote|truncatechars:150 }}“
     </blockquote>
     <div class="storefront__opinion-text">
-        {% blocktrans with name=item.project.name|truncatechars:60 %}
-            What is your opinion on this: {{ name }}?
-        {% endblocktrans %}
+        {% blocktrans with name=item.project.name|truncatechars:60 %}What is your opinion on this: {{ name }}?{% endblocktrans %}
     </div>
 </a>
 {% elif not item.project and item.quote %}

--- a/meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html
+++ b/meinberlin/apps/livequestions/templates/meinberlin_livequestions/includes/module_affiliations_form.html
@@ -1,8 +1,6 @@
 {% load i18n %}
 
-<p class="form-hint">{% blocktrans %}Here you can specify affiliations. Users must classify
-    questions accordingly. The questions can be filtered by affiliation and evaluated in the
-    statistics.{% endblocktrans %}
+<p class="form-hint">{% blocktrans %}Here you can specify affiliations. Users must classify questions accordingly. The questions can be filtered by affiliation and evaluated in the statistics.{% endblocktrans %}
 </p>
 
 <div class="js-formset category-formset"

--- a/meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/project_plans_form.html
@@ -1,17 +1,13 @@
 {% load i18n %}
 <p class="form-hint">
-    {% blocktrans %}
-Please select the plan your project belongs to. Your project will be shown in the list of plans accordingly.
-{% endblocktrans %}
+    {% blocktrans %}Please select the plan your project belongs to. Your project will be shown in the list of plans accordingly.{% endblocktrans %}
 </p>
 {% if form.plans.field.choices %}
     {% include 'a4dashboard/includes/form_field.html' with field=form.plans %}
 {% else %}
     <p class="form-hint">
     {% url 'a4dashboard:plan-create' form.instance.organisation.slug as plan_create_url  %}
-    {% blocktrans %}
-    No plan has been created yet. You can do that <a href="{{ plan_create_url }}">here</a>.
-    {% endblocktrans %}
+    {% blocktrans %}No plan has been created yet. You can do that <a href="{{ plan_create_url }}">here</a>.{% endblocktrans %}
     </p>
 {{ form.plans.errors }}
 {% endif %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html
@@ -62,7 +62,7 @@
                         <span class="participation-tile__status">
                             <i class="fas fa-clock" aria-hidden="true"></i>
                             {% if project.module_running_days_left < 365 %}
-                            {% blocktrans with time_left=project.module_running_time_left %} {{ time_left }} remaining {% endblocktrans %}
+                            {% blocktrans with time_left=project.module_running_time_left %}{{ time_left }} remaining {% endblocktrans %}
                             {% else %}
                             <span>{% trans 'more than 1 year remaining' %}</span>
                             {% endif %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/participantinvite_form.html
@@ -8,10 +8,7 @@
             <h1>{% blocktrans with project=participantinvite.project.name %}Do you want to join {{ project }}?{% endblocktrans %}</h1>
             {{ form.non_field_errors }}
             <p>
-                {% blocktrans with user=request.user.username %}
-                You were invited by the initiator of the project. If you accept you will be able to participate in the project with your username "{{ user }}".
-                If you want to join with a different profile please login with your other profile and follow the invitation link again. If you decline the invitation the link is not valid anymore.
-                {% endblocktrans %}
+                {% blocktrans with user=request.user.username %}You were invited by the initiator of the project. If you accept you will be able to participate in the project with your username "{{ user }}". If you want to join with a different profile please login with your other profile and follow the invitation link again. If you decline the invitation the link is not valid anymore.{% endblocktrans %}
             </p>
             <form method="POST">
                 {% csrf_token %}

--- a/meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html
+++ b/meinberlin/apps/servicekonto/templates/meinberlin_servicekonto/login.html
@@ -7,13 +7,7 @@
 <div class="l-wrapper">
     <div class="l-center-6">
         <h1>{% trans 'Login via Service-Konto' %}</h1>
-        {% blocktrans %}
-            <p>To sign in via Service-Konto on meinBerlin you will be redirected to the Service-Konto.</p>
-            <p>
-                There you have to sign in with your credentials first, find the Service <strong>mein.Berlin</strong> and
-                finally click on <strong>Hier starten</strong> to return to the meinBerlin platform.
-            </p>
-        {% endblocktrans %}
+        {% blocktrans %}<p>To sign in via Service-Konto on meinBerlin you will be redirected to the Service-Konto.</p><p>There you have to sign in with your credentials first, find the Service <strong>mein.Berlin</strong> and finally click on <strong>Hier starten</strong> to return to the meinBerlin platform.</p>{% endblocktrans %}
 
         <a class="btn btn--primary" href="{{ login_redirect_url }}">
             {% trans 'Service-Konto Login' %}

--- a/meinberlin/templates/a4categories/includes/module_categories_form.html
+++ b/meinberlin/templates/a4categories/includes/module_categories_form.html
@@ -1,8 +1,6 @@
 {% load i18n %}
 
-<p class="form-hint">{% blocktrans %}In this section, you can create
-categories. If you create any, each contribution has to be assigned
-to one of them. This way, content can be classified.{% endblocktrans %}</p>
+<p class="form-hint">{% blocktrans %}In this section, you can create categories. If you create any, each contribution has to be assigned to one of them. This way, content can be classified.{% endblocktrans %}</p>
 
 <div class="js-formset category-formset"
      data-prefix="{{ form.prefix }}">

--- a/meinberlin/templates/a4dashboard/includes/module_phases_form.html
+++ b/meinberlin/templates/a4dashboard/includes/module_phases_form.html
@@ -3,10 +3,7 @@
 {{ form.management_form }}
 
 <p class="form-hint">
-    {% blocktrans %}Depending on the selected module, the participation
-    process has one or two phases. The name and description of the phase(s)
-    should encourage the users to participate and let them know how
-    they can participate.{% endblocktrans %}
+    {% blocktrans %}Depending on the selected module, the participation process has one or two phases. The name and description of the phase(s) should encourage the users to participate and let them know how they can participate.{% endblocktrans %}
 </p>
 
 {% for phase_form in form %}

--- a/meinberlin/templates/a4labels/includes/module_labels_form.html
+++ b/meinberlin/templates/a4labels/includes/module_labels_form.html
@@ -1,8 +1,6 @@
 {% load i18n %}
 
-<p class="form-hint">{% blocktrans %}In this section, you can create
-labels. If you create any, each contribution can be assigned
-to one or more of them. This way, content can be classified.{% endblocktrans %}</p>
+<p class="form-hint">{% blocktrans %}In this section, you can create labels. If you create any, each contribution can be assigned to one or more of them. This way, content can be classified.{% endblocktrans %}</p>
 
 <div class="js-formset category-formset"
      data-prefix="{{ form.prefix }}">

--- a/meinberlin/templates/account/email_confirm.html
+++ b/meinberlin/templates/account/email_confirm.html
@@ -8,9 +8,7 @@
 
     {% if confirmation %}
         {% user_display confirmation.email_address.user as user_display %}
-        <p>{% blocktrans with confirmation.email_address.email as email %}Please
-            confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an
-            email address for user {{ user_display }}.{% endblocktrans %}</p>
+        <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an email address for user {{ user_display }}.{% endblocktrans %}</p>
 
         <form method="post">
             {% csrf_token %}
@@ -18,9 +16,7 @@
         </form>
     {% else %}
         {% url 'account_email' as email_url %}
-        <p>{% blocktrans %}This email confirmation link expired or is invalid.
-            Please <a href="{{ email_url }}">issue a new email confirmation
-                request</a>.{% endblocktrans %}</p>
+        <p>{% blocktrans %}This email confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new email confirmation request</a>.{% endblocktrans %}</p>
 
     {% endif %}
 

--- a/meinberlin/templates/account/signup.html
+++ b/meinberlin/templates/account/signup.html
@@ -6,8 +6,7 @@
 {% block content %}
     <h1>{% trans "Register" %}</h1>
 
-    <p>{% blocktrans %}Already have an account? Then please
-        <a href="{{ login_url }}">login</a>.{% endblocktrans %}</p>
+    <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">login</a>.{% endblocktrans %}</p>
 
     <p>{% trans "If you register on mein.berlin.de, you can write ideas and comments for ongoing participation processes and rate the contributors of other users." %}</p>
 
@@ -28,9 +27,7 @@
         <div class="form-check">
             <label class="form-check__label">
                 {{ form.terms_of_use }}
-                {% blocktrans with terms_of_use_url="/terms-of-use" privacy_policy="/datenschutz" %}
-                 I hereby expressly consent to the collection and processing (storage) of my data and expressly consent to the processing and publication of my ideas, comments and contributions as described in the privacy policy. I also confirm that I have read and accept the <a href="{{terms_of_use_url}}" target="_blank">terms of use</a> and the <a href="{{privacy_policy}}" target="_blank">privacy policy</a>.
-                {% endblocktrans %}
+                {% blocktrans with terms_of_use_url="/terms-of-use" privacy_policy="/datenschutz" %}I hereby expressly consent to the collection and processing (storage) of my data and expressly consent to the processing and publication of my ideas, comments and contributions as described in the privacy policy. I also confirm that I have read and accept the <a href="{{terms_of_use_url}}" target="_blank">terms of use</a> and the <a href="{{privacy_policy}}" target="_blank">privacy policy</a>.{% endblocktrans %}
             </label>
             {{ form.terms_of_use.errors }}
         </div>

--- a/meinberlin/templates/socialaccount/signup.html
+++ b/meinberlin/templates/socialaccount/signup.html
@@ -7,8 +7,7 @@
 {% block content %}
     <h1>{% trans "Sign Up" %}</h1>
 
-<p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
-{{site_name}}. As a final step, please complete the following form:{% endblocktrans %}</p>
+<p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to {{site_name}}. As a final step, please complete the following form:{% endblocktrans %}</p>
 
 <form id="signup_form" method="post" action="{% url 'socialaccount_signup' %}">
         {{ form.non_field_errors }}
@@ -25,9 +24,7 @@
         <div class="form-check">
             <label class="form-check__label">
                 {{ form.terms_of_use }}
-                {% blocktrans with terms_of_use_url="/terms-of-use" privacy_policy="/datenschutz" %}
-                 I hereby expressly consent to the collection and processing (storage) of my data and expressly consent to the processing and publication of my ideas, comments and contributions as described in the privacy policy. I also confirm that I have read and accept the <a href="{{terms_of_use_url}}" target="_blank">terms of use</a> and the <a href="{{privacy_policy}}" target="_blank">privacy policy</a>.
-                {% endblocktrans %}
+                {% blocktrans with terms_of_use_url="/terms-of-use" privacy_policy="/datenschutz" %}I hereby expressly consent to the collection and processing (storage) of my data and expressly consent to the processing and publication of my ideas, comments and contributions as described in the privacy policy. I also confirm that I have read and accept the <a href="{{terms_of_use_url}}" target="_blank">terms of use</a> and the <a href="{{privacy_policy}}" target="_blank">privacy policy</a>.{% endblocktrans %}
             </label>
             {{ form.terms_of_use.errors }}
         </div>


### PR DESCRIPTION
Translations in po-files from blocktrans blocks contain linebreaks with \n in them, if they are not in 1 line in the templates.

Thus, in this PR, all blocktrans blocks in the project were checked to see whether they ran over more than one line. 

In the 1st commit, these were refactored to close on the same line. In addition, in order to _reinstate_ a necessary blocktranslate in the **cms//storefronts template**, the html_date tag was removed, as it is not possible to use this in a blocktrans block.

The 2nd and 3rd commits are the refactored as well as new translations.
