### PR TITLE
Ks 2022 02 csrf failure template

### DIFF
--- a/meinberlin/templates/403_csrf.html
+++ b/meinberlin/templates/403_csrf.html
@@ -1,0 +1,6 @@
+{% extends "403.html" %}
+{% load i18n %}
+
+{% block error_description %}
+    <p>{% trans 'The verification of your input has failed. Please reload the page and make sure that your browser settings allow setting session cookies.' %}</p>
+{% endblock %}


### PR DESCRIPTION
Not super sure about this approach.. the request is aborted, so not there if csrf fails, thats why I had to add that check in userindicator. Also, because request is not there, it then shows the 'anmelden/register' button, even though the user is still logged in.. Not sure if we need (or even can) change that behaviour? Should I investigate more, what do you think @fuzzylogic2000 ?

fixes #4170