### PR TITLE
Ks 2021 12 token voting permissions

### DIFF
--- a/meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx
+++ b/meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx
@@ -41,7 +41,7 @@ export const BudgetingProposalListItem = (props) => {
           <span className="list-item__author">{proposal.creator}</span>
           {date}
         </div>
-        {isVotingPhase && (
+        {proposal.vote_allowed && (
           <VoteButton
             objectID={proposal.pk}
             tokenvoteApiUrl={tokenvoteApiUrl}

--- a/meinberlin/apps/budgeting/predicates.py
+++ b/meinberlin/apps/budgeting/predicates.py
@@ -1,0 +1,8 @@
+import rules
+
+from adhocracy4.phases.predicates import phase_allows_vote
+
+
+@rules.predicate
+def is_allowed_vote_proposal(user, proposal):
+    return (not proposal.is_archived) and phase_allows_vote(user, proposal)

--- a/meinberlin/apps/budgeting/rules.py
+++ b/meinberlin/apps/budgeting/rules.py
@@ -4,6 +4,7 @@ from adhocracy4.modules import predicates as module_predicates
 from adhocracy4.phases import predicates as phase_predicates
 
 from . import models
+from .predicates import is_allowed_vote_proposal
 
 rules.add_perm(
     'meinberlin_budgeting.view_proposal',
@@ -42,5 +43,10 @@ rules.add_perm(
 
 rules.add_perm(
     'meinberlin_budgeting.vote_proposal',
-    phase_predicates.phase_allows_vote(models.Proposal)
+    is_allowed_vote_proposal
+)
+
+rules.add_perm(
+    'meinberlin_budgeting.add_vote',
+    phase_predicates.phase_allows_add_vote(models.Proposal)
 )

--- a/meinberlin/apps/budgeting/rules.py
+++ b/meinberlin/apps/budgeting/rules.py
@@ -50,3 +50,8 @@ rules.add_perm(
     'meinberlin_budgeting.add_vote',
     phase_predicates.phase_allows_add_vote(models.Proposal)
 )
+
+rules.add_perm(
+    'meinberlin_budgeting.delete_vote',
+    phase_predicates.phase_allows_delete_vote
+)

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
@@ -12,7 +12,16 @@
 {% endblock %}
 
 {% block vote_button %}
-<div class="l-center-6 u-bottom-divider">
-    {% react_proposals_vote view.module proposal %}
-</div>
+{% comment %}
+    FIXME: differentiating 2 and 3 phase buergerhaushalt by just counting the phases
+           should be changed once we have module types
+{% endcomment %}
+{% if module.phases.count == 3 %}
+    {% has_perm 'meinberlin_budgeting.vote_proposal' request.user proposal as vote_allowed %}
+    {% if vote_allowed %}
+    <div class="l-center-6 u-bottom-divider">
+        {% react_proposals_vote view.module proposal %}
+    </div>
+    {% endif %}
+{% endif %}
 {% endblock %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -24,7 +24,7 @@
                should be changed once we have module types
     {% endcomment %}
     {% if module.phases.count == 3 %}
-        {% has_perm 'meinberlin_budgeting.vote_proposal' request.user module as vote_allowed %}
+        {% has_perm 'meinberlin_budgeting.add_vote' request.user module as vote_allowed %}
         {% if vote_allowed %}
             {% if request.session.voting_token %}
                 You are using token {{ request.session.voting_token }}

--- a/meinberlin/apps/budgeting/templatetags/react_proposals.py
+++ b/meinberlin/apps/budgeting/templatetags/react_proposals.py
@@ -18,7 +18,10 @@ def react_proposals(context, module):
     proposal_ct = ContentType.objects.get(app_label='meinberlin_budgeting',
                                           model='proposal')
     tokenvote_api_url = reverse('tokenvotes-list',
-                                kwargs={'content_type': proposal_ct.id})
+                                kwargs={
+                                    'module_pk': module.pk,
+                                    'content_type': proposal_ct.id
+                                })
 
     attributes = {'proposals_api_url': proposals_api_url,
                   'tokenvote_api_url': tokenvote_api_url,

--- a/meinberlin/apps/budgeting/templatetags/react_proposals_vote.py
+++ b/meinberlin/apps/budgeting/templatetags/react_proposals_vote.py
@@ -21,7 +21,10 @@ def react_proposals_vote(context, module, proposal):
     proposal_ct = ContentType.objects.get(app_label='meinberlin_budgeting',
                                           model='proposal')
     tokenvote_api_url = reverse('tokenvotes-list',
-                                kwargs={'content_type': proposal_ct.id})
+                                kwargs={
+                                    'module_pk': module.pk,
+                                    'content_type': proposal_ct.id
+                                })
 
     request = context['request']
     session_token_voted = False

--- a/meinberlin/apps/votes/routers.py
+++ b/meinberlin/apps/votes/routers.py
@@ -6,7 +6,8 @@ from adhocracy4.api.routers import CustomRouterMixin
 class TokenVoteRouterMixin(CustomRouterMixin):
 
     prefix_regex = (
-        r'contenttypes/(?P<content_type>[\d]+)/{prefix}'
+        r'modules/(?P<module_pk>[\d]+)/contenttypes/'
+        r'(?P<content_type>[\d]+)/{prefix}'
     )
 
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@testing-library/react-native": "9.0.0",
     "acorn": "8.6.0",
-    "adhocracy4": "liqd/adhocracy4#af2eddfe691cf1ce9334ba23c0ffbd1eb691c239",
+    "adhocracy4": "liqd/adhocracy4#e2660a76501e50ccc710f878134d84353464a07d",
     "autoprefixer": "10.4.0",
     "axios": "0.24.0",
     "babel-loader": "8.2.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@af2eddfe691cf1ce9334ba23c0ffbd1eb691c239#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@e2660a76501e50ccc710f878134d84353464a07d#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0

--- a/tests/budgeting/rules/test_rules_vote.py
+++ b/tests/budgeting/rules/test_rules_vote.py
@@ -9,7 +9,7 @@ from adhocracy4.test.helpers import setup_phase
 from adhocracy4.test.helpers import setup_users
 from meinberlin.apps.budgeting import phases
 
-perm_name = 'meinberlin_budgeting.vote_proposal'
+perm_name = 'meinberlin_budgeting.add_vote'
 
 
 def test_perm_exists():


### PR DESCRIPTION
I did some more research and decided to not use rules for the token voting api permissions as rules are dependent on users and arent really useful here. 
I instead introduced a new Permission class, called TokenVotePermission that checks manually the relevant requirements on the token for create and destroy actions.
Also, I added a check in TokenVoteMixin to make sure that the token is valid before anything else is checked.