### PR TITLE
deps/python: remove bleach - as is only used in a4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,6 @@ whitenoise==6.2.0
 zeep==4.1.0
 
 # Inherited a4-core requirements
-bleach==4.1.0
 Django==3.2.15
 django-allauth==0.51.0
 git+https://github.com/fuzzylogic2000/django-autoslug.git@master#egg=django-autoslug


### PR DESCRIPTION
Installing locally works without bleach. We only use it in a4: https://github.com/liqd/adhocracy4/blob/main/adhocracy4/transforms.py But then also in a+ for the ck editor, I guess.

But why do we only have the css-bleach in a4? Don't we need the other bleach for the tags and attributes? https://github.com/liqd/adhocracy4/blob/043494bbd9e66e3da0159fa643315d89112db140/tests/project/settings.py#L177

Hmm, unsure what to do here.