### PR TITLE
tests/documents/rules /offlineevents/rules /plans/rules: group member…

### DIFF
--- a/tests/documents/rules/test_rules_add_chapter.py
+++ b/tests/documents/rules/test_rules_add_chapter.py
@@ -8,6 +8,7 @@ from adhocracy4.test.helpers import freeze_pre_phase
 from adhocracy4.test.helpers import setup_phase
 from adhocracy4.test.helpers import setup_users
 from meinberlin.apps.documents import phases
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_documents.add_chapter'
 
@@ -17,96 +18,136 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_pre_phase(phase_factory, user):
+def test_pre_phase(phase_factory, user_factory,
+                   group_factory, user):
     phase, module, project, _ = setup_phase(phase_factory, None,
                                             phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, group_member_in_orga, module)
+        assert not rules.has_perm(perm_name, group_member_out, module)
         assert not rules.has_perm(perm_name, moderator, module)
+        assert rules.has_perm(perm_name, group_member_in_project, module)
         assert rules.has_perm(perm_name, initiator, module)
 
 
 @pytest.mark.django_db
-def test_phase_active(phase_factory, user):
+def test_phase_active(phase_factory, user_factory,
+                      group_factory, user):
     phase, module, project, _ = setup_phase(phase_factory, None,
                                             phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, group_member_in_orga, module)
+        assert not rules.has_perm(perm_name, group_member_out, module)
         assert not rules.has_perm(perm_name, moderator, module)
+        assert rules.has_perm(perm_name, group_member_in_project, module)
         assert rules.has_perm(perm_name, initiator, module)
 
 
 @pytest.mark.django_db
-def test_phase_active_project_private(phase_factory, user, user2):
+def test_phase_active_project_private(phase_factory, user_factory,
+                                      group_factory, user):
     phase, module, project, _ = setup_phase(
         phase_factory, None, phases.CommentPhase,
         module__project__access=Access.PRIVATE)
-    anonymous, moderator, initiator = setup_users(project)
 
-    participant = user2
+    anonymous, moderator, initiator = setup_users(project)
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
         assert not rules.has_perm(perm_name, participant, module)
+        assert not rules.has_perm(perm_name, group_member_in_orga, module)
+        assert not rules.has_perm(perm_name, group_member_out, module)
         assert not rules.has_perm(perm_name, moderator, module)
+        assert rules.has_perm(perm_name, group_member_in_project, module)
         assert rules.has_perm(perm_name, initiator, module)
 
 
 @pytest.mark.django_db
-def test_phase_active_project_semipublic(phase_factory, user, user2):
+def test_phase_active_project_semipublic(phase_factory, user_factory,
+                                         group_factory, user):
     phase, module, project, _ = setup_phase(
         phase_factory, None, phases.CommentPhase,
         module__project__access=Access.SEMIPUBLIC)
-    anonymous, moderator, initiator = setup_users(project)
 
-    participant = user2
+    anonymous, moderator, initiator = setup_users(project)
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.SEMIPUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
         assert not rules.has_perm(perm_name, participant, module)
+        assert not rules.has_perm(perm_name, group_member_in_orga, module)
+        assert not rules.has_perm(perm_name, group_member_out, module)
         assert not rules.has_perm(perm_name, moderator, module)
+        assert rules.has_perm(perm_name, group_member_in_project, module)
         assert rules.has_perm(perm_name, initiator, module)
 
 
 @pytest.mark.django_db
-def test_phase_active_project_draft(phase_factory, user):
+def test_phase_active_project_draft(phase_factory, user_factory,
+                                    group_factory, user):
     phase, module, project, _ = setup_phase(phase_factory, None,
                                             phases.CommentPhase,
                                             module__project__is_draft=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_draft
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, group_member_in_orga, module)
+        assert not rules.has_perm(perm_name, group_member_out, module)
         assert not rules.has_perm(perm_name, moderator, module)
+        assert rules.has_perm(perm_name, group_member_in_project, module)
         assert rules.has_perm(perm_name, initiator, module)
 
 
 @pytest.mark.django_db
-def test_post_phase_project_archived(phase_factory, user):
+def test_post_phase_project_archived(phase_factory, user_factory,
+                                     group_factory, user):
     phase, module, project, _ = setup_phase(phase_factory, None,
                                             phases.CommentPhase,
                                             module__project__is_archived=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_archived
     with freeze_post_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, module)
         assert not rules.has_perm(perm_name, user, module)
+        assert not rules.has_perm(perm_name, group_member_in_orga, module)
+        assert not rules.has_perm(perm_name, group_member_out, module)
         assert not rules.has_perm(perm_name, moderator, module)
+        assert rules.has_perm(perm_name, group_member_in_project, module)
         assert rules.has_perm(perm_name, initiator, module)

--- a/tests/documents/rules/test_rules_change_chapter.py
+++ b/tests/documents/rules/test_rules_change_chapter.py
@@ -8,6 +8,7 @@ from adhocracy4.test.helpers import freeze_pre_phase
 from adhocracy4.test.helpers import setup_phase
 from adhocracy4.test.helpers import setup_users
 from meinberlin.apps.documents import phases
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_documents.change_chapter'
 
@@ -17,47 +18,68 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_pre_phase(phase_factory, chapter_factory, user):
+def test_pre_phase(phase_factory, chapter_factory,
+                   user_factory, group_factory,
+                   user):
+
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
-    anonymous, moderator, initiator = setup_users(project)
+
     creator = item.creator
+    anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_public
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
         assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
         assert not rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
-def test_phase_active(phase_factory, chapter_factory, user):
+def test_phase_active(phase_factory, chapter_factory,
+                      user_factory, group_factory,
+                      user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
-    anonymous, moderator, initiator = setup_users(project)
+
     creator = item.creator
+    anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_public
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
         assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
         assert not rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, chapter_factory,
-                                      user, user2):
+                                      user_factory, group_factory,
+                                      user):
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.PRIVATE)
-    anonymous, moderator, initiator = setup_users(project)
+
     creator = item.creator
-    participant = user2
+    anonymous, moderator, initiator = setup_users(project)
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.PRIVATE
     with freeze_phase(phase):
@@ -65,20 +87,27 @@ def test_phase_active_project_private(phase_factory, chapter_factory,
         assert not rules.has_perm(perm_name, user, item)
         assert not rules.has_perm(perm_name, creator, item)
         assert not rules.has_perm(perm_name, participant, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
         assert not rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
 def test_phase_active_project_semipublic(phase_factory, chapter_factory,
-                                         user, user2):
+                                         user_factory, group_factory,
+                                         user):
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.SEMIPUBLIC)
-    anonymous, moderator, initiator = setup_users(project)
+
     creator = item.creator
-    participant = user2
+    anonymous, moderator, initiator = setup_users(project)
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.SEMIPUBLIC
     with freeze_phase(phase):
@@ -86,39 +115,58 @@ def test_phase_active_project_semipublic(phase_factory, chapter_factory,
         assert not rules.has_perm(perm_name, user, item)
         assert not rules.has_perm(perm_name, creator, item)
         assert not rules.has_perm(perm_name, participant, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
         assert not rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
-def test_phase_active_project_draft(phase_factory, chapter_factory, user):
+def test_phase_active_project_draft(phase_factory, chapter_factory,
+                                    user_factory, group_factory,
+                                    user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase,
                                           module__project__is_draft=True)
-    anonymous, moderator, initiator = setup_users(project)
+
     creator = item.creator
+    anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_draft
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
         assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
         assert not rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
-def test_post_phase_project_archived(phase_factory, chapter_factory, user):
+def test_post_phase_project_archived(phase_factory, chapter_factory,
+                                     user_factory, group_factory,
+                                     user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase,
                                           module__project__is_archived=True)
-    anonymous, moderator, initiator = setup_users(project)
+
     creator = item.creator
+    anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_archived
     with freeze_post_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
         assert not rules.has_perm(perm_name, creator, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
         assert not rules.has_perm(perm_name, moderator, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, initiator, item)

--- a/tests/documents/rules/test_rules_comment_chapter.py
+++ b/tests/documents/rules/test_rules_comment_chapter.py
@@ -8,6 +8,7 @@ from adhocracy4.test.helpers import freeze_pre_phase
 from adhocracy4.test.helpers import setup_phase
 from adhocracy4.test.helpers import setup_users
 from meinberlin.apps.documents import phases
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_documents.comment_chapter'
 
@@ -17,47 +18,68 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_pre_phase(phase_factory, chapter_factory, user):
+def test_pre_phase(phase_factory, chapter_factory, user_factory,
+                   group_factory, user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_public
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, moderator, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
-def test_phase_active(phase_factory, chapter_factory, user):
+def test_phase_active(phase_factory, chapter_factory, user_factory,
+                      group_factory, user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_public
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert rules.has_perm(perm_name, user, item)
+        assert rules.has_perm(perm_name, group_member_in_orga, item)
+        assert rules.has_perm(perm_name, group_member_out, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, moderator, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, chapter_factory,
-                                      user, user2):
+                                      user_factory, group_factory,
+                                      user):
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.PRIVATE)
+
     anonymous, moderator, initiator = setup_users(project)
-    participant = user2
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, participant, item)
         assert rules.has_perm(perm_name, moderator, item)
         assert rules.has_perm(perm_name, initiator, item)
@@ -65,48 +87,72 @@ def test_phase_active_project_private(phase_factory, chapter_factory,
 
 @pytest.mark.django_db
 def test_phase_active_project_semipublic(phase_factory, chapter_factory,
-                                         user, user2):
+                                         user_factory, group_factory,
+                                         user):
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.SEMIPUBLIC)
+
     anonymous, moderator, initiator = setup_users(project)
-    participant = user2
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.access == Access.SEMIPUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, participant, item)
         assert rules.has_perm(perm_name, moderator, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
-def test_phase_active_project_draft(phase_factory, chapter_factory, user):
+def test_phase_active_project_draft(phase_factory, chapter_factory,
+                                    user_factory, group_factory,
+                                    user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase,
                                           module__project__is_draft=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_draft
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, moderator, item)
         assert rules.has_perm(perm_name, initiator, item)
 
 
 @pytest.mark.django_db
-def test_post_phase_project_archived(phase_factory, chapter_factory, user):
+def test_post_phase_project_archived(phase_factory, chapter_factory,
+                                     user_factory, group_factory,
+                                     user):
+
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase,
                                           module__project__is_archived=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_archived
     with freeze_post_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, item)
         assert not rules.has_perm(perm_name, user, item)
+        assert not rules.has_perm(perm_name, group_member_in_orga, item)
+        assert not rules.has_perm(perm_name, group_member_out, item)
+        assert rules.has_perm(perm_name, group_member_in_project, item)
         assert rules.has_perm(perm_name, moderator, item)
         assert rules.has_perm(perm_name, initiator, item)

--- a/tests/documents/rules/test_rules_comment_paragraph.py
+++ b/tests/documents/rules/test_rules_comment_paragraph.py
@@ -8,6 +8,7 @@ from adhocracy4.test.helpers import freeze_pre_phase
 from adhocracy4.test.helpers import setup_phase
 from adhocracy4.test.helpers import setup_users
 from meinberlin.apps.documents import phases
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_documents.comment_paragraph'
 
@@ -17,50 +18,74 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_pre_phase(phase_factory, chapter_factory, paragraph_factory, user):
+def test_pre_phase(phase_factory, chapter_factory, paragraph_factory,
+                   user_factory, group_factory, user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
+        assert not rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert not rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
 
 
 @pytest.mark.django_db
-def test_phase_active(phase_factory, chapter_factory, paragraph_factory, user):
+def test_phase_active(phase_factory, chapter_factory, paragraph_factory,
+                      user_factory, group_factory, user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
 
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, chapter_factory,
-                                      paragraph_factory, user, user2):
+                                      paragraph_factory, user_factory,
+                                      group_factory, user):
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.PRIVATE)
+
     anonymous, moderator, initiator = setup_users(project)
-    participant = user2
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
+        assert not rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert not rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, participant, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
@@ -68,19 +93,27 @@ def test_phase_active_project_private(phase_factory, chapter_factory,
 
 @pytest.mark.django_db
 def test_phase_active_project_semipublic(phase_factory, chapter_factory,
-                                         paragraph_factory, user, user2):
+                                         paragraph_factory, user_factory,
+                                         group_factory, user):
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.SEMIPUBLIC)
+
     anonymous, moderator, initiator = setup_users(project)
-    participant = user2
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.SEMIPUBLIC
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
+        assert not rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert not rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, participant, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
@@ -88,33 +121,49 @@ def test_phase_active_project_semipublic(phase_factory, chapter_factory,
 
 @pytest.mark.django_db
 def test_phase_active_project_draft(phase_factory, chapter_factory,
-                                    paragraph_factory, user):
+                                    paragraph_factory, user_factory,
+                                    group_factory, user):
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__is_draft=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.is_draft
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
+        assert not rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert not rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
 
 
 @pytest.mark.django_db
 def test_post_phase_project_archived(phase_factory, chapter_factory,
-                                     paragraph_factory, user):
+                                     paragraph_factory, user_factory,
+                                     group_factory, user):
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase,
                                           module__project__is_archived=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.is_archived
     with freeze_post_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
+        assert not rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert not rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)

--- a/tests/documents/rules/test_rules_view_paragraph.py
+++ b/tests/documents/rules/test_rules_view_paragraph.py
@@ -8,6 +8,7 @@ from adhocracy4.test.helpers import freeze_pre_phase
 from adhocracy4.test.helpers import setup_phase
 from adhocracy4.test.helpers import setup_users
 from meinberlin.apps.documents import phases
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_documents.view_paragraph'
 
@@ -17,50 +18,77 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_pre_phase(phase_factory, chapter_factory, paragraph_factory, user):
+def test_pre_phase(phase_factory, chapter_factory, paragraph_factory,
+                   user_factory, group_factory, user):
+
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.PUBLIC
     with freeze_pre_phase(phase):
         assert rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
 
 
 @pytest.mark.django_db
-def test_phase_active(phase_factory, chapter_factory, paragraph_factory, user):
+def test_phase_active(phase_factory, chapter_factory, paragraph_factory,
+                      user_factory, user, group_factory):
+
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.PUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
 
 
 @pytest.mark.django_db
 def test_phase_active_project_private(phase_factory, chapter_factory,
-                                      paragraph_factory, user, user2):
+                                      paragraph_factory, user_factory,
+                                      group_factory, user):
+
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.PRIVATE)
+
     anonymous, moderator, initiator = setup_users(project)
-    participant = user2
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.PRIVATE
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
+        assert not rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert not rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, participant, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
@@ -68,19 +96,28 @@ def test_phase_active_project_private(phase_factory, chapter_factory,
 
 @pytest.mark.django_db
 def test_phase_active_project_semipublic(phase_factory, chapter_factory,
-                                         paragraph_factory, user, user2):
+                                         paragraph_factory, user_factory,
+                                         group_factory, user):
+
     phase, _, project, item = setup_phase(
         phase_factory, chapter_factory, phases.CommentPhase,
         module__project__access=Access.SEMIPUBLIC)
+
     anonymous, moderator, initiator = setup_users(project)
-    participant = user2
+    participant = user_factory()
     project.participants.add(participant)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.access == Access.SEMIPUBLIC
     with freeze_phase(phase):
         assert rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, participant, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
@@ -88,33 +125,51 @@ def test_phase_active_project_semipublic(phase_factory, chapter_factory,
 
 @pytest.mark.django_db
 def test_phase_active_project_draft(phase_factory, chapter_factory,
-                                    paragraph_factory, user):
+                                    paragraph_factory, user_factory,
+                                    group_factory, user):
+
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase,
                                           module__project__is_draft=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.is_draft
     with freeze_phase(phase):
         assert not rules.has_perm(perm_name, anonymous, paragraph)
         assert not rules.has_perm(perm_name, user, paragraph)
+        assert not rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert not rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)
 
 
 @pytest.mark.django_db
 def test_post_phase_project_archived(phase_factory, chapter_factory,
-                                     paragraph_factory, user):
+                                     paragraph_factory, user_factory,
+                                     group_factory, user):
+
     phase, _, project, item = setup_phase(phase_factory, chapter_factory,
                                           phases.CommentPhase,
                                           module__project__is_archived=True)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
+
     paragraph = paragraph_factory(chapter=item)
 
     assert project.is_archived
     with freeze_post_phase(phase):
         assert rules.has_perm(perm_name, anonymous, paragraph)
         assert rules.has_perm(perm_name, user, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_orga, paragraph)
+        assert rules.has_perm(perm_name, group_member_out, paragraph)
+        assert rules.has_perm(perm_name, group_member_in_project, paragraph)
         assert rules.has_perm(perm_name, moderator, paragraph)
         assert rules.has_perm(perm_name, initiator, paragraph)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,3 +12,19 @@ class pytest_regex:
 
     def __repr__(self):
         return self._regex.pattern
+
+
+def setup_group_users(user_factory, group_factory, project):
+    group1 = group_factory()
+    group2 = group_factory()
+    group3 = group_factory()
+    group_member_in_orga = user_factory.create(groups=(group1, group2))
+    group_member_out = user_factory.create(groups=(group2,))
+    group_member_in_project = user_factory.create(groups=(group2, group3))
+
+    project.organisation.groups.add(group1)
+    project.group = group3
+    project.save()
+
+    return group_member_in_orga, group_member_out, group_member_in_project, \
+        project

--- a/tests/offlineevents/rules/test_rules_add.py
+++ b/tests/offlineevents/rules/test_rules_add.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_offlineevents.add_offlineevent'
 
@@ -11,11 +12,19 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(offline_event, user):
+def test_rule(offline_event, user_factory, group_factory,
+              user):
+
     project = offline_event.project
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert not rules.has_perm(perm_name, anonymous, project)
     assert not rules.has_perm(perm_name, user, project)
+    assert not rules.has_perm(perm_name, group_member_in_orga, project)
+    assert not rules.has_perm(perm_name, group_member_out, project)
     assert not rules.has_perm(perm_name, moderator, project)
+    assert rules.has_perm(perm_name, group_member_in_project, project)
     assert rules.has_perm(perm_name, initiator, project)

--- a/tests/offlineevents/rules/test_rules_change.py
+++ b/tests/offlineevents/rules/test_rules_change.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_offlineevents.change_offlineevent'
 
@@ -11,11 +12,19 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(offline_event, user):
+def test_rule(offline_event, user_factory, group_factory,
+              user):
+
     project = offline_event.project
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert not rules.has_perm(perm_name, anonymous, project)
     assert not rules.has_perm(perm_name, user, project)
+    assert not rules.has_perm(perm_name, group_member_in_orga, project)
+    assert not rules.has_perm(perm_name, group_member_out, project)
     assert not rules.has_perm(perm_name, moderator, project)
+    assert rules.has_perm(perm_name, group_member_in_project, project)
     assert rules.has_perm(perm_name, initiator, project)

--- a/tests/offlineevents/rules/test_rules_list.py
+++ b/tests/offlineevents/rules/test_rules_list.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_offlineevents.list_offlineevent'
 
@@ -11,11 +12,19 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(offline_event, user):
+def test_rule(offline_event, user_factory, group_factory,
+              user):
+
     project = offline_event.project
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert not rules.has_perm(perm_name, anonymous, project)
     assert not rules.has_perm(perm_name, user, project)
+    assert not rules.has_perm(perm_name, group_member_in_orga, project)
+    assert not rules.has_perm(perm_name, group_member_out, project)
     assert not rules.has_perm(perm_name, moderator, project)
+    assert rules.has_perm(perm_name, group_member_in_project, project)
     assert rules.has_perm(perm_name, initiator, project)

--- a/tests/offlineevents/rules/test_rules_view.py
+++ b/tests/offlineevents/rules/test_rules_view.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_offlineevents.view_offlineevent'
 
@@ -11,37 +12,61 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(offline_event, user):
+def test_rule(offline_event, user_factory, group_factory,
+              user):
+
     project = offline_event.project
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert rules.has_perm(perm_name, anonymous, offline_event)
     assert rules.has_perm(perm_name, user, offline_event)
     assert rules.has_perm(perm_name, moderator, offline_event)
     assert rules.has_perm(perm_name, initiator, offline_event)
+    assert rules.has_perm(perm_name, group_member_in_orga, offline_event)
+    assert rules.has_perm(perm_name, group_member_out, offline_event)
+    assert rules.has_perm(perm_name, group_member_in_project, offline_event)
 
 
 @pytest.mark.django_db
-def test_rule_project_draft(offline_event_factory, user):
+def test_rule_project_draft(offline_event_factory, user_factory, group_factory,
+                            user):
+
     offline_event = offline_event_factory(project__is_draft=True)
     project = offline_event.project
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_draft
     assert not rules.has_perm(perm_name, anonymous, offline_event)
     assert not rules.has_perm(perm_name, user, offline_event)
+    assert not rules.has_perm(perm_name, group_member_in_orga, offline_event)
+    assert not rules.has_perm(perm_name, group_member_out, offline_event)
+    assert rules.has_perm(perm_name, group_member_in_project, offline_event)
     assert rules.has_perm(perm_name, moderator, offline_event)
     assert rules.has_perm(perm_name, initiator, offline_event)
 
 
 @pytest.mark.django_db
-def test_rule_project_archived(offline_event_factory, user):
+def test_rule_project_archived(offline_event_factory, user_factory,
+                               group_factory, user):
+
     offline_event = offline_event_factory(project__is_archived=True)
     project = offline_event.project
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert project.is_archived
     assert rules.has_perm(perm_name, anonymous, offline_event)
     assert rules.has_perm(perm_name, user, offline_event)
+    assert rules.has_perm(perm_name, group_member_in_orga, offline_event)
+    assert rules.has_perm(perm_name, group_member_out, offline_event)
+    assert rules.has_perm(perm_name, group_member_in_project, offline_event)
     assert rules.has_perm(perm_name, moderator, offline_event)
     assert rules.has_perm(perm_name, initiator, offline_event)

--- a/tests/plans/rules/test_rules_add.py
+++ b/tests/plans/rules/test_rules_add.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_plans.add_plan'
 
@@ -11,11 +12,20 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(plan, project, user):
+def test_rule(plan, user_factory, group_factory,
+              project, user):
+
     plan.projects.add(project)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert not rules.has_perm(perm_name, anonymous, plan.organisation)
     assert not rules.has_perm(perm_name, user, plan.organisation)
     assert not rules.has_perm(perm_name, moderator, plan.organisation)
+    assert not rules.has_perm(perm_name, group_member_out, plan.organisation)
+    assert not rules.has_perm(perm_name, group_member_in_project,
+                              plan.organisation)
+    assert rules.has_perm(perm_name, group_member_in_orga, plan.organisation)
     assert rules.has_perm(perm_name, initiator, plan.organisation)

--- a/tests/plans/rules/test_rules_change.py
+++ b/tests/plans/rules/test_rules_change.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_plans.change_plan'
 
@@ -11,11 +12,19 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(plan, user, project):
+def test_rule(plan, user_factory, group_factory,
+              project, user):
+
     plan.projects.add(project)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert not rules.has_perm(perm_name, anonymous, plan)
     assert not rules.has_perm(perm_name, user, plan)
     assert not rules.has_perm(perm_name, moderator, plan)
+    assert not rules.has_perm(perm_name, group_member_in_orga, plan)
+    assert not rules.has_perm(perm_name, group_member_out, plan)
+    assert not rules.has_perm(perm_name, group_member_in_project, plan)
     assert rules.has_perm(perm_name, initiator, plan)

--- a/tests/plans/rules/test_rules_export.py
+++ b/tests/plans/rules/test_rules_export.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_plans.export_plan'
 
@@ -11,11 +12,20 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(plan, user, project):
+def test_rule(plan, user_factory, group_factory,
+              project, user):
+
     plan.projects.add(project)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert not rules.has_perm(perm_name, anonymous, plan.organisation)
     assert not rules.has_perm(perm_name, user, plan.organisation)
     assert not rules.has_perm(perm_name, moderator, plan.organisation)
+    assert not rules.has_perm(perm_name, group_member_out, plan.organisation)
+    assert not rules.has_perm(perm_name, group_member_in_project,
+                              plan.organisation)
+    assert rules.has_perm(perm_name, group_member_in_orga, plan.organisation)
     assert rules.has_perm(perm_name, initiator, plan.organisation)

--- a/tests/plans/rules/test_rules_list.py
+++ b/tests/plans/rules/test_rules_list.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_plans.list_plan'
 
@@ -11,11 +12,19 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(plan, user, project):
+def test_rule(plan, user_factory, group_factory,
+              project, user):
+
     plan.projects.add(project)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert rules.has_perm(perm_name, anonymous, None)
     assert rules.has_perm(perm_name, user, None)
     assert rules.has_perm(perm_name, moderator, None)
     assert rules.has_perm(perm_name, initiator, None)
+    assert rules.has_perm(perm_name, group_member_in_orga, None)
+    assert rules.has_perm(perm_name, group_member_out, None)
+    assert rules.has_perm(perm_name, group_member_in_project, None)

--- a/tests/plans/rules/test_rules_view.py
+++ b/tests/plans/rules/test_rules_view.py
@@ -2,6 +2,7 @@ import pytest
 import rules
 
 from adhocracy4.test.helpers import setup_users
+from tests.helpers import setup_group_users
 
 perm_name = 'meinberlin_plans.view_plan'
 
@@ -11,23 +12,39 @@ def test_perm_exists():
 
 
 @pytest.mark.django_db
-def test_rule(plan, user, project):
+def test_rule(plan, user_factory, group_factory,
+              project, user):
+
     plan.projects.add(project)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert rules.has_perm(perm_name, anonymous, plan)
     assert rules.has_perm(perm_name, user, plan)
     assert rules.has_perm(perm_name, moderator, plan)
     assert rules.has_perm(perm_name, initiator, plan)
+    assert rules.has_perm(perm_name, group_member_in_orga, plan)
+    assert rules.has_perm(perm_name, group_member_out, plan)
+    assert rules.has_perm(perm_name, group_member_in_project, plan)
 
 
 @pytest.mark.django_db
-def test_rule_plan_draft(plan_factory, user, project):
+def test_rule_plan_draft(plan_factory, user_factory, group_factory,
+                         project, user):
+
     plan = plan_factory(is_draft=True, organisation=project.organisation)
     plan.projects.add(project)
+
     anonymous, moderator, initiator = setup_users(project)
+    group_member_in_orga, group_member_out, group_member_in_project, project \
+        = setup_group_users(user_factory, group_factory, project)
 
     assert not rules.has_perm(perm_name, anonymous, plan)
     assert not rules.has_perm(perm_name, user, plan)
     assert not rules.has_perm(perm_name, moderator, plan)
+    assert not rules.has_perm(perm_name, group_member_in_orga, plan)
+    assert not rules.has_perm(perm_name, group_member_out, plan)
+    assert not rules.has_perm(perm_name, group_member_in_project, plan)
     assert rules.has_perm(perm_name, initiator, plan)


### PR DESCRIPTION
…ship was added to rules testing

Fixes #3269

Testing for group membership for the module rules for plans, documents, and offlineevents is added here.
Group membership testing for project rules was added in [PR 477](https://github.com/liqd/a4-meinberlin/pull/4077/files).