### PR TITLE
[#50499] restrict moderation to not change projects

### DIFF
--- a/meinberlin/apps/projects/rules.py
+++ b/meinberlin/apps/projects/rules.py
@@ -9,11 +9,6 @@ from adhocracy4.projects.predicates import is_project_member
 from adhocracy4.projects.predicates import is_public
 from adhocracy4.projects.predicates import is_semipublic
 
-rules.remove_perm('a4projects.change_project')
-rules.add_perm('a4projects.change_project',
-               is_superuser | is_initiator |
-               is_moderator | is_prj_group_member)
-
 rules.remove_perm('a4projects.view_project')
 rules.add_perm('a4projects.view_project',
                is_superuser | is_initiator |

--- a/tests/polls/test_poll_export_overwrites.py
+++ b/tests/polls/test_poll_export_overwrites.py
@@ -37,7 +37,7 @@ def test_poll_export_view(client, phase_factory, user_factory, group_factory,
 
     client.login(username=moderator, password='password')
     response = client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == 403
 
     client.login(username=initiator, password='password')
     response = client.get(url)
@@ -82,7 +82,7 @@ def test_poll_comment_export_view(client, phase_factory, user_factory,
 
     client.login(username=moderator, password='password')
     response = client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == 403
 
     client.login(username=initiator, password='password')
     response = client.get(url)

--- a/tests/projects/dashboard_components/test_views_project_moderators.py
+++ b/tests/projects/dashboard_components/test_views_project_moderators.py
@@ -136,25 +136,14 @@ def test_moderator_can_only_be_invited_once(
 
 
 @pytest.mark.django_db
-def test_moderator_can_edit(client, phase_factory):
+def test_moderator_cannot_edit(client, phase_factory):
     phase, module, project, idea = setup_phase(
         phase_factory, None, CollectFeedbackPhase)
     url = component.get_base_url(project)
     moderator = project.moderators.first()
     client.login(username=moderator.email, password='password')
     response = client.get(url)
-    assert_template_response(
-        response, 'meinberlin_projects/project_moderators.html')
-
-    data = {
-        'add_users': 'test1@foo.bar,test2@foo.bar',
-    }
-    response = client.post(url, data)
-    assert redirect_target(response) == \
-        'dashboard-{}-edit'.format(component.identifier)
-    assert ModeratorInvite.objects.get(email='test1@foo.bar')
-    assert ModeratorInvite.objects.get(email='test2@foo.bar')
-    assert len(mail.outbox) == 2
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db

--- a/tests/projects/dashboard_components/test_views_project_participants.py
+++ b/tests/projects/dashboard_components/test_views_project_participants.py
@@ -138,26 +138,14 @@ def test_participant_can_only_be_invited_once(
 
 
 @pytest.mark.django_db
-def test_moderator_can_edit(client, phase_factory):
+def test_moderator_cannot_edit(client, phase_factory):
     phase, module, project, idea = setup_phase(
         phase_factory, None, CollectFeedbackPhase)
     url = component.get_base_url(project)
     moderator = project.moderators.first()
     client.login(username=moderator.email, password='password')
     response = client.get(url)
-    response = client.get(url)
-    assert_template_response(
-        response, 'meinberlin_projects/project_participants.html')
-
-    data = {
-        'add_users': 'test1@foo.bar,test2@foo.bar',
-    }
-    response = client.post(url, data)
-    assert redirect_target(response) == \
-        'dashboard-{}-edit'.format(component.identifier)
-    assert ParticipantInvite.objects.get(email='test1@foo.bar')
-    assert ParticipantInvite.objects.get(email='test2@foo.bar')
-    assert len(mail.outbox) == 2
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR is in regard to [US 50499](https://taiga.liqd.net/project/liqd-liquid-software/us/5049?milestone=290).

The meinBerlin-specific rules for changing projects were removed, leaving the original a4 permissions that do not specify moderators.
The tests were changed according to this new permission setup. 