### PR TITLE
django-admin: fix custom CK editor fields

### DIFF
--- a/meinberlin/apps/activities/admin.py
+++ b/meinberlin/apps/activities/admin.py
@@ -1,5 +1,25 @@
+from ckeditor_uploader.widgets import CKEditorUploadingWidget
+from django import forms
 from django.contrib import admin
 
 from . import models
 
-admin.site.register(models.Activity)
+
+class ActivityAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['description'].widget = CKEditorUploadingWidget(
+            config_name='collapsible-image-editor', )
+
+    class Meta:
+        model = models.Activity
+        fields = '__all__'
+
+
+class ActivityAdmin(admin.ModelAdmin):
+    form = ActivityAdminForm
+
+
+admin.site.register(models.Activity, ActivityAdmin)

--- a/meinberlin/apps/offlineevents/admin.py
+++ b/meinberlin/apps/offlineevents/admin.py
@@ -1,3 +1,5 @@
+from ckeditor_uploader.widgets import CKEditorUploadingWidget
+from django import forms
 from django.contrib import admin
 
 from adhocracy4.projects.admin import ProjectAdminFilter
@@ -5,8 +7,22 @@ from adhocracy4.projects.admin import ProjectAdminFilter
 from . import models
 
 
+class OfflineEventAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['description'].widget = CKEditorUploadingWidget(
+            config_name='collapsible-image-editor', )
+
+    class Meta:
+        model = models.OfflineEvent
+        fields = '__all__'
+
+
 @admin.register(models.OfflineEvent)
 class OfflineEventAdmin(admin.ModelAdmin):
+    form = OfflineEventAdminForm
     list_display = ('__str__', 'project', 'date', 'created')
     list_filter = (
         'project__organisation',

--- a/meinberlin/apps/plans/admin.py
+++ b/meinberlin/apps/plans/admin.py
@@ -1,10 +1,26 @@
+from ckeditor_uploader.widgets import CKEditorUploadingWidget
+from django import forms
 from django.contrib import admin
 
 from . import models
 
 
+class PlanAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['description'].widget = CKEditorUploadingWidget(
+            config_name='collapsible-image-editor', )
+
+    class Meta:
+        model = models.Plan
+        fields = '__all__'
+
+
 @admin.register(models.Plan)
 class PlanAdmin(admin.ModelAdmin):
+    form = PlanAdminForm
     list_display = ('__str__', 'organisation', 'created')
 
     date_hierarchy = 'created'

--- a/meinberlin/apps/projects/admin.py
+++ b/meinberlin/apps/projects/admin.py
@@ -1,3 +1,5 @@
+from ckeditor_uploader.widgets import CKEditorUploadingWidget
+from django import forms
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
@@ -18,7 +20,23 @@ def set_is_archived_false(modeladmin, request, queryset):
 set_is_archived_false.short_description = _('dearchive')
 
 
+class ProjectAdminForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['information'].widget = CKEditorUploadingWidget(
+            config_name='collapsible-image-editor')
+        self.fields['result'].widget = CKEditorUploadingWidget(
+            config_name='collapsible-image-editor')
+
+    class Meta:
+        model = models.Project
+        fields = '__all__'
+
+
 class ProjectAdmin(admin.ModelAdmin):
+    form = ProjectAdminForm
     list_display = (
         '__str__', 'organisation', 'is_draft', 'is_archived',
         'project_type', 'created'


### PR DESCRIPTION
Similar as fix for [#1656 in a+](https://github.com/liqd/adhocracy-plus/issues/1656), done [here](https://github.com/liqd/adhocracy-plus/pull/1664/commits/6c9be35bb186c8cd504f492255f866dd224ff95c). In meinBerlin, this fix was required for the django-admin forms for

- Projects
- Activities
- Offline Events
- Plans.