### PR TITLE
[#5135] tests/budgeting /ideas /mapideas /projects: added missing tests for r…

### DIFF
--- a/tests/budgeting/rules/test_rules_vote.py
+++ b/tests/budgeting/rules/test_rules_vote.py
@@ -1,0 +1,183 @@
+import pytest
+import rules
+
+from adhocracy4.projects.enums import Access
+from adhocracy4.test.helpers import freeze_phase
+from adhocracy4.test.helpers import freeze_post_phase
+from adhocracy4.test.helpers import freeze_pre_phase
+from adhocracy4.test.helpers import setup_phase
+from adhocracy4.test.helpers import setup_users
+from meinberlin.apps.budgeting import phases
+
+perm_name = 'meinberlin_budgeting.vote_proposal'
+
+
+def test_perm_exists():
+    assert rules.perm_exists(perm_name)
+
+
+# This test is modeled on test_rules_rate.
+# I guess the permissions aren't completely tested by testing the rules here
+# b/c the existing rule only checks for the phase being active...
+@pytest.mark.django_db
+def test_pre_phase(user_factory, phase_factory, proposal_factory, user):
+    phase, module, project, _ = setup_phase(phase_factory, proposal_factory,
+                                            phases.RequestPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    assert project.is_public
+    with freeze_pre_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+        assert not rules.has_perm(perm_name, admin, module)
+
+
+@pytest.mark.django_db
+def test_request_phase_active(user_factory, phase_factory, proposal_factory,
+                              user):
+    phase, module, project, _ = setup_phase(phase_factory, proposal_factory,
+                                            phases.RequestPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    assert project.is_public
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+        assert not rules.has_perm(perm_name, admin, module)
+
+
+@pytest.mark.django_db
+def test_collect_phase_active(user_factory, phase_factory, proposal_factory,
+                              user):
+    phase, module, project, _ = setup_phase(phase_factory, proposal_factory,
+                                            phases.CollectPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    assert project.is_public
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, admin, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+
+
+@pytest.mark.django_db
+def test_rating_phase_active(user_factory, phase_factory, proposal_factory,
+                             user):
+    phase, module, project, _ = setup_phase(phase_factory, proposal_factory,
+                                            phases.RatingPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    assert project.is_public
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, admin, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+
+
+@pytest.mark.django_db
+def test_voting_phase_active(user_factory, phase_factory, proposal_factory,
+                             user):
+    phase, module, project, _ = setup_phase(phase_factory, proposal_factory,
+                                            phases.VotingPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    assert project.is_public
+    with freeze_phase(phase):
+        assert rules.has_perm(perm_name, anonymous, module)
+        assert rules.has_perm(perm_name, user, module)
+        assert rules.has_perm(perm_name, admin, module)
+        assert rules.has_perm(perm_name, moderator, module)
+        assert rules.has_perm(perm_name, initiator, module)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_private(user_factory, phase_factory,
+                                      proposal_factory, user, user2):
+    phase, module, project, _ = setup_phase(
+        phase_factory, proposal_factory, phases.RequestPhase,
+        module__project__access=Access.PRIVATE)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    participant = user2
+    project.participants.add(participant)
+
+    assert project.access == Access.PRIVATE
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, participant, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+        assert not rules.has_perm(perm_name, admin, module)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_semipublic(user_factory, phase_factory,
+                                         proposal_factory, user, user2):
+    phase, module, project, _ = setup_phase(
+        phase_factory, proposal_factory, phases.RequestPhase,
+        module__project__access=Access.SEMIPUBLIC)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    participant = user2
+    project.participants.add(participant)
+
+    assert project.access == Access.SEMIPUBLIC
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, participant, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+        assert not rules.has_perm(perm_name, admin, module)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_draft(user_factory, phase_factory,
+                                    proposal_factory, user):
+    phase, module, project, _ = setup_phase(phase_factory, proposal_factory,
+                                            phases.RequestPhase,
+                                            module__project__is_draft=True)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    assert project.is_draft
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+        assert not rules.has_perm(perm_name, admin, module)
+
+
+@pytest.mark.django_db
+def test_post_phase_project_archived(user_factory, phase_factory,
+                                     proposal_factory, user):
+    phase, module, project, _ = setup_phase(phase_factory, proposal_factory,
+                                            phases.RequestPhase,
+                                            module__project__is_archived=True)
+    anonymous, moderator, initiator = setup_users(project)
+    admin = user_factory(is_superuser=True)
+
+    assert project.is_archived
+    with freeze_post_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, module)
+        assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, moderator, module)
+        assert not rules.has_perm(perm_name, initiator, module)
+        assert not rules.has_perm(perm_name, admin, module)

--- a/tests/ideas/rules/test_rules_moderate.py
+++ b/tests/ideas/rules/test_rules_moderate.py
@@ -1,0 +1,126 @@
+import pytest
+import rules
+
+from adhocracy4.projects.enums import Access
+from adhocracy4.test.helpers import freeze_phase
+from adhocracy4.test.helpers import freeze_post_phase
+from adhocracy4.test.helpers import freeze_pre_phase
+from adhocracy4.test.helpers import setup_phase
+from adhocracy4.test.helpers import setup_users
+from meinberlin.apps.ideas import phases
+
+perm_name = 'meinberlin_ideas.moderate_idea'
+
+
+def test_perm_exists():
+    assert rules.perm_exists(perm_name)
+
+
+@pytest.mark.django_db
+def test_pre_phase(phase_factory, idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, idea_factory,
+                                          phases.CollectPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_public
+    with freeze_pre_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active(phase_factory, idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, idea_factory,
+                                          phases.CollectPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_public
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_private(phase_factory, idea_factory,
+                                      user, user2):
+    phase, _, project, item = setup_phase(
+        phase_factory, idea_factory, phases.CollectPhase,
+        module__project__access=Access.PRIVATE)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    participant = user2
+    project.participants.add(participant)
+
+    assert project.access == Access.PRIVATE
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, participant, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_semipublic(phase_factory, idea_factory,
+                                         user, user2):
+    phase, _, project, item = setup_phase(
+        phase_factory, idea_factory, phases.CollectPhase,
+        module__project__access=Access.SEMIPUBLIC)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    participant = user2
+    project.participants.add(participant)
+
+    assert project.access == Access.SEMIPUBLIC
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, participant, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_draft(phase_factory, idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, idea_factory,
+                                          phases.CollectPhase,
+                                          module__project__is_draft=True)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_draft
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_post_phase_project_archived(phase_factory, idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, idea_factory,
+                                          phases.CollectPhase,
+                                          module__project__is_archived=True)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_archived
+    with freeze_post_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)

--- a/tests/mapideas/rules/test_rules_moderate.py
+++ b/tests/mapideas/rules/test_rules_moderate.py
@@ -1,0 +1,126 @@
+import pytest
+import rules
+
+from adhocracy4.projects.enums import Access
+from adhocracy4.test.helpers import freeze_phase
+from adhocracy4.test.helpers import freeze_post_phase
+from adhocracy4.test.helpers import freeze_pre_phase
+from adhocracy4.test.helpers import setup_phase
+from adhocracy4.test.helpers import setup_users
+from meinberlin.apps.mapideas import phases
+
+perm_name = 'meinberlin_mapideas.moderate_mapidea'
+
+
+def test_perm_exists():
+    assert rules.perm_exists(perm_name)
+
+
+@pytest.mark.django_db
+def test_pre_phase(phase_factory, map_idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, map_idea_factory,
+                                          phases.CollectPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_public
+    with freeze_pre_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active(phase_factory, map_idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, map_idea_factory,
+                                          phases.CollectPhase)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_public
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_private(phase_factory, map_idea_factory,
+                                      user, user2):
+    phase, _, project, item = setup_phase(
+        phase_factory, map_idea_factory, phases.CollectPhase,
+        module__project__access=Access.PRIVATE)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    participant = user2
+    project.participants.add(participant)
+
+    assert project.access == Access.PRIVATE
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, participant, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_semipublic(phase_factory, map_idea_factory,
+                                         user, user2):
+    phase, _, project, item = setup_phase(
+        phase_factory, map_idea_factory, phases.CollectPhase,
+        module__project__access=Access.SEMIPUBLIC)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    participant = user2
+    project.participants.add(participant)
+
+    assert project.access == Access.SEMIPUBLIC
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, participant, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_phase_active_project_draft(phase_factory, map_idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, map_idea_factory,
+                                          phases.CollectPhase,
+                                          module__project__is_draft=True)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_draft
+    with freeze_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)
+
+
+@pytest.mark.django_db
+def test_post_phase_project_archived(phase_factory, map_idea_factory, user):
+    phase, _, project, item = setup_phase(phase_factory, map_idea_factory,
+                                          phases.CollectPhase,
+                                          module__project__is_archived=True)
+    anonymous, moderator, initiator = setup_users(project)
+    creator = item.creator
+
+    assert project.is_archived
+    with freeze_post_phase(phase):
+        assert not rules.has_perm(perm_name, anonymous, item)
+        assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, creator, item)
+        assert rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, initiator, item)

--- a/tests/projects/rules/test_rules_add_change_delete.py
+++ b/tests/projects/rules/test_rules_add_change_delete.py
@@ -1,0 +1,102 @@
+import pytest
+import rules
+from django.contrib.auth.models import AnonymousUser
+
+from adhocracy4.test.helpers import setup_users
+
+perm_name_add = 'a4projects.add_project'
+perm_name_change = 'a4projects.change_project'
+perm_name_delete = 'a4projects.delete_project'
+
+
+def test_perm_exists():
+    assert rules.perm_exists(perm_name_add)
+    assert rules.perm_exists(perm_name_change)
+    assert rules.perm_exists(perm_name_delete)
+
+
+@pytest.mark.django_db
+def test_add_project(user_factory, group_factory, organisation):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group_member_in = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+
+    assert not rules.has_perm(perm_name_add, anonymous, organisation)
+    assert not rules.has_perm(perm_name_add, user, organisation)
+    assert not rules.has_perm(perm_name_add, moderator, organisation)
+    assert not rules.has_perm(perm_name_add, group_member_out, organisation)
+    assert rules.has_perm(perm_name_add, initiator, organisation)
+    assert rules.has_perm(perm_name_add, admin, organisation)
+    assert rules.has_perm(perm_name_add, group_member_in, organisation)
+
+
+@pytest.mark.django_db
+def test_change_project(user_factory, group_factory, organisation,
+                        project_factory):
+    user = user_factory()
+    initiator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4, organisation=organisation)
+    anonymous, moderator, initiator = setup_users(project)
+
+    assert not rules.has_perm(perm_name_change, anonymous, project)
+    assert not rules.has_perm(perm_name_change, user, project)
+    assert not rules.has_perm(perm_name_change, moderator, project)
+    assert not rules.has_perm(perm_name_change, group_member_in_orga, project)
+    assert not rules.has_perm(perm_name_change, group_member_out, project)
+    assert rules.has_perm(perm_name_change, group_member_in_project, project)
+    assert rules.has_perm(perm_name_change, initiator, project)
+    assert rules.has_perm(perm_name_change, admin, project)
+
+
+@pytest.mark.django_db
+def test_delete_project(user_factory, group_factory, organisation,
+                        project_factory):
+    user = user_factory()
+    initiator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4, organisation=organisation)
+    anonymous, moderator, initiator = setup_users(project)
+
+    assert not rules.has_perm(perm_name_delete, anonymous, project)
+    assert not rules.has_perm(perm_name_delete, user, project)
+    assert not rules.has_perm(perm_name_delete, moderator, project)
+    assert not rules.has_perm(perm_name_delete, group_member_in_orga, project)
+    assert not rules.has_perm(perm_name_delete, group_member_out, project)
+    assert not rules.has_perm(perm_name_delete, group_member_in_project,
+                              project)
+    assert rules.has_perm(perm_name_delete, initiator, project)
+    assert rules.has_perm(perm_name_delete, admin, project)

--- a/tests/projects/rules/test_rules_participate.py
+++ b/tests/projects/rules/test_rules_participate.py
@@ -1,0 +1,198 @@
+import pytest
+import rules
+from django.contrib.auth.models import AnonymousUser
+
+from adhocracy4.projects.enums import Access
+
+perm_name_participate = 'a4projects.participate_in_project'
+
+
+def test_perm_exists():
+    assert rules.perm_exists(perm_name_participate)
+
+
+@pytest.mark.django_db
+def test_participate_project_draft(user_factory, group_factory, organisation,
+                                   project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              is_draft=True)
+    project.moderators.add(moderator)
+
+    assert not rules.has_perm(perm_name_participate, anonymous, project)
+    assert not rules.has_perm(perm_name_participate, user, project)
+    assert not rules.has_perm(perm_name_participate, group_member_in_orga,
+                              project)
+    assert not rules.has_perm(perm_name_participate, group_member_out, project)
+    assert not rules.has_perm(perm_name_participate, group_member_in_project,
+                              project)
+    assert rules.has_perm(perm_name_participate, moderator, project)
+    assert rules.has_perm(perm_name_participate, initiator, project)
+    assert rules.has_perm(perm_name_participate, admin, project)
+
+
+@pytest.mark.django_db
+def test_participate_live_project(user_factory, group_factory,
+                                  organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation)
+    project.moderators.add(moderator)
+
+    assert rules.has_perm(perm_name_participate, anonymous, project)
+    assert rules.has_perm(perm_name_participate, user, project)
+    assert rules.has_perm(perm_name_participate, group_member_in_orga,
+                          project)
+    assert rules.has_perm(perm_name_participate, group_member_out, project)
+    assert rules.has_perm(perm_name_participate, group_member_in_project,
+                          project)
+    assert rules.has_perm(perm_name_participate, moderator, project)
+    assert rules.has_perm(perm_name_participate, initiator, project)
+    assert rules.has_perm(perm_name_participate, admin, project)
+
+
+@pytest.mark.django_db
+def test_participate_archived_project(user_factory, group_factory,
+                                      organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              is_archived=True)
+    project.moderators.add(moderator)
+
+    assert rules.has_perm(perm_name_participate, anonymous, project)
+    assert rules.has_perm(perm_name_participate, user, project)
+    assert rules.has_perm(perm_name_participate, group_member_in_orga,
+                          project)
+    assert rules.has_perm(perm_name_participate, group_member_out, project)
+    assert rules.has_perm(perm_name_participate, group_member_in_project,
+                          project)
+    assert rules.has_perm(perm_name_participate, moderator, project)
+    assert rules.has_perm(perm_name_participate, initiator, project)
+    assert rules.has_perm(perm_name_participate, admin, project)
+
+
+@pytest.mark.django_db
+def test_participate_private_project(user_factory, group_factory,
+                                     organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    participant = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              access=Access.PRIVATE)
+    project.moderators.add(moderator)
+    project.participants.add(participant)
+
+    assert project.access == Access.PRIVATE
+    assert not rules.has_perm(perm_name_participate, anonymous, project)
+    assert not rules.has_perm(perm_name_participate, user, project)
+    assert not rules.has_perm(perm_name_participate, group_member_in_orga,
+                              project)
+    assert not rules.has_perm(perm_name_participate, group_member_out, project)
+    assert not rules.has_perm(perm_name_participate, group_member_in_project,
+                              project)
+    assert rules.has_perm(perm_name_participate, participant, project)
+    assert rules.has_perm(perm_name_participate, moderator, project)
+    assert rules.has_perm(perm_name_participate, initiator, project)
+    assert rules.has_perm(perm_name_participate, admin, project)
+
+
+@pytest.mark.django_db
+def test_participate_semiprivate_project(user_factory, group_factory,
+                                         organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    participant = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              access=Access.SEMIPUBLIC)
+    project.moderators.add(moderator)
+    project.participants.add(participant)
+
+    assert project.access == Access.SEMIPUBLIC
+    assert not rules.has_perm(perm_name_participate, anonymous, project)
+    assert not rules.has_perm(perm_name_participate, user, project)
+    assert not rules.has_perm(perm_name_participate, group_member_in_orga,
+                              project)
+    assert not rules.has_perm(perm_name_participate, group_member_out, project)
+    assert not rules.has_perm(perm_name_participate, group_member_in_project,
+                              project)
+    assert rules.has_perm(perm_name_participate, participant, project)
+    assert rules.has_perm(perm_name_participate, moderator, project)
+    assert rules.has_perm(perm_name_participate, initiator, project)
+    assert rules.has_perm(perm_name_participate, admin, project)

--- a/tests/projects/rules/test_rules_view.py
+++ b/tests/projects/rules/test_rules_view.py
@@ -1,0 +1,199 @@
+import pytest
+import rules
+from django.contrib.auth.models import AnonymousUser
+
+from adhocracy4.projects.enums import Access
+
+perm_name_view = 'a4projects.view_project'
+
+
+def test_perm_exists():
+    assert rules.perm_exists(perm_name_view)
+
+
+@pytest.mark.django_db
+def test_view_project_draft(user_factory, group_factory,
+                            organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              is_draft=True)
+    project.moderators.add(moderator)
+
+    assert project.is_draft
+    assert not rules.has_perm(perm_name_view, anonymous, project)
+    assert not rules.has_perm(perm_name_view, user, project)
+    assert not rules.has_perm(perm_name_view, group_member_in_orga,
+                              project)
+    assert not rules.has_perm(perm_name_view, group_member_out, project)
+    assert rules.has_perm(perm_name_view, group_member_in_project,
+                          project)
+    assert rules.has_perm(perm_name_view, moderator, project)
+    assert rules.has_perm(perm_name_view, initiator, project)
+    assert rules.has_perm(perm_name_view, admin, project)
+
+
+@pytest.mark.django_db
+def test_view_project_live(user_factory, group_factory,
+                           organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation)
+    project.moderators.add(moderator)
+
+    assert rules.has_perm(perm_name_view, anonymous, project)
+    assert rules.has_perm(perm_name_view, user, project)
+    assert rules.has_perm(perm_name_view, group_member_in_orga,
+                          project)
+    assert rules.has_perm(perm_name_view, group_member_out, project)
+    assert rules.has_perm(perm_name_view, group_member_in_project,
+                          project)
+    assert rules.has_perm(perm_name_view, moderator, project)
+    assert rules.has_perm(perm_name_view, initiator, project)
+    assert rules.has_perm(perm_name_view, admin, project)
+
+
+@pytest.mark.django_db
+def test_view_archived_project(user_factory, group_factory,
+                               organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              is_archived=True)
+    project.moderators.add(moderator)
+
+    assert rules.has_perm(perm_name_view, anonymous, project)
+    assert rules.has_perm(perm_name_view, user, project)
+    assert rules.has_perm(perm_name_view, group_member_in_orga,
+                          project)
+    assert rules.has_perm(perm_name_view, group_member_out, project)
+    assert rules.has_perm(perm_name_view, group_member_in_project,
+                          project)
+    assert rules.has_perm(perm_name_view, moderator, project)
+    assert rules.has_perm(perm_name_view, initiator, project)
+    assert rules.has_perm(perm_name_view, admin, project)
+
+
+@pytest.mark.django_db
+def test_view_private_project(user_factory, group_factory,
+                              organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    participant = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              access=Access.PRIVATE)
+    project.moderators.add(moderator)
+    project.participants.add(participant)
+
+    assert project.access == Access.PRIVATE
+    assert not rules.has_perm(perm_name_view, anonymous, project)
+    assert not rules.has_perm(perm_name_view, user, project)
+    assert not rules.has_perm(perm_name_view, group_member_in_orga,
+                              project)
+    assert not rules.has_perm(perm_name_view, group_member_out, project)
+    assert rules.has_perm(perm_name_view, group_member_in_project,
+                          project)
+    assert rules.has_perm(perm_name_view, participant, project)
+    assert rules.has_perm(perm_name_view, moderator, project)
+    assert rules.has_perm(perm_name_view, initiator, project)
+    assert rules.has_perm(perm_name_view, admin, project)
+
+
+@pytest.mark.django_db
+def test_view_semiprivate_project(user_factory, group_factory,
+                                  organisation, project_factory):
+    anonymous = AnonymousUser()
+    user = user_factory()
+    participant = user_factory()
+    initiator = user_factory()
+    moderator = user_factory()
+    admin = user_factory(is_superuser=True)
+
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group4 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2, group3))
+    group_member_in_project = user_factory.create(groups=(group2, group4))
+
+    organisation.initiators.add(initiator)
+    organisation.groups.add(group1)
+    project = project_factory(group=group4,
+                              organisation=organisation,
+                              access=Access.SEMIPUBLIC)
+    project.moderators.add(moderator)
+    project.participants.add(participant)
+
+    assert project.access == Access.SEMIPUBLIC
+    assert rules.has_perm(perm_name_view, anonymous, project)
+    assert rules.has_perm(perm_name_view, user, project)
+    assert rules.has_perm(perm_name_view, group_member_in_orga,
+                          project)
+    assert rules.has_perm(perm_name_view, group_member_out, project)
+    assert rules.has_perm(perm_name_view, group_member_in_project,
+                          project)
+    assert rules.has_perm(perm_name_view, participant, project)
+    assert rules.has_perm(perm_name_view, moderator, project)
+    assert rules.has_perm(perm_name_view, initiator, project)
+    assert rules.has_perm(perm_name_view, admin, project)


### PR DESCRIPTION
…ules

This PR regards Task [#5135 add tests](https://taiga.liqd.net/project/liqd-liquid-software/task/5135) within US "#4986 [mB] backend and dashboard: add voting as 3rd phase testing" . Voting-testing was added within the budgeting-tests.

In addition, all tests for rules 
- for the project as a whole and 
- for module rules for ideas and mapideas moderation 
that were missing were added. 