### PR TITLE
deps: use own version of django-autoslug with fix - fixes #4366

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ zeep==4.1.0
 bleach==4.1.0
 Django==3.2.13 # pyup: <3.3
 django-allauth==0.50.0
-django-autoslug==1.9.8
+git+https://github.com/fuzzylogic2000/django-autoslug.git@master#egg=django-autoslug
 django-background-tasks==1.2.5
 django-ckeditor==6.4.0
 django-enumfield==2.0.2


### PR DESCRIPTION
This works! 
I would rather use a tag instead of the master branch, but I couldn't think of one (that we will then also use in all projects). Is there a convention @goapunk ?