### PR TITLE
[#4126 (comment)] apps/budgeting: consolidate wording proposal list

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-03 12:06+0100\n"
+"POT-Creation-Date: 2022-01-05 09:32+0100\n"
 "PO-Revision-Date: 2017-10-16 13:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -4456,122 +4456,122 @@ msgstr "Dieser Abstimmungsschlüssel ist nicht aktiviert."
 msgid "This token has no votes left."
 msgstr "Dieser Abstimmungsschlüssel hat keine weiteren Stimmen."
 
-#: meinberlin/config/settings/base.py:314
-#: meinberlin/config/settings/base.py:327
-#: meinberlin/config/settings/base.py:338
-#: meinberlin/config/settings/base.py:353
+#: meinberlin/config/settings/base.py:317
+#: meinberlin/config/settings/base.py:330
+#: meinberlin/config/settings/base.py:341
+#: meinberlin/config/settings/base.py:358
 msgid "Rich text editor"
 msgstr "Rich Text Editor"
 
-#: meinberlin/config/settings/base.py:497
+#: meinberlin/config/settings/base.py:503
 msgid "Pin without icon"
 msgstr "Pin ohne Icon"
 
-#: meinberlin/config/settings/base.py:498
+#: meinberlin/config/settings/base.py:504
 msgid "Diamond"
 msgstr "Diamant"
 
-#: meinberlin/config/settings/base.py:499
+#: meinberlin/config/settings/base.py:505
 msgid "Triangle up"
 msgstr "Dreieck Spitze oben"
 
-#: meinberlin/config/settings/base.py:500
+#: meinberlin/config/settings/base.py:506
 msgid "Triangle down"
 msgstr "Dreieck Spitze unten"
 
-#: meinberlin/config/settings/base.py:501
+#: meinberlin/config/settings/base.py:507
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: meinberlin/config/settings/base.py:502
+#: meinberlin/config/settings/base.py:508
 msgid "Semi circle"
 msgstr "Halbkreis"
 
-#: meinberlin/config/settings/base.py:503
+#: meinberlin/config/settings/base.py:509
 msgid "Hexagon"
 msgstr "Sechseck"
 
-#: meinberlin/config/settings/base.py:504
+#: meinberlin/config/settings/base.py:510
 msgid "Rhomboid"
 msgstr "Parallelogramm"
 
-#: meinberlin/config/settings/base.py:505
+#: meinberlin/config/settings/base.py:511
 msgid "Star"
 msgstr "Stern"
 
-#: meinberlin/config/settings/base.py:506
+#: meinberlin/config/settings/base.py:512
 msgid "Square"
 msgstr "Quadrat"
 
-#: meinberlin/config/settings/base.py:507
+#: meinberlin/config/settings/base.py:513
 msgid "Octothorpe"
 msgstr "Raute"
 
-#: meinberlin/config/settings/base.py:508
+#: meinberlin/config/settings/base.py:514
 msgid "Rectangle"
 msgstr "Viereck"
 
-#: meinberlin/config/settings/base.py:509
+#: meinberlin/config/settings/base.py:515
 msgid "Circle"
 msgstr "Kreis"
 
-#: meinberlin/config/settings/base.py:510
+#: meinberlin/config/settings/base.py:516
 msgid "Right triangle"
 msgstr "Dreieck Spitze rechts"
 
-#: meinberlin/config/settings/base.py:511
+#: meinberlin/config/settings/base.py:517
 msgid "Zigzag"
 msgstr "ZickZack"
 
-#: meinberlin/config/settings/base.py:520
+#: meinberlin/config/settings/base.py:526
 msgid "Anti-discrimination"
 msgstr "Antidiskriminierung"
 
-#: meinberlin/config/settings/base.py:521
+#: meinberlin/config/settings/base.py:527
 msgid "Work & economy"
 msgstr "Arbeit & Wirtschaft"
 
-#: meinberlin/config/settings/base.py:522
+#: meinberlin/config/settings/base.py:528
 msgid "Building & living"
 msgstr "Bauen & Wohnen"
 
-#: meinberlin/config/settings/base.py:523
+#: meinberlin/config/settings/base.py:529
 msgid "Education & research"
 msgstr "Bildung & Forschung"
 
-#: meinberlin/config/settings/base.py:524
+#: meinberlin/config/settings/base.py:530
 msgid "Children, youth & family"
 msgstr "Kinder, Jugend & Familie"
 
-#: meinberlin/config/settings/base.py:525
+#: meinberlin/config/settings/base.py:531
 msgid "Finances"
 msgstr "Finanzen"
 
-#: meinberlin/config/settings/base.py:526
+#: meinberlin/config/settings/base.py:532
 msgid "Health & sports"
 msgstr "Gesundheit & Sport"
 
-#: meinberlin/config/settings/base.py:527
+#: meinberlin/config/settings/base.py:533
 msgid "Integration"
 msgstr "Integration"
 
-#: meinberlin/config/settings/base.py:528
+#: meinberlin/config/settings/base.py:534
 msgid "Culture & leisure"
 msgstr "Kultur & Freizeit"
 
-#: meinberlin/config/settings/base.py:529
+#: meinberlin/config/settings/base.py:535
 msgid "Neighborhood & participation"
 msgstr "Nachbarschaft & Teilhabe"
 
-#: meinberlin/config/settings/base.py:530
+#: meinberlin/config/settings/base.py:536
 msgid "Urban development"
 msgstr "Stadtentwicklung"
 
-#: meinberlin/config/settings/base.py:531
+#: meinberlin/config/settings/base.py:537
 msgid "Environment & public green space"
 msgstr "Umwelt & Grünflächen"
 
-#: meinberlin/config/settings/base.py:532
+#: meinberlin/config/settings/base.py:538
 msgid "Traffic"
 msgstr "Verkehr"
 

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -751,7 +751,7 @@ msgstr[1] "Sie haben noch %s Stimmen."
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:12
 msgid "updated on"
-msgstr ""
+msgstr "bearbeitet am"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:16
 msgid "created on"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-03 12:06+0100\n"
+"POT-Creation-Date: 2022-01-05 09:32+0100\n"
 "PO-Revision-Date: 2017-05-30 12:06+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -750,8 +750,8 @@ msgstr[0] "Sie haben noch %s Stimmen."
 msgstr[1] "Sie haben noch %s Stimmen."
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:12
-msgid "modified on"
-msgstr "bearbeitet am"
+msgid "updated on"
+msgstr ""
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:16
 msgid "created on"
@@ -1195,6 +1195,9 @@ msgid "More information can be found in the privacy policy of Vimeo under: "
 msgstr ""
 "Weitere Informationen finden Sie in der Datenschutzerklärung von Vimeo "
 "unter: "
+
+#~ msgid "modified on"
+#~ msgstr "bearbeitet am"
 
 #~ msgid ""
 #~ "Thanks for the feedback. It will be checked by the moderators as soon as "

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-03 12:06+0100\n"
+"POT-Creation-Date: 2022-01-05 09:32+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4288,122 +4288,122 @@ msgstr "This token is not active."
 msgid "This token has no votes left."
 msgstr "This token has no votes left."
 
-#: meinberlin/config/settings/base.py:314
-#: meinberlin/config/settings/base.py:327
-#: meinberlin/config/settings/base.py:338
-#: meinberlin/config/settings/base.py:353
+#: meinberlin/config/settings/base.py:317
+#: meinberlin/config/settings/base.py:330
+#: meinberlin/config/settings/base.py:341
+#: meinberlin/config/settings/base.py:358
 msgid "Rich text editor"
 msgstr "Rich text editor"
 
-#: meinberlin/config/settings/base.py:497
+#: meinberlin/config/settings/base.py:503
 msgid "Pin without icon"
 msgstr "Pin without icon"
 
-#: meinberlin/config/settings/base.py:498
+#: meinberlin/config/settings/base.py:504
 msgid "Diamond"
 msgstr "Diamond"
 
-#: meinberlin/config/settings/base.py:499
+#: meinberlin/config/settings/base.py:505
 msgid "Triangle up"
 msgstr "Triangle up"
 
-#: meinberlin/config/settings/base.py:500
+#: meinberlin/config/settings/base.py:506
 msgid "Triangle down"
 msgstr "Triangle down"
 
-#: meinberlin/config/settings/base.py:501
+#: meinberlin/config/settings/base.py:507
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: meinberlin/config/settings/base.py:502
+#: meinberlin/config/settings/base.py:508
 msgid "Semi circle"
 msgstr "Semi circle"
 
-#: meinberlin/config/settings/base.py:503
+#: meinberlin/config/settings/base.py:509
 msgid "Hexagon"
 msgstr "Hexagon"
 
-#: meinberlin/config/settings/base.py:504
+#: meinberlin/config/settings/base.py:510
 msgid "Rhomboid"
 msgstr "Rhomboid"
 
-#: meinberlin/config/settings/base.py:505
+#: meinberlin/config/settings/base.py:511
 msgid "Star"
 msgstr "Star"
 
-#: meinberlin/config/settings/base.py:506
+#: meinberlin/config/settings/base.py:512
 msgid "Square"
 msgstr "Square"
 
-#: meinberlin/config/settings/base.py:507
+#: meinberlin/config/settings/base.py:513
 msgid "Octothorpe"
 msgstr "Octothorpe"
 
-#: meinberlin/config/settings/base.py:508
+#: meinberlin/config/settings/base.py:514
 msgid "Rectangle"
 msgstr "Rectangle"
 
-#: meinberlin/config/settings/base.py:509
+#: meinberlin/config/settings/base.py:515
 msgid "Circle"
 msgstr "Circle"
 
-#: meinberlin/config/settings/base.py:510
+#: meinberlin/config/settings/base.py:516
 msgid "Right triangle"
 msgstr "Right triangle"
 
-#: meinberlin/config/settings/base.py:511
+#: meinberlin/config/settings/base.py:517
 msgid "Zigzag"
 msgstr "Zigzag"
 
-#: meinberlin/config/settings/base.py:520
+#: meinberlin/config/settings/base.py:526
 msgid "Anti-discrimination"
 msgstr "Anti-discrimination"
 
-#: meinberlin/config/settings/base.py:521
+#: meinberlin/config/settings/base.py:527
 msgid "Work & economy"
 msgstr "Work & economy"
 
-#: meinberlin/config/settings/base.py:522
+#: meinberlin/config/settings/base.py:528
 msgid "Building & living"
 msgstr "Building & living"
 
-#: meinberlin/config/settings/base.py:523
+#: meinberlin/config/settings/base.py:529
 msgid "Education & research"
 msgstr "Education & research"
 
-#: meinberlin/config/settings/base.py:524
+#: meinberlin/config/settings/base.py:530
 msgid "Children, youth & family"
 msgstr "Children, youth & family"
 
-#: meinberlin/config/settings/base.py:525
+#: meinberlin/config/settings/base.py:531
 msgid "Finances"
 msgstr "Finances"
 
-#: meinberlin/config/settings/base.py:526
+#: meinberlin/config/settings/base.py:532
 msgid "Health & sports"
 msgstr "Health & sports"
 
-#: meinberlin/config/settings/base.py:527
+#: meinberlin/config/settings/base.py:533
 msgid "Integration"
 msgstr "Integration"
 
-#: meinberlin/config/settings/base.py:528
+#: meinberlin/config/settings/base.py:534
 msgid "Culture & leisure"
 msgstr "Culture & leisure"
 
-#: meinberlin/config/settings/base.py:529
+#: meinberlin/config/settings/base.py:535
 msgid "Neighborhood & participation"
 msgstr "Neighborhood & participation"
 
-#: meinberlin/config/settings/base.py:530
+#: meinberlin/config/settings/base.py:536
 msgid "Urban development"
 msgstr "Urban development"
 
-#: meinberlin/config/settings/base.py:531
+#: meinberlin/config/settings/base.py:537
 msgid "Environment & public green space"
 msgstr "Environment & public green space"
 
-#: meinberlin/config/settings/base.py:532
+#: meinberlin/config/settings/base.py:538
 msgid "Traffic"
 msgstr "Traffic"
 

--- a/locale/en_GB/LC_MESSAGES/djangojs.po
+++ b/locale/en_GB/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-03 12:06+0100\n"
+"POT-Creation-Date: 2022-01-05 09:32+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -624,8 +624,8 @@ msgstr[0] "you have 1 vote left"
 msgstr[1] "you have %s votes left"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:12
-msgid "modified on"
-msgstr "modified on"
+msgid "updated on"
+msgstr "updated on"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:16
 msgid "created on"
@@ -1061,6 +1061,9 @@ msgstr ""
 #: dsgvo-video-embed/js/dsgvo-video-embed.js:20
 msgid "More information can be found in the privacy policy of Vimeo under: "
 msgstr "More information can be found in the privacy policy of Vimeo under: "
+
+#~ msgid "modified on"
+#~ msgstr "modified on"
 
 #~ msgid ""
 #~ "Thanks for the feedback. It will be checked by the moderators as soon as "

--- a/meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx
+++ b/meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx
@@ -9,7 +9,7 @@ export const BudgetingProposalListItem = (props) => {
   const { proposal, isVotingPhase, tokenvoteApiUrl } = props
   const safeLocale = props.locale ? props.locale : undefined
   const date = proposal.modified
-    ? `${django.gettext('modified on')} ${toLocaleDate(
+    ? `${django.gettext('updated on')} ${toLocaleDate(
         proposal.modified,
         safeLocale
       )}`


### PR DESCRIPTION
This is in reference to https://github.com/liqd/a4-meinberlin/pull/4126#discussion_r777473157
This change consolidates the wording use for the new react proposal list to use the same wording as is used in this context everywhere else (commit 1), and adds the corresponding translation (commits 2 & 3).