### PR TITLE
apps/notifications: take absolute url of comment, not item commented on

### DIFF
--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.de.email
@@ -14,7 +14,7 @@
 {% endif %}
 Möchten Sie antworten?{% endblock %}
 
-{% block cta_url %}{% if action.target.get_absolute_url %}{{ email.get_host }}{{ action.target.get_absolute_url }}{% else %}{{ email.get_host }}{{ action.project.get_absolute_url }}{% endif %}{% endblock %}
-{% block cta_label %}{% if action.target.get_absolute_url %}Beitrag anzeigen{% else %}Projekt anzeigen{% endif %}{% endblock %}
+{% block cta_url %}{% if action.obj.get_absolute_url %}{{ email.get_host }}{{ action.obj.get_absolute_url }}{% else %}{{ email.get_host }}{{ action.project.get_absolute_url }}{% endif %}{% endblock %}
+{% block cta_label %}{% if action.obj.get_absolute_url %}Beitrag anzeigen{% else %}Projekt anzeigen{% endif %}{% endblock %}
 
 {% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Sie haben die E-Mail erhalten, weil Sie einen Beitrag in einem Projekt erstellt haben. Wenn Sie keine Benachrichtigungen mehr erhalten möchten, ändern Sie die Einstellungen zu Ihrem <a href="{{ email.get_host }}{% url 'account' %}">Nutzerkonto</a>.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_creator.en.email
@@ -14,7 +14,7 @@
 {% endif %}
 Would you like to answer?{% endblock %}
 
-{% block cta_url %}{% if action.target.get_absolute_url %}{{ email.get_host }}{{ action.target.get_absolute_url }}{% else %}{{ email.get_host }}{{ action.project.get_absolute_url }}{% endif %}{% endblock %}
-{% block cta_label %}{% if action.target.get_absolute_url %}View Post{% else %}Visit the project{% endif %}{% endblock %}
+{% block cta_url %}{% if action.obj.get_absolute_url %}{{ email.get_host }}{{ action.obj.get_absolute_url }}{% else %}{{ email.get_host }}{{ action.project.get_absolute_url }}{% endif %}{% endblock %}
+{% block cta_label %}{% if action.obj.get_absolute_url %}View Post{% else %}Visit the project{% endif %}{% endblock %}
 
 {% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you added a contribution to the above project. If you no longer want to receive notifications, change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}


### PR DESCRIPTION
fixes #4257 

@sabinammm You are the only one assigned for testing again. :smile:  If you don't get it to work locally, just ask and/or assign the others to test.