### PR TITLE
deps: update a4 to hotfix tag mB-v2206.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ compilemessages:
 .PHONY: release
 release: export DJANGO_SETTINGS_MODULE ?= meinberlin.config.settings.build
 release:
-	npm install --silent
+	npm install --silent --legacy-peer-deps
 	npm run build:prod
 	$(VIRTUAL_ENV)/bin/python3 -m pip install -r requirements.txt -q
 	$(VIRTUAL_ENV)/bin/python3 manage.py compilemessages -v0

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@testing-library/react-native": "9.2.0",
     "acorn": "8.7.1",
-    "adhocracy4": "liqd/adhocracy4#mB-v2203.1",
+    "adhocracy4": "liqd/adhocracy4#mB-v2206.1",
     "autoprefixer": "10.4.7",
     "babel-loader": "8.2.5",
     "bootstrap": "5.1.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@mB-v2203.1#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@mB-v2206.1#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0


### PR DESCRIPTION
fixes #4383

I needed ridicilously long to get a4 right, because last time I creteated a tag, that I then didn't use. :roll_eyes: But I think, this is fine now! I used the a4 version from the last release (v2203.1) and cherry-picked the a4 fix onto that. I didn't do that on main, because I thought, we will properly update a4 there next.