### PR TITLE
apps/livequestions apps/plans: fixed missing translations by moving translation strings into variables at top of files in all affected jsx files

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -4422,7 +4422,7 @@ msgstr "Plattform-Mail"
 
 #: meinberlin/apps/votes/api.py:90
 msgid "No token given or token not valid for module."
-msgstr ""
+msgstr "Fehlender oder für das Modul ungültiger Abstimmungsschlüssel."
 
 #: meinberlin/apps/votes/api.py:95
 msgid "Token is inactive."

--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-07 15:11+0100\n"
+"POT-Creation-Date: 2022-01-12 15:51+0100\n"
 "PO-Revision-Date: 2017-10-16 13:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -260,7 +260,7 @@ msgstr "privat"
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_dashboard_list_item.html:19
 #: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/includes/offlineevent_list_item.html:20
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:52
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:195
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:191
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:28
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:73
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_dashboard_list_item.html:19
@@ -429,7 +429,7 @@ msgstr "Kategorien bearbeiten"
 #: adhocracy4/categories/filters.py:16
 #: adhocracy4/categories/forms.py:45
 #: adhocracy4/exports/mixins/items.py:14
-#: meinberlin/apps/budgeting/api.py:63
+#: meinberlin/apps/budgeting/api.py:65
 msgid "Category"
 msgstr "Kategorie"
 
@@ -541,24 +541,24 @@ msgid "Edit areasettings"
 msgstr "Kartenbereich bearbeiten"
 
 #: adhocracy4/dashboard/filter.py:15
-#: meinberlin/apps/budgeting/api.py:70 meinberlin/apps/projects/views.py:57
+#: meinberlin/apps/budgeting/api.py:72 meinberlin/apps/projects/views.py:57
 msgid "Archived"
 msgstr "Archiviert"
 
 #: adhocracy4/dashboard/filter.py:19
 #: adhocracy4/filters/widgets.py:32
-#: meinberlin/apps/budgeting/api.py:52 meinberlin/apps/budgeting/api.py:72
+#: meinberlin/apps/budgeting/api.py:54 meinberlin/apps/budgeting/api.py:74
 #: meinberlin/apps/projects/views.py:61
 msgid "All"
 msgstr "Alle"
 
 #: adhocracy4/dashboard/filter.py:20
-#: meinberlin/apps/budgeting/api.py:73 meinberlin/apps/projects/views.py:62
+#: meinberlin/apps/budgeting/api.py:75 meinberlin/apps/projects/views.py:62
 msgid "No"
 msgstr "Nein"
 
 #: adhocracy4/dashboard/filter.py:21
-#: meinberlin/apps/budgeting/api.py:74
+#: meinberlin/apps/budgeting/api.py:76
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_confirm_delete.html:13
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html:13
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_confirm_delete.html:13
@@ -583,7 +583,7 @@ msgstr ""
 
 #: adhocracy4/dashboard/forms.py:86
 #: meinberlin/apps/plans/templates/meinberlin_plans/includes/plan_form.html:32
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:131
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:127
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:126
 msgid "Contact for questions"
 msgstr "Kontakt für Rückfragen"
@@ -721,7 +721,7 @@ msgstr "Merkmale"
 #: adhocracy4/exports/mixins/items.py:46
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:60
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:99
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:95
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
 msgid "Reference No."
 msgstr "Referenznr."
@@ -751,7 +751,7 @@ msgid "Negative ratings"
 msgstr "Negative Bewertungen"
 
 #: adhocracy4/filters/widgets.py:66
-#: meinberlin/apps/budgeting/api.py:85 meinberlin/apps/projects/views.py:40
+#: meinberlin/apps/budgeting/api.py:87 meinberlin/apps/projects/views.py:40
 msgid "Ordering"
 msgstr "Sortierung"
 
@@ -1131,7 +1131,7 @@ msgid "Postal address"
 msgstr "Postadresse"
 
 #: adhocracy4/projects/models.py:54
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:143
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:139
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
 msgid "Email"
@@ -1146,8 +1146,8 @@ msgid "Phone"
 msgstr "Telefon"
 
 #: adhocracy4/projects/models.py:72
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:148
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:163
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:144
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:159
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:143
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:158
 msgid "Website"
@@ -1742,7 +1742,7 @@ msgstr ""
 "Legen Sie ein Formular zur Stellungnahme zu den Bebauungsplänen an. Dieses "
 "Formular wird dann auf externen Seiten eingebunden."
 
-#: meinberlin/apps/budgeting/api.py:79 meinberlin/apps/budgeting/views.py:18
+#: meinberlin/apps/budgeting/api.py:81 meinberlin/apps/budgeting/views.py:19
 #: meinberlin/apps/ideas/views.py:32 meinberlin/apps/kiezkasse/views.py:15
 #: meinberlin/apps/mapideas/views.py:15
 #: meinberlin/apps/maptopicprio/views.py:18
@@ -1750,7 +1750,7 @@ msgstr ""
 msgid "Most recent"
 msgstr "am aktuellsten"
 
-#: meinberlin/apps/budgeting/api.py:81 meinberlin/apps/budgeting/views.py:20
+#: meinberlin/apps/budgeting/api.py:83 meinberlin/apps/budgeting/views.py:21
 #: meinberlin/apps/ideas/views.py:34 meinberlin/apps/kiezkasse/views.py:17
 #: meinberlin/apps/mapideas/views.py:17
 #: meinberlin/apps/maptopicprio/views.py:20
@@ -1758,7 +1758,7 @@ msgstr "am aktuellsten"
 msgid "Most popular"
 msgstr "am beliebtesten"
 
-#: meinberlin/apps/budgeting/api.py:82 meinberlin/apps/budgeting/views.py:21
+#: meinberlin/apps/budgeting/api.py:84 meinberlin/apps/budgeting/views.py:22
 #: meinberlin/apps/ideas/views.py:35 meinberlin/apps/kiezkasse/views.py:18
 #: meinberlin/apps/mapideas/views.py:18
 #: meinberlin/apps/maptopicprio/views.py:21
@@ -1980,25 +1980,25 @@ msgstr ""
 msgid "Submit proposal"
 msgstr "Vorschlag anlegen"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:38
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:36
 msgid "Enter code"
 msgstr "Schlüssel eingeben"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:59
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:57
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:34
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:34
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:25
 msgid "Zoom in"
 msgstr "hineinzoomen"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:60
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:58
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:35
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:35
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:26
 msgid "Zoom out"
 msgstr "auszoomen"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:85
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:83
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html:29
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:52
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:60
@@ -2044,7 +2044,7 @@ msgstr "%(title)s bearbeiten"
 msgid "Edit proposal"
 msgstr "Vorschlag bearbeiten"
 
-#: meinberlin/apps/budgeting/views.py:107 meinberlin/apps/kiezkasse/views.py:76
+#: meinberlin/apps/budgeting/views.py:125 meinberlin/apps/kiezkasse/views.py:76
 msgid "Your budget request has been deleted"
 msgstr "Ihr Vorschlag wurde gelöscht"
 
@@ -2282,7 +2282,7 @@ msgstr "Negative Bewertungen"
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:54
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:44
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:49
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:102
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:98
 msgid "updated on "
 msgstr "bearbeitet am "
 
@@ -2290,14 +2290,14 @@ msgstr "bearbeitet am "
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:46
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:51
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:104
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:100
 msgid "created on "
 msgstr "erstellt am "
 
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:86
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:95
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:177
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:186
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:173
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:182
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -3470,7 +3470,7 @@ msgstr ""
 "Projekte nach Bezirk gefiltert werden. "
 
 #: meinberlin/apps/plans/models.py:94
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:82
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:78
 msgid "Cost"
 msgstr "Kosten"
 
@@ -3539,7 +3539,7 @@ msgid "In the project overview projects can be filtered by status."
 msgstr "In der Projektübersicht können Projekte nach Status gefiltert werden."
 
 #: meinberlin/apps/plans/models.py:148
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:87
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:83
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:51
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:97
 msgid "Participation"
@@ -3554,7 +3554,7 @@ msgstr ""
 "werden."
 
 #: meinberlin/apps/plans/models.py:158
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:76
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:72
 msgid "Duration"
 msgstr "Laufzeit"
 
@@ -3675,21 +3675,21 @@ msgstr "Ort"
 msgid "Topic"
 msgstr "Thema"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:88
 msgid "see participation plans"
 msgstr "siehe Beteiligung"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:139
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:135
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:134
 msgid "Telephone"
 msgstr "Telefon"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:156
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:152
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:151
 msgid "Responsible body"
 msgstr "Verantwortliche Stelle"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:212
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:208
 #: meinberlin/templates/a4dashboard/base_project_list.html:7
 #: meinberlin/templates/a4dashboard/base_project_list.html:16
 #: meinberlin/templates/a4dashboard/project_list.html:9
@@ -4420,17 +4420,13 @@ msgstr "Nutzerkonto Einstellungen"
 msgid "Platform Email"
 msgstr "Plattform-Mail"
 
-#: meinberlin/apps/votes/api.py:84
-msgid "No token given."
-msgstr "Fehlender Abstimmungsschlüssel."
+#: meinberlin/apps/votes/api.py:90
+msgid "No token given or token not valid for module."
+msgstr ""
 
-#: meinberlin/apps/votes/api.py:89
+#: meinberlin/apps/votes/api.py:95
 msgid "Token is inactive."
 msgstr "Abstimmungsschlüssel ist nicht aktiviert."
-
-#: meinberlin/apps/votes/api.py:94
-msgid "Token not valid for module."
-msgstr "Der Abstimmungsschlüssel ist nicht gültig für dieses Modul."
 
 #: meinberlin/apps/votes/forms.py:45
 msgid "This token is not valid"
@@ -5134,6 +5130,12 @@ msgid ""
 msgstr ""
 "Sie sind dabei sich mit Ihrem %(provider_name)s-Konto auf %(site_name)s "
 "anzumelden. Füllen Sie bitte das folgende Formular als letzten Schritt aus:"
+
+#~ msgid "No token given."
+#~ msgstr "Fehlender Abstimmungsschlüssel."
+
+#~ msgid "Token not valid for module."
+#~ msgstr "Der Abstimmungsschlüssel ist nicht gültig für dieses Modul."
 
 #~ msgid ""
 #~ "This token is not valid. It might be expired or not valid for this "

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-07 15:11+0100\n"
+"POT-Creation-Date: 2022-01-12 15:51+0100\n"
 "PO-Revision-Date: 2017-05-30 12:06+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -389,6 +389,7 @@ msgstr "sortiert nach: "
 
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:9
 msgid " characters"
 msgstr " Zeichen"
 
@@ -552,7 +553,7 @@ msgstr "entfernen"
 
 #: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:16
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:19
-#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:69
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:7
 msgid "Question"
 msgstr "Frage"
 
@@ -739,7 +740,8 @@ msgid "Send Report"
 msgstr "Meldung senden"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:76
-#: meinberlin/apps/plans/assets/PlansList.jsx:252
+#: meinberlin/apps/plans/assets/PlansList.jsx:11
+#: meinberlin/apps/plans/assets/PlansMap.jsx:11
 msgid "Nothing to show"
 msgstr "Keine Ergebnisse"
 
@@ -763,7 +765,7 @@ msgid "View as list"
 msgstr "Als Liste ansehen"
 
 #: meinberlin/apps/budgeting/assets/FilterBarListMapSwitch.jsx:14
-#: meinberlin/apps/plans/assets/Toggles.jsx:129
+#: meinberlin/apps/plans/assets/Toggles.jsx:9
 msgid "List"
 msgstr "Liste"
 
@@ -772,7 +774,7 @@ msgid "View as map"
 msgstr "Als Karte ansehen"
 
 #: meinberlin/apps/budgeting/assets/FilterBarListMapSwitch.jsx:22
-#: meinberlin/apps/plans/assets/Toggles.jsx:130
+#: meinberlin/apps/plans/assets/Toggles.jsx:10
 msgid "Map"
 msgstr "Karte"
 
@@ -883,9 +885,17 @@ msgstr ""
 "Sie haben Third Party Cookies deaktiviert. Sie können sich dieses Projekt "
 "zwar anschauen, werden sich aber nicht anmelden können."
 
-#: meinberlin/apps/livequestions/assets/CategorySelect.jsx:16
+#: meinberlin/apps/livequestions/assets/CategorySelect.jsx:5
 msgid "Affiliation"
 msgstr "Zugehörigkeit"
+
+#: meinberlin/apps/livequestions/assets/CategorySelect.jsx:6
+msgid ""
+"Answered questions will be displayed in the statistics according to the "
+"chosen affiliation."
+msgstr ""
+"Beantwortete Fragen werden entsprechend der ausgewählten Zugehörigkeit in "
+"der Statistik dargestellt."
 
 #: meinberlin/apps/livequestions/assets/Filters.jsx:21
 msgid "only show marked questions"
@@ -932,22 +942,37 @@ msgstr "Information öffnen"
 msgid "Hide"
 msgstr "Ausblenden"
 
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:21
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:49
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:10
 msgid "select affiliation"
 msgstr "Zugehörigkeit auswählen"
 
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:185
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:11
 msgid "Information"
 msgstr "Information"
 
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:207
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:12
+msgid "Questions"
+msgstr "Fragen"
+
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:13
 msgid "Statistics"
 msgstr "Statistik"
 
-#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:64
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:14
+msgid "display on screen"
+msgstr "auf Bildschirm anzeigen"
+
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:6
 msgid "Here you can ask your question"
 msgstr "Hier können Sie Ihre Frage stellen"
+
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:8
+msgid "Your question"
+msgstr "Ihre Frage"
+
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:10
+msgid "Post"
+msgstr "Senden"
 
 #: meinberlin/apps/livequestions/assets/QuestionModerator.jsx:97
 msgid "mark as hidden"
@@ -1038,19 +1063,27 @@ msgstr "Projekte anzeigen"
 msgid "more filters"
 msgstr "weitere Filter"
 
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:81
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:6
 msgid "Search title"
 msgstr "nach Projekttitel suchen"
 
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:114
-msgid "Enter the name of the organisation"
-msgstr "Name der Organisation eingeben"
-
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:141
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:7
 msgid "Organisation"
 msgstr "Organisation"
 
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:166
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:8
+msgid "Enter the name of the organisation"
+msgstr "Name der Organisation eingeben"
+
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:9
+msgid "Participation"
+msgstr "Beteiligung"
+
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:10
+msgid "Project status"
+msgstr "Projektstatus"
+
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:11
 msgid "show projects"
 msgstr "Projekte anzeigen"
 
@@ -1090,37 +1123,48 @@ msgstr "abgeschlossen"
 msgid "Project overview"
 msgstr "Projektübersicht"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:82
+#: meinberlin/apps/plans/assets/PlansList.jsx:5
+#: meinberlin/apps/plans/assets/PopUp.jsx:7
 msgid "remaining"
 msgstr "noch"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:83
-#: meinberlin/apps/plans/assets/PopUp.jsx:20
+#: meinberlin/apps/plans/assets/PlansList.jsx:6
+#: meinberlin/apps/plans/assets/PopUp.jsx:6
 msgid "More than 1 year remaining"
 msgstr "noch länger als 1 Jahr"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:133
+#: meinberlin/apps/plans/assets/PlansList.jsx:7
+#: meinberlin/apps/plans/assets/PopUp.jsx:11
 msgid "Participation projects: "
 msgstr "Beteiligungsprojekte: "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:134
-#: meinberlin/apps/plans/assets/PopUp.jsx:32
+#: meinberlin/apps/plans/assets/PlansList.jsx:8
+#: meinberlin/apps/plans/assets/PopUp.jsx:8
 msgid "Participation: from "
 msgstr "Beteiligung: ab "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:135
+#: meinberlin/apps/plans/assets/PlansList.jsx:9
+#: meinberlin/apps/plans/assets/PopUp.jsx:9
 msgid "Participation ended. Read result."
 msgstr "Beteiligung beendet. Ergebnis lesen."
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:136
+#: meinberlin/apps/plans/assets/PlansList.jsx:10
 msgid "Status: "
 msgstr "Status: "
 
-#: meinberlin/apps/plans/assets/PlansMap.jsx:267
+#: meinberlin/apps/plans/assets/PlansMap.jsx:9
+msgid "Address search"
+msgstr "Adresssuche"
+
+#: meinberlin/apps/plans/assets/PlansMap.jsx:10
 msgid "Address Search"
 msgstr "Adresssuche"
 
-#: meinberlin/apps/plans/assets/PlansMap.jsx:301
+#: meinberlin/apps/plans/assets/PlansMap.jsx:12
+msgid "Close information box"
+msgstr "Informationsfenster schließen"
+
+#: meinberlin/apps/plans/assets/PlansMap.jsx:13
 msgid ""
 "Projects without spacial reference are not shown on the map. Please have a "
 "look at the project list."
@@ -1128,22 +1172,33 @@ msgstr ""
 "Projekte ohne räumlichen Bezug werden nicht auf der Karte angezeigt. Bitte "
 "beachten Sie daher auch die Projektliste. "
 
-#: meinberlin/apps/plans/assets/Toggles.jsx:41
-#: meinberlin/apps/plans/assets/Toggles.jsx:95
+#: meinberlin/apps/plans/assets/PopUp.jsx:10
+msgid "Superordinate project: "
+msgstr "Übergeordnetes Projekt: "
+
+#: meinberlin/apps/plans/assets/PopUp.jsx:12
+msgid "Participation: "
+msgstr "Beteiligung: "
+
+#: meinberlin/apps/plans/assets/Toggles.jsx:5
 msgid " search results"
 msgstr " Suchergebnisse"
 
-#: meinberlin/apps/plans/assets/Toggles.jsx:75
+#: meinberlin/apps/plans/assets/Toggles.jsx:6
 msgid "Show map"
 msgstr "Karte anzeigen"
 
-#: meinberlin/apps/plans/assets/Toggles.jsx:131
-msgid "show list"
-msgstr "Liste anzeigen"
-
-#: meinberlin/apps/plans/assets/Toggles.jsx:132
+#: meinberlin/apps/plans/assets/Toggles.jsx:7
 msgid "show map"
 msgstr "Karte anzeigen"
+
+#: meinberlin/apps/plans/assets/Toggles.jsx:8
+msgid "hide map"
+msgstr "Karte ausblenden"
+
+#: meinberlin/apps/plans/assets/Toggles.jsx:11
+msgid "show list"
+msgstr "Liste anzeigen"
 
 #: meinberlin/assets/js/unload_warning.js:16
 msgid "If you leave this page changes you made will not be saved."
@@ -1215,43 +1270,3 @@ msgstr ""
 #~ msgstr ""
 #~ "Danke für die Rückmeldung. Der Beitrag wird so schnell wie möglich von "
 #~ "der Moderation geprüft."
-
-#~ msgid ""
-#~ "Answered questions will be displayed in the statistics according to the "
-#~ "chosen affiliation."
-#~ msgstr ""
-#~ "Beantwortete Fragen werden entsprechend der ausgewählten Zugehörigkeit in "
-#~ "der Statistik dargestellt."
-
-#~ msgid "Questions"
-#~ msgstr "Fragen"
-
-#~ msgid "display on screen"
-#~ msgstr "auf Bildschirm anzeigen"
-
-#~ msgid "Your question"
-#~ msgstr "Ihre Frage"
-
-#~ msgid "Post"
-#~ msgstr "Senden"
-
-#~ msgid "Participation"
-#~ msgstr "Beteiligung"
-
-#~ msgid "Project status"
-#~ msgstr "Projektstatus"
-
-#~ msgid "Address search"
-#~ msgstr "Adresssuche"
-
-#~ msgid "Close information box"
-#~ msgstr "Informationsfenster schließen"
-
-#~ msgid "Superordinate project: "
-#~ msgstr "Übergeordnetes Projekt: "
-
-#~ msgid "Participation: "
-#~ msgstr "Beteiligung: "
-
-#~ msgid "hide map"
-#~ msgstr "Karte ausblenden"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-07 15:11+0100\n"
+"POT-Creation-Date: 2022-01-12 15:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -226,7 +226,7 @@ msgstr "private"
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/includes/maptopic_dashboard_list_item.html:19
 #: meinberlin/apps/offlineevents/templates/meinberlin_offlineevents/includes/offlineevent_list_item.html:20
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:52
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:195
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:191
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:28
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:73
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_dashboard_list_item.html:19
@@ -366,7 +366,7 @@ msgstr "Edit categories"
 
 #: adhocracy4/categories/fields.py:12 adhocracy4/categories/filters.py:16
 #: adhocracy4/categories/forms.py:45 adhocracy4/exports/mixins/items.py:14
-#: meinberlin/apps/budgeting/api.py:63
+#: meinberlin/apps/budgeting/api.py:65
 msgid "Category"
 msgstr "Category"
 
@@ -472,23 +472,23 @@ msgstr "Areasettings"
 msgid "Edit areasettings"
 msgstr "Edit areasettings"
 
-#: adhocracy4/dashboard/filter.py:15 meinberlin/apps/budgeting/api.py:70
+#: adhocracy4/dashboard/filter.py:15 meinberlin/apps/budgeting/api.py:72
 #: meinberlin/apps/projects/views.py:57
 msgid "Archived"
 msgstr "Archived"
 
 #: adhocracy4/dashboard/filter.py:19 adhocracy4/filters/widgets.py:32
-#: meinberlin/apps/budgeting/api.py:52 meinberlin/apps/budgeting/api.py:72
+#: meinberlin/apps/budgeting/api.py:54 meinberlin/apps/budgeting/api.py:74
 #: meinberlin/apps/projects/views.py:61
 msgid "All"
 msgstr "All"
 
-#: adhocracy4/dashboard/filter.py:20 meinberlin/apps/budgeting/api.py:73
+#: adhocracy4/dashboard/filter.py:20 meinberlin/apps/budgeting/api.py:75
 #: meinberlin/apps/projects/views.py:62
 msgid "No"
 msgstr "No"
 
-#: adhocracy4/dashboard/filter.py:21 meinberlin/apps/budgeting/api.py:74
+#: adhocracy4/dashboard/filter.py:21 meinberlin/apps/budgeting/api.py:76
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_confirm_delete.html:13
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_confirm_delete.html:13
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_confirm_delete.html:13
@@ -512,7 +512,7 @@ msgstr "Only invited users can participate (private)."
 
 #: adhocracy4/dashboard/forms.py:86
 #: meinberlin/apps/plans/templates/meinberlin_plans/includes/plan_form.html:32
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:131
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:127
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:126
 msgid "Contact for questions"
 msgstr "Contact for questions"
@@ -643,7 +643,7 @@ msgstr "Labels"
 #: adhocracy4/exports/mixins/items.py:46
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:60
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html:61
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:99
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:95
 #: meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html:45
 msgid "Reference No."
 msgstr "Reference No."
@@ -672,7 +672,7 @@ msgstr "Positive ratings"
 msgid "Negative ratings"
 msgstr "Negative ratings"
 
-#: adhocracy4/filters/widgets.py:66 meinberlin/apps/budgeting/api.py:85
+#: adhocracy4/filters/widgets.py:66 meinberlin/apps/budgeting/api.py:87
 #: meinberlin/apps/projects/views.py:40
 msgid "Ordering"
 msgstr "Ordering"
@@ -1020,7 +1020,7 @@ msgid "Postal address"
 msgstr "Postal address"
 
 #: adhocracy4/projects/models.py:54
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:143
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:139
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/removeable_invite_list.html:7
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:138
 msgid "Email"
@@ -1035,8 +1035,8 @@ msgid "Phone"
 msgstr "Phone"
 
 #: adhocracy4/projects/models.py:72
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:148
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:163
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:144
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:159
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:143
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:158
 msgid "Website"
@@ -1623,7 +1623,7 @@ msgstr ""
 "Create a statement formular for development plans to be embedded on external "
 "sites."
 
-#: meinberlin/apps/budgeting/api.py:79 meinberlin/apps/budgeting/views.py:18
+#: meinberlin/apps/budgeting/api.py:81 meinberlin/apps/budgeting/views.py:19
 #: meinberlin/apps/ideas/views.py:32 meinberlin/apps/kiezkasse/views.py:15
 #: meinberlin/apps/mapideas/views.py:15
 #: meinberlin/apps/maptopicprio/views.py:18
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Most recent"
 msgstr "Most recent"
 
-#: meinberlin/apps/budgeting/api.py:81 meinberlin/apps/budgeting/views.py:20
+#: meinberlin/apps/budgeting/api.py:83 meinberlin/apps/budgeting/views.py:21
 #: meinberlin/apps/ideas/views.py:34 meinberlin/apps/kiezkasse/views.py:17
 #: meinberlin/apps/mapideas/views.py:17
 #: meinberlin/apps/maptopicprio/views.py:20
@@ -1639,7 +1639,7 @@ msgstr "Most recent"
 msgid "Most popular"
 msgstr "Most popular"
 
-#: meinberlin/apps/budgeting/api.py:82 meinberlin/apps/budgeting/views.py:21
+#: meinberlin/apps/budgeting/api.py:84 meinberlin/apps/budgeting/views.py:22
 #: meinberlin/apps/ideas/views.py:35 meinberlin/apps/kiezkasse/views.py:18
 #: meinberlin/apps/mapideas/views.py:18
 #: meinberlin/apps/maptopicprio/views.py:21
@@ -1856,25 +1856,25 @@ msgstr ""
 msgid "Submit proposal"
 msgstr "Submit proposal"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:38
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:36
 msgid "Enter code"
 msgstr "Enter code"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:59
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:57
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:34
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:34
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:25
 msgid "Zoom in"
 msgstr "Zoom in"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:60
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:58
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:35
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:35
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:26
 msgid "Zoom out"
 msgstr "Zoom out"
 
-#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:85
+#: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:83
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html:29
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:52
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:60
@@ -1920,7 +1920,7 @@ msgstr "Edit %(title)s"
 msgid "Edit proposal"
 msgstr "Edit proposal"
 
-#: meinberlin/apps/budgeting/views.py:107 meinberlin/apps/kiezkasse/views.py:76
+#: meinberlin/apps/budgeting/views.py:125 meinberlin/apps/kiezkasse/views.py:76
 msgid "Your budget request has been deleted"
 msgstr "Your budget request has been deleted"
 
@@ -2156,7 +2156,7 @@ msgstr "Negative Ratings"
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:54
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:44
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:49
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:102
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:98
 msgid "updated on "
 msgstr "updated on "
 
@@ -2164,14 +2164,14 @@ msgstr "updated on "
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:56
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_list_item.html:46
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_list_item.html:51
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:104
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:100
 msgid "created on "
 msgstr "created on "
 
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:86
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html:95
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:177
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:186
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:173
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:182
 msgid "Actions"
 msgstr "Actions"
 
@@ -3314,7 +3314,7 @@ msgstr ""
 "plan. In the project overview projects can be filtered by district."
 
 #: meinberlin/apps/plans/models.py:94
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:82
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:78
 msgid "Cost"
 msgstr "Cost"
 
@@ -3382,7 +3382,7 @@ msgid "In the project overview projects can be filtered by status."
 msgstr "In the project overview projects can be filtered by status."
 
 #: meinberlin/apps/plans/models.py:148
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:87
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:83
 #: meinberlin/apps/projectcontainers/templates/meinberlin_projectcontainers/includes/container_detail.html:51
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:97
 msgid "Participation"
@@ -3397,7 +3397,7 @@ msgstr ""
 "status."
 
 #: meinberlin/apps/plans/models.py:158
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:76
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:72
 msgid "Duration"
 msgstr "Duration"
 
@@ -3518,21 +3518,21 @@ msgstr "Location"
 msgid "Topic"
 msgstr "Topic"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:92
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:88
 msgid "see participation plans"
 msgstr "see participation plans"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:139
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:135
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:134
 msgid "Telephone"
 msgstr "Telephone"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:156
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:152
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:151
 msgid "Responsible body"
 msgstr "Responsible body"
 
-#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:212
+#: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:208
 #: meinberlin/templates/a4dashboard/base_project_list.html:7
 #: meinberlin/templates/a4dashboard/base_project_list.html:16
 #: meinberlin/templates/a4dashboard/project_list.html:9
@@ -4252,17 +4252,13 @@ msgstr "Account Settings"
 msgid "Platform Email"
 msgstr "Platform Email"
 
-#: meinberlin/apps/votes/api.py:84
-msgid "No token given."
-msgstr "No token given."
+#: meinberlin/apps/votes/api.py:90
+msgid "No token given or token not valid for module."
+msgstr "No token given or token not valid for module."
 
-#: meinberlin/apps/votes/api.py:89
+#: meinberlin/apps/votes/api.py:95
 msgid "Token is inactive."
 msgstr "Token is inactive."
-
-#: meinberlin/apps/votes/api.py:94
-msgid "Token not valid for module."
-msgstr "Token not valid for module."
 
 #: meinberlin/apps/votes/forms.py:45
 msgid "This token is not valid"
@@ -4958,6 +4954,12 @@ msgid ""
 msgstr ""
 "You are about to use your %(provider_name)s account to login to "
 "%(site_name)s. As a final step, please complete the following form:"
+
+#~ msgid "No token given."
+#~ msgstr "No token given."
+
+#~ msgid "Token not valid for module."
+#~ msgstr "Token not valid for module."
 
 #~ msgid ""
 #~ "This token is not valid. It might be expired or not valid for this "

--- a/locale/en_GB/LC_MESSAGES/djangojs.po
+++ b/locale/en_GB/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-07 15:11+0100\n"
+"POT-Creation-Date: 2022-01-12 15:51+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -303,6 +303,7 @@ msgid "sorted by: "
 msgstr "sorted by: "
 
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:9
 msgid " characters"
 msgstr " characters"
 
@@ -431,7 +432,7 @@ msgstr "remove"
 
 #: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:16
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:19
-#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:69
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:7
 msgid "Question"
 msgstr "Question"
 
@@ -613,7 +614,8 @@ msgid "Send Report"
 msgstr "Send Report"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:76
-#: meinberlin/apps/plans/assets/PlansList.jsx:252
+#: meinberlin/apps/plans/assets/PlansList.jsx:11
+#: meinberlin/apps/plans/assets/PlansMap.jsx:11
 msgid "Nothing to show"
 msgstr "Nothing to show"
 
@@ -637,7 +639,7 @@ msgid "View as list"
 msgstr "View as list"
 
 #: meinberlin/apps/budgeting/assets/FilterBarListMapSwitch.jsx:14
-#: meinberlin/apps/plans/assets/Toggles.jsx:129
+#: meinberlin/apps/plans/assets/Toggles.jsx:9
 msgid "List"
 msgstr "List"
 
@@ -646,7 +648,7 @@ msgid "View as map"
 msgstr "View as map"
 
 #: meinberlin/apps/budgeting/assets/FilterBarListMapSwitch.jsx:22
-#: meinberlin/apps/plans/assets/Toggles.jsx:130
+#: meinberlin/apps/plans/assets/Toggles.jsx:10
 msgid "Map"
 msgstr "Map"
 
@@ -757,9 +759,17 @@ msgstr ""
 "You have third party cookies disabled. You can still view the content of "
 "this project but won't be able to login."
 
-#: meinberlin/apps/livequestions/assets/CategorySelect.jsx:16
+#: meinberlin/apps/livequestions/assets/CategorySelect.jsx:5
 msgid "Affiliation"
 msgstr "Affiliation"
+
+#: meinberlin/apps/livequestions/assets/CategorySelect.jsx:6
+msgid ""
+"Answered questions will be displayed in the statistics according to the "
+"chosen affiliation."
+msgstr ""
+"Answered questions will be displayed in the statistics according to the "
+"chosen affiliation."
 
 #: meinberlin/apps/livequestions/assets/Filters.jsx:21
 msgid "only show marked questions"
@@ -805,22 +815,37 @@ msgstr "Open information"
 msgid "Hide"
 msgstr "Hide"
 
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:21
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:49
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:10
 msgid "select affiliation"
 msgstr "select affiliation"
 
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:185
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:11
 msgid "Information"
 msgstr "Information"
 
-#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:207
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:12
+msgid "Questions"
+msgstr "Questions"
+
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:13
 msgid "Statistics"
 msgstr "Statistics"
 
-#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:64
+#: meinberlin/apps/livequestions/assets/QuestionBox.jsx:14
+msgid "display on screen"
+msgstr "display on screen"
+
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:6
 msgid "Here you can ask your question"
 msgstr "Here you can ask your question"
+
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:8
+msgid "Your question"
+msgstr "Your question"
+
+#: meinberlin/apps/livequestions/assets/QuestionForm.jsx:10
+msgid "Post"
+msgstr "Post"
 
 #: meinberlin/apps/livequestions/assets/QuestionModerator.jsx:97
 msgid "mark as hidden"
@@ -911,19 +936,27 @@ msgstr "display projects"
 msgid "more filters"
 msgstr "more filters"
 
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:81
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:6
 msgid "Search title"
 msgstr "Search title"
 
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:114
-msgid "Enter the name of the organisation"
-msgstr "Enter the name of the organisation"
-
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:141
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:7
 msgid "Organisation"
 msgstr "Organisation"
 
-#: meinberlin/apps/plans/assets/FilterSecondary.jsx:166
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:8
+msgid "Enter the name of the organisation"
+msgstr "Enter the name of the organisation"
+
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:9
+msgid "Participation"
+msgstr "Participation"
+
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:10
+msgid "Project status"
+msgstr "Project status"
+
+#: meinberlin/apps/plans/assets/FilterSecondary.jsx:11
 msgid "show projects"
 msgstr "show projects"
 
@@ -963,37 +996,48 @@ msgstr "done"
 msgid "Project overview"
 msgstr "Project overview"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:82
+#: meinberlin/apps/plans/assets/PlansList.jsx:5
+#: meinberlin/apps/plans/assets/PopUp.jsx:7
 msgid "remaining"
 msgstr "remaining"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:83
-#: meinberlin/apps/plans/assets/PopUp.jsx:20
+#: meinberlin/apps/plans/assets/PlansList.jsx:6
+#: meinberlin/apps/plans/assets/PopUp.jsx:6
 msgid "More than 1 year remaining"
 msgstr "More than 1 year remaining"
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:133
+#: meinberlin/apps/plans/assets/PlansList.jsx:7
+#: meinberlin/apps/plans/assets/PopUp.jsx:11
 msgid "Participation projects: "
 msgstr "Participation projects: "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:134
-#: meinberlin/apps/plans/assets/PopUp.jsx:32
+#: meinberlin/apps/plans/assets/PlansList.jsx:8
+#: meinberlin/apps/plans/assets/PopUp.jsx:8
 msgid "Participation: from "
 msgstr "Participation: from "
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:135
+#: meinberlin/apps/plans/assets/PlansList.jsx:9
+#: meinberlin/apps/plans/assets/PopUp.jsx:9
 msgid "Participation ended. Read result."
 msgstr "Participation ended. Read result."
 
-#: meinberlin/apps/plans/assets/PlansList.jsx:136
+#: meinberlin/apps/plans/assets/PlansList.jsx:10
 msgid "Status: "
 msgstr "Status: "
 
-#: meinberlin/apps/plans/assets/PlansMap.jsx:267
+#: meinberlin/apps/plans/assets/PlansMap.jsx:9
+msgid "Address search"
+msgstr "Address search"
+
+#: meinberlin/apps/plans/assets/PlansMap.jsx:10
 msgid "Address Search"
 msgstr "Address Search"
 
-#: meinberlin/apps/plans/assets/PlansMap.jsx:301
+#: meinberlin/apps/plans/assets/PlansMap.jsx:12
+msgid "Close information box"
+msgstr "Close information box"
+
+#: meinberlin/apps/plans/assets/PlansMap.jsx:13
 msgid ""
 "Projects without spacial reference are not shown on the map. Please have a "
 "look at the project list."
@@ -1001,22 +1045,33 @@ msgstr ""
 "Projects without spacial reference are not shown on the map. Please have a "
 "look at the project list."
 
-#: meinberlin/apps/plans/assets/Toggles.jsx:41
-#: meinberlin/apps/plans/assets/Toggles.jsx:95
+#: meinberlin/apps/plans/assets/PopUp.jsx:10
+msgid "Superordinate project: "
+msgstr "Superordinate project: "
+
+#: meinberlin/apps/plans/assets/PopUp.jsx:12
+msgid "Participation: "
+msgstr "Participation: "
+
+#: meinberlin/apps/plans/assets/Toggles.jsx:5
 msgid " search results"
 msgstr " search results"
 
-#: meinberlin/apps/plans/assets/Toggles.jsx:75
+#: meinberlin/apps/plans/assets/Toggles.jsx:6
 msgid "Show map"
 msgstr "Show map"
 
-#: meinberlin/apps/plans/assets/Toggles.jsx:131
-msgid "show list"
-msgstr "show list"
-
-#: meinberlin/apps/plans/assets/Toggles.jsx:132
+#: meinberlin/apps/plans/assets/Toggles.jsx:7
 msgid "show map"
 msgstr "show map"
+
+#: meinberlin/apps/plans/assets/Toggles.jsx:8
+msgid "hide map"
+msgstr "hide map"
+
+#: meinberlin/apps/plans/assets/Toggles.jsx:11
+msgid "show list"
+msgstr "show list"
 
 #: meinberlin/assets/js/unload_warning.js:16
 msgid "If you leave this page changes you made will not be saved."
@@ -1081,46 +1136,6 @@ msgstr "More information can be found in the privacy policy of Vimeo under: "
 #~ msgstr ""
 #~ "Thanks for the feedback. It will be checked by the moderators as soon as "
 #~ "possible."
-
-#~ msgid ""
-#~ "Answered questions will be displayed in the statistics according to the "
-#~ "chosen affiliation."
-#~ msgstr ""
-#~ "Answered questions will be displayed in the statistics according to the "
-#~ "chosen affiliation."
-
-#~ msgid "Questions"
-#~ msgstr "Questions"
-
-#~ msgid "display on screen"
-#~ msgstr "display on screen"
-
-#~ msgid "Your question"
-#~ msgstr "Your question"
-
-#~ msgid "Post"
-#~ msgstr "Post"
-
-#~ msgid "Participation"
-#~ msgstr "Participation"
-
-#~ msgid "Project status"
-#~ msgstr "Project status"
-
-#~ msgid "Address search"
-#~ msgstr "Address search"
-
-#~ msgid "Close information box"
-#~ msgstr "Close information box"
-
-#~ msgid "Superordinate project: "
-#~ msgstr "Superordinate project: "
-
-#~ msgid "Participation: "
-#~ msgstr "Participation: "
-
-#~ msgid "hide map"
-#~ msgstr "hide map"
 
 #~ msgid "January"
 #~ msgstr "January"

--- a/meinberlin/apps/livequestions/assets/CategorySelect.jsx
+++ b/meinberlin/apps/livequestions/assets/CategorySelect.jsx
@@ -2,6 +2,9 @@ import django from 'django'
 import React from 'react'
 import $ from 'jquery' // FIXME needed to run test but file should be refactored to not include jquery
 
+const affiliationStr = django.gettext('Affiliation')
+const answeredQuestionsStr = django.gettext('Answered questions will be displayed in the statistics according to the chosen affiliation.')
+
 export default class SelectCategory extends React.Component {
   componentDidMount () {
     const select = $('#categorySelect')
@@ -13,9 +16,9 @@ export default class SelectCategory extends React.Component {
       <div>
         {Object.keys(this.props.category_dict).length > 0 &&
           <div className="live_questions__select u-spacer-bottom">
-            <label htmlFor="categorySelect">{django.gettext('Affiliation')}*</label>
+            <label htmlFor="categorySelect">{affiliationStr}*</label>
             <div className="form-hint">
-              {django.gettext('Answered questions will be displayed in the statistics according to the chosen affiliation.')}
+              {answeredQuestionsStr}
             </div>
             <select
               name="categorySelect"

--- a/meinberlin/apps/livequestions/assets/QuestionBox.jsx
+++ b/meinberlin/apps/livequestions/assets/QuestionBox.jsx
@@ -7,6 +7,12 @@ import InfoBox from './InfoBox'
 import Filters from './Filters'
 import StatisticsBox from './StatisticsBox'
 
+const selectAffiliationStr = django.gettext('select affiliation')
+const informationStr = django.gettext('Information')
+const questionsStr = django.gettext('Questions')
+const statisticsStr = django.gettext('Statistics')
+const displayStr = django.gettext('display on screen')
+
 export default class QuestionBox extends React.Component {
   constructor (props) {
     super(props)
@@ -18,7 +24,7 @@ export default class QuestionBox extends React.Component {
       filteredQuestions: [],
       answeredQuestions: [],
       category: '-1',
-      categoryName: django.gettext('select affiliation'),
+      categoryName: selectAffiliationStr,
       displayNotHiddenOnly: false,
       displayOnShortlist: false,
       orderedByLikes: false,
@@ -46,7 +52,7 @@ export default class QuestionBox extends React.Component {
   }
 
   setCategory (category) {
-    const newName = (category === '-1') ? django.gettext('select affiliation') : category
+    const newName = (category === '-1') ? selectAffiliationStr : category
     this.setState({
       filterChanged: true,
       categoryName: newName,
@@ -182,7 +188,7 @@ export default class QuestionBox extends React.Component {
                 aria-controls="tabpanel-information"
                 aria-expanded="false"
               >
-                {django.gettext('Information')}
+                {informationStr}
               </a>
               <a
                 id="tab-questions"
@@ -193,7 +199,7 @@ export default class QuestionBox extends React.Component {
                 aria-controls="tabpanel-questions"
                 aria-expanded="true"
               >
-                {django.gettext('Questions')}
+                {questionsStr}
               </a>
               <a
                 id="tab-statistics"
@@ -204,7 +210,7 @@ export default class QuestionBox extends React.Component {
                 aria-controls="tabpanel-statistics"
                 aria-expanded="false"
               >
-                {django.gettext('Statistics')}
+                {statisticsStr}
               </a>
             </nav>
           </div>
@@ -268,7 +274,7 @@ export default class QuestionBox extends React.Component {
                           <i className="fas fa-tv fa-stack-2x" aria-label="hidden"> </i>
                           <i className="fas fa-arrow-up fa-stack-1x" aria-label="hidden"> </i>
                         </span>
-                        {django.gettext('display on screen')}
+                        {displayStr}
                       </a>
                     </div>}
                 </div>

--- a/meinberlin/apps/livequestions/assets/QuestionForm.jsx
+++ b/meinberlin/apps/livequestions/assets/QuestionForm.jsx
@@ -3,6 +3,12 @@ import React from 'react'
 import { updateItem } from '../../contrib/assets/helpers.js'
 import CategorySelect from './CategorySelect'
 
+const askQuestionStr = django.gettext('Here you can ask your question')
+const questionStr = django.gettext('Question')
+const yourQuestionStr = django.gettext('Your question')
+const charsStr = django.gettext(' characters')
+const postStr = django.gettext('Post')
+
 export default class QuestionForm extends React.Component {
   constructor (props) {
     super(props)
@@ -61,14 +67,14 @@ export default class QuestionForm extends React.Component {
     return (
       <div className="container">
         <form id="id-comment-form" action="" onSubmit={this.addQuestion.bind(this)}>
-          <h2>{django.gettext('Here you can ask your question')}</h2>
+          <h2>{askQuestionStr}</h2>
           <CategorySelect
             onSelect={this.selectCategory.bind(this)}
             category_dict={this.props.category_dict}
           />
-          <label htmlFor="questionTextField">{django.gettext('Question')}*</label>
+          <label htmlFor="questionTextField">{questionStr}*</label>
           <textarea
-            placeholder={django.gettext('Your question')}
+            placeholder={yourQuestionStr}
             id="questionTextField"
             className="form-control"
             name="questionTextFieldName"
@@ -78,7 +84,7 @@ export default class QuestionForm extends React.Component {
             value={this.state.question}
             maxLength="1000"
           />
-          <label htmlFor="id-comment-form" className="live_questions__char-count">{this.state.questionCharCount}/1000{django.gettext(' characters')}</label>
+          <label htmlFor="id-comment-form" className="live_questions__char-count">{this.state.questionCharCount}/1000{charsStr}</label>
 
           <div className="form-check">
             <label className="form-check__label">
@@ -86,7 +92,7 @@ export default class QuestionForm extends React.Component {
               {this.getPrivacyPolicyLabelWithLinks()}
             </label>
           </div>
-          <input type="submit" value={django.gettext('Post')} className="submit-button" />
+          <input type="submit" value={postStr} className="submit-button" />
         </form>
       </div>
     )

--- a/meinberlin/apps/plans/assets/FilterSecondary.jsx
+++ b/meinberlin/apps/plans/assets/FilterSecondary.jsx
@@ -3,6 +3,13 @@ const Typeahead = require('react-bootstrap-typeahead').Typeahead
 const FilterRadio = require('./FilterRadio')
 const React = require('react')
 
+const searchTitleStr = django.gettext('Search title')
+const orgaStr = django.gettext('Organisation')
+const enterOrgaNameStr = django.gettext('Enter the name of the organisation')
+const participationStr = django.gettext('Participation')
+const projectStatStr = django.gettext('Project status')
+const showProjectsStr = django.gettext('show projects')
+
 class FilterSecondary extends React.Component {
   constructor (props) {
     super(props)
@@ -78,7 +85,7 @@ class FilterSecondary extends React.Component {
             className="input-group__input filter-bar__search"
             type="text"
             id="id-title-search"
-            placeholder={django.gettext('Search title')}
+            placeholder={searchTitleStr}
             value={this.state.titleSearchChoice}
             onChange={this.changeTitleSearch.bind(this)}
           />
@@ -89,13 +96,13 @@ class FilterSecondary extends React.Component {
           >
             <i className="fa fa-search" aria-hidden="true" />
           </button>
-          <span className="visually-hidden">{django.gettext('Search title')}
+          <span className="visually-hidden">{searchTitleStr}
           </span>
         </label>
         {this.props.organisationFilterOnTop &&
           <div className="form-group">
             <div className="typeahead__input-label">
-              <h2 className="u-no-margin">{django.gettext('Organisation')}</h2>
+              <h2 className="u-no-margin">{orgaStr}</h2>
             </div>
             <span className="typeahead__input-group">
               <span className="typeahead__input-group-prepend">
@@ -111,7 +118,7 @@ class FilterSecondary extends React.Component {
                 multiple={false}
                 options={this.props.organisations}
                 selected={this.state.organisationChoice}
-                placeholder={django.gettext('Enter the name of the organisation')}
+                placeholder={enterOrgaNameStr}
               />
             </span>
           </div>}
@@ -119,7 +126,7 @@ class FilterSecondary extends React.Component {
           <div className="filter-bar__menu-radio-part">
             <FilterRadio
               filterId="par"
-              question={django.gettext('Participation')}
+              question={participationStr}
               chosen={this.state.participationChoice}
               choiceNames={this.props.participationNames}
               onSelect={this.clickParticipation.bind(this)}
@@ -128,7 +135,7 @@ class FilterSecondary extends React.Component {
           <div className="filter-bar__menu-radio-proj">
             <FilterRadio
               filterId="sta"
-              question={django.gettext('Project status')}
+              question={projectStatStr}
               chosen={this.state.statusChoice}
               choiceNames={this.props.statusNames}
               onSelect={this.clickStatus.bind(this)}
@@ -138,7 +145,7 @@ class FilterSecondary extends React.Component {
         {!this.props.organisationFilterOnTop &&
           <div className="form-group">
             <div className="typeahead__input-label">
-              <h2 className="u-no-margin">{django.gettext('Organisation')}</h2>
+              <h2 className="u-no-margin">{orgaStr}</h2>
             </div>
             <span className="typeahead__input-group">
               <span className="typeahead__input-group-prepend">
@@ -154,7 +161,7 @@ class FilterSecondary extends React.Component {
                 multiple={false}
                 options={this.props.organisations}
                 selected={this.state.organisationChoice}
-                placeholder={django.gettext('Enter the name of the organisation')}
+                placeholder={enterOrgaNameStr}
               />
             </span>
           </div>}
@@ -163,7 +170,7 @@ class FilterSecondary extends React.Component {
           type="submit"
           onClick={this.submitSecondaryFilters.bind(this)}
         >
-          {django.gettext('show projects')}
+          {showProjectsStr}
         </button>
       </form>
     )

--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -2,6 +2,14 @@
 const React = require('react')
 const Moment = require('moment')
 
+const remainingStr = django.gettext('remaining')
+const moreThanStr = django.gettext('More than 1 year remaining')
+const participationProjectsStr = django.gettext('Participation projects: ')
+const futureParticipationStr = django.gettext('Participation: from ')
+const endedParticipationStr = django.gettext('Participation ended. Read result.')
+const statusStr = django.gettext('Status: ')
+const nothingStr = django.gettext('Nothing to show')
+
 class LazyBackground extends React.Component {
   constructor (props) {
     super(props)
@@ -79,8 +87,6 @@ class PlansList extends React.Component {
   }
 
   getTimespan (item) {
-    const remainingStr = django.gettext('remaining')
-    const moreThanStr = django.gettext('More than 1 year remaining')
     const timeRemaining = item.active_phase[1].split(' ')
     const daysRemaining = parseInt(timeRemaining[0])
     if (daysRemaining > 365) {
@@ -130,10 +136,6 @@ class PlansList extends React.Component {
 
   renderListItem (item, i) {
     const statusClass = (item.participation_active === true) ? 'participation-tile__status-active' : 'participation-tile__status-inactive'
-    const participationProjectsStr = django.gettext('Participation projects: ')
-    const futureParticipationStr = django.gettext('Participation: from ')
-    const endedParticipationStr = django.gettext('Participation ended. Read result.')
-    const statusStr = django.gettext('Status: ')
     return (
       <li
         className={this.props.isHorizontal ? 'participation-tile__horizontal' : 'participation-tile__vertical'}
@@ -249,7 +251,6 @@ class PlansList extends React.Component {
 
   renderList () {
     const list = []
-    const nothingStr = django.gettext('Nothing to show')
     this.props.items.forEach((item, i) => {
       list.push(this.renderListItem(item, i))
     })

--- a/meinberlin/apps/plans/assets/PlansMap.jsx
+++ b/meinberlin/apps/plans/assets/PlansMap.jsx
@@ -5,6 +5,13 @@ import { withCookies } from 'react-cookie'
 import PopUp from './PopUp'
 import { maps } from 'adhocracy4'
 import 'leaflet.markercluster'
+
+const addressSearchStr = django.gettext('Address search')
+const addressSearchCapStr = django.gettext('Address Search')
+const nothingStr = django.gettext('Nothing to show')
+const closeInfoBoxStr = django.gettext('Close information box')
+const projectsNotShownStr = django.gettext('Projects without spacial reference are not shown on the map. Please have a look at the project list.')
+
 const L = window.L
 const $ = window.$
 
@@ -264,10 +271,10 @@ class PlansMap extends Component {
                 name="search"
                 type="search"
                 id="id-map-search"
-                placeholder={django.gettext('Address Search')}
+                placeholder={addressSearchCapStr}
               />
-              <button className="input-group__after input-group__after--search btn btn--light" type="submit" title={django.gettext('Address search')}>
-                <i className="fas fa-search" aria-label={django.gettext('Address search')} />
+              <button className="input-group__after input-group__after--search btn btn--light" type="submit" title={addressSearchStr}>
+                <i className="fas fa-search" aria-label={addressSearchStr} />
               </button>
             </label>
 
@@ -290,15 +297,15 @@ class PlansMap extends Component {
 
             {this.state.displayError &&
               <ul aria-labelledby="id_filter_address" className="map-list-combined__map__search__error">
-                <li>{django.gettext('Nothing to show')}</li>
+                <li>{nothingStr}</li>
               </ul>}
 
           </form>
         </div>
         {this.state.showInfoBox &&
           <div className="map-infobox">
-            <button className="infobox__close" id="close" aria-label={django.gettext('Close information box')} onClick={this.closeInfoBox.bind(this)}><i className="fa fa-times" /></button>
-            <i className="fa fa-info-circle" aria-hidden="true" /><span>{django.gettext('Projects without spacial reference are not shown on the map. Please have a look at the project list.')}</span>
+            <button className="infobox__close" id="close" aria-label={closeInfoBoxStr} onClick={this.closeInfoBox.bind(this)}><i className="fa fa-times" /></button>
+            <i className="fa fa-info-circle" aria-hidden="true" /><span>{projectsNotShownStr}</span>
           </div>}
       </div>
     )

--- a/meinberlin/apps/plans/assets/PopUp.jsx
+++ b/meinberlin/apps/plans/assets/PopUp.jsx
@@ -3,6 +3,14 @@ const React = require('react')
 const $ = require('jquery')
 const Moment = require('moment')
 
+const moreThanStr = django.gettext('More than 1 year remaining')
+const remainingStr = django.gettext('remaining')
+const futureParticipationStr = django.gettext('Participation: from ')
+const endedParticipationStr = django.gettext('Participation ended. Read result.')
+const superordProjectStr = django.gettext('Superordinate project: ')
+const participationProjectsStr = django.gettext('Participation projects: ')
+const participationStr = django.gettext('Participation: ')
+
 class PopUp extends React.Component {
   escapeHtml (unsafe) {
     return $('<div>').text(unsafe).html()
@@ -17,11 +25,11 @@ class PopUp extends React.Component {
     const daysRemaining = parseInt(timeRemaining[0])
     if (daysRemaining > 365) {
       return (
-        <span>{django.gettext('More than 1 year remaining')}</span>
+        <span>{moreThanStr}</span>
       )
     } else {
       return (
-        <span>{django.gettext('remaining')} {this.props.item.active_phase[1]}</span>
+        <span>{remainingStr} {this.props.item.active_phase[1]}</span>
       )
     }
   }
@@ -29,7 +37,7 @@ class PopUp extends React.Component {
   getTranslation () {
     let newDate = Date.parse(this.props.item.future_phase.replace(/ /g, 'T'))
     newDate = Moment(newDate).format('DD.MM.YYYY')
-    return django.gettext('Participation: from ') + newDate
+    return futureParticipationStr + newDate
   }
 
   renderTopics () {
@@ -65,11 +73,11 @@ class PopUp extends React.Component {
             </div>}
           {this.props.item.past_phase && !this.props.item.active_phase && !this.props.item.future_phase &&
             <div className="maplist-item-popup__status status-bar__past">
-              <span className="maplist-item-popup__status">{django.gettext('Participation ended. Read result.')}</span>
+              <span className="maplist-item-popup__status">{endedParticipationStr}</span>
             </div>}
           {this.props.item.plan_url &&
             <div className="maps-popups-popup-name maplist-item-popup__proj-plan">
-              <span className="maplist-popup-item__roofline">{django.gettext('Superordinate project: ')}</span>
+              <span className="maplist-popup-item__roofline">{superordProjectStr}</span>
               <br />
               <a href={this.props.item.plan_url}>{this.props.item.plan_title}</a>
             </div>}
@@ -85,11 +93,11 @@ class PopUp extends React.Component {
           </div>
           <div className="maplist-popup-item__stats">
             <span className="maplist-item-popup__proj-count">
-              <i className="fas fa-th" />{django.gettext('Participation projects: ')}
+              <i className="fas fa-th" />{participationProjectsStr}
             </span>
             <span>{this.props.item.published_projects_count}</span>
             <br />
-            <span className="maplist-item-popup__status"><i className="fas fa-clock" />{django.gettext('Participation: ')}</span>
+            <span className="maplist-item-popup__status"><i className="fas fa-clock" />{participationStr}</span>
             <span className={statusClass}>{this.props.item.participation_string}</span>
           </div>
         </div>

--- a/meinberlin/apps/plans/assets/Toggles.jsx
+++ b/meinberlin/apps/plans/assets/Toggles.jsx
@@ -2,6 +2,14 @@ import React from 'react'
 import django from 'django'
 import { IconSwitch } from '../../contrib/assets/IconSwitch'
 
+const searchResultsStr = django.gettext(' search results')
+const showMapStr = django.gettext('Show map')
+const showMapAriaStr = django.gettext('show map')
+const hideMapStr = django.gettext('hide map')
+const listStr = django.gettext('List')
+const mapStr = django.gettext('Map')
+const showListStr = django.gettext('show list')
+
 class Toggles extends React.Component {
   clickStatusButton () {
     this.props.changeStatusSelection(-1)
@@ -38,7 +46,7 @@ class Toggles extends React.Component {
       return (
         <div>
           <div className="l-frame switch-container">
-            <div className={this.props.displayButtons ? 'switch-filter__label' : 'd-none'}>{this.props.projectCount}{django.gettext(' search results')}</div>
+            <div className={this.props.displayButtons ? 'switch-filter__label' : 'd-none'}>{this.props.projectCount}{searchResultsStr}</div>
             <div className="switch-filter__btn-group">
               {this.props.displayButtons && this.props.statusSelected &&
                 <button
@@ -72,14 +80,14 @@ class Toggles extends React.Component {
             <div className="switch">
               <div className="switch-group" role="group" aria-labelledby="switch-primary">
                 <label htmlFor="switch-primary" className="switch-label">
-                  <span className="switch-label__text">{django.gettext('Show map')}</span>
+                  <span className="switch-label__text">{showMapStr}</span>
                   <input
                     className="switch-input"
                     id="switch-primary"
                     onChange={this.props.toggleSwitch} /* eslint-disable-line react/jsx-handler-names */
                     name="switch-primary"
                     type="checkbox"
-                    aria-label={django.gettext('hide map')}
+                    aria-label={hideMapStr}
                   />
                   <span className="switch__toggle" />
                 </label>
@@ -92,7 +100,7 @@ class Toggles extends React.Component {
       return (
         <div>
           <div className="l-frame switch-container">
-            <div className={this.props.displayButtons ? 'switch-filter__label' : 'd-none'}>{this.props.projectCount}{django.gettext(' search results')}</div>
+            <div className={this.props.displayButtons ? 'switch-filter__label' : 'd-none'}>{this.props.projectCount}{searchResultsStr}</div>
             <div className="switch-filter__btn-group">
               {this.props.displayButtons && this.props.statusSelected &&
                 <button
@@ -126,10 +134,10 @@ class Toggles extends React.Component {
             <IconSwitch
               activeClass="btn btn--icon btn--light switch--btn active"
               inactiveClass="btn btn--icon btn--light"
-              startText={django.gettext('List')}
-              endText={django.gettext('Map')}
-              startAria={django.gettext('show list')}
-              endAria={django.gettext('show map')}
+              startText={listStr}
+              endText={mapStr}
+              startAria={showListStr}
+              endAria={showMapAriaStr}
               startIconClass="fa fa-list"
               endIconClass="fa fa-map"
               startID="show_list"


### PR DESCRIPTION
Fixes Issues #4150  and #4149 as caused by PR #4126

Leaving this in WIP until [question](https://github.com/liqd/a4-meinberlin/pull/4126/files#r783143986) is resolved, i.e. if there is another PR besides #4126 that deleted translations that are actually still needed.

