### PR TITLE
deps: update a4 depending on extra release branch - fixes #4356

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@testing-library/react-native": "9.2.0",
     "acorn": "8.7.1",
-    "adhocracy4": "liqd/adhocracy4#mB-v2203.1",
+    "adhocracy4": "liqd/adhocracy4#mB-v2206",
     "autoprefixer": "10.4.7",
     "babel-loader": "8.2.5",
     "bootstrap": "5.1.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@mB-v2203.1#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@mB-v2206#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0


### PR DESCRIPTION
Great, we allow a longer filename in a4 now, but this gives an OS error: 
```
Internal Server Error: /api/organisations/1/bplan/
Traceback (most recent call last):
  File "/home/katharina/a4-meinberlin/meinberlin/apps/bplan/serializers.py", line 159, in _download_image_from_url
    self._image_storage.save(file_name, f)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/django/core/files/storage.py", line 54, in save
    name = self._save(name, content)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/django/core/files/storage.py", line 279, in _save
    fd = os.open(full_path, self.OS_OPEN_FLAGS, 0o666)
OSError: [Errno 36] File name too long: '/home/katharina/a4-meinberlin/media/projects/tiles/L3N5czExLXByb2QvYmEtbmV1a29lbGxuL3BvbGl0aWstdW5kLXZlcndhbHR1bmcvYWVtdGVyL3N0YWR0ZW50d2lja2x1bmdzYW10L3N0YWR0cGxhbnVuZy9iZWJhdXVuZ3NwbGFlbmUvYmViYXV1bmdzcGxhbi1mdWVyLW1laW5iZXJsaW4vdW50ZXJsYWdlbi9rYXJ0ZW4tdW5kLXBsYWVuZS91cGxvYWRfXzgzZWIwZjA4OGNjZmEwMTUxNjk0YTcyODQzZWJjYjA1X3hpdi0zLTFfMTAwMDB1ZWJlcnNpY2h0LmpwZw.jpeg'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/adhocracy4/api/mixins.py", line 82, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/mixins.py", line 24, in perform_create
    serializer.save()
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/rest_framework/serializers.py", line 212, in save
    self.instance = self.create(validated_data)
  File "/home/katharina/a4-meinberlin/meinberlin/apps/bplan/serializers.py", line 82, in create
    self._download_image_from_url(image_url)
  File "/home/katharina/a4-meinberlin/meinberlin/apps/bplan/serializers.py", line 162, in _download_image_from_url
    self._image_storage.delete(file_name)
  File "/home/katharina/a4-meinberlin/venv/lib/python3.8/site-packages/django/core/files/storage.py", line 318, in delete
    os.remove(name)
OSError: [Errno 36] File name too long: '/home/katharina/a4-meinberlin/media/projects/tiles/L3N5czExLXByb2QvYmEtbmV1a29lbGxuL3BvbGl0aWstdW5kLXZlcndhbHR1bmcvYWVtdGVyL3N0YWR0ZW50d2lja2x1bmdzYW10L3N0YWR0cGxhbnVuZy9iZWJhdXVuZ3NwbGFlbmUvYmViYXV1bmdzcGxhbi1mdWVyLW1laW5iZXJsaW4vdW50ZXJsYWdlbi9rYXJ0ZW4tdW5kLXBsYWVuZS91cGxvYWRfXzgzZWIwZjA4OGNjZmEwMTUxNjk0YTcyODQzZWJjYjA1X3hpdi0zLTFfMTAwMDB1ZWJlcnNpY2h0LmpwZw.jpeg'
```

Is that sth. we can fix @goapunk ? Or do we need another approach with uploading the image and save it with a shorter name?