### PR TITLE
WIP plans/assets: Render project tiles on demand

### DIFF
--- a/meinberlin/apps/plans/assets/PlansList.jsx
+++ b/meinberlin/apps/plans/assets/PlansList.jsx
@@ -10,6 +10,9 @@ const endedParticipationStr = django.gettext('Participation ended. Read result.'
 const statusStr = django.gettext('Status: ')
 const nothingStr = django.gettext('Nothing to show')
 
+const autoScrollThreshold = 500
+const itemListInterval = 10
+
 class LazyBackground extends React.Component {
   constructor (props) {
     super(props)
@@ -78,6 +81,56 @@ class LazyBackground extends React.Component {
 }
 
 class PlansList extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.addItemsToList = this.addItemsToList.bind(this)
+    this.bindList = this.bindList.bind(this)
+    this.handleScroll = this.handleScroll.bind(this)
+    this.renderTopics = this.renderTopics.bind(this)
+
+    this.state = {
+      itemList: []
+    }
+  }
+
+  componentDidMount () {
+    window.addEventListener('scroll', this.handleScroll, { passive: true })
+    this.addItemsToList()
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('scroll', this.handleScroll)
+  }
+
+  getDocumentHeight () {
+    const D = document
+    return Math.max(
+      D.body.scrollHeight, D.documentElement.scrollHeight,
+      D.body.offsetHeight, D.documentElement.offsetHeight,
+      D.body.clientHeight, D.documentElement.clientHeight
+    )
+  }
+
+  handleScroll () {
+    const html = document.documentElement
+    if (html.scrollTop + html.clientHeight > this.getDocumentHeight() - autoScrollThreshold) {
+      this.addItemsToList()
+    }
+  }
+
+  addItemsToList () {
+    const newItemList = this.state.itemList.slice()
+    for (let i = this.state.itemList.length;
+      i < this.props.items.length &&
+      (i - this.state.itemList.length) < itemListInterval; i++) {
+      newItemList.push(this.renderListItem(this.props.items[i], i))
+    }
+    this.setState({
+      itemList: newItemList
+    })
+  }
+
   bindList (element) {
     this.listElement = element
   }
@@ -148,7 +201,7 @@ class PlansList extends React.Component {
               {item.tile_image &&
                 <LazyBackground
                   item={item}
-                  renderTopics={this.renderTopics.bind(this)}
+                  renderTopics={this.renderTopics}
                   isHorizontal={this.props.isHorizontal}
                 />}
               <div className="participation-tile__content">
@@ -250,15 +303,10 @@ class PlansList extends React.Component {
   }
 
   renderList () {
-    const list = []
-    this.props.items.forEach((item, i) => {
-      list.push(this.renderListItem(item, i))
-    })
-
-    if (list.length > 0) {
+    if (this.state.itemList.length > 0) {
       return (
         <ul className="u-list-reset participation-tile__list">
-          {list}
+          {this.state.itemList}
         </ul>
       )
     } else {
@@ -270,7 +318,7 @@ class PlansList extends React.Component {
 
   render () {
     return (
-      <div ref={this.bindList.bind(this)}>
+      <div ref={this.bindList}>
         {this.renderList()}
       </div>
     )


### PR DESCRIPTION
The list of active projects can get quite long, resulting in high
client cpu load. Skip rendering until the tile becomes visible. - currently does not decrease load time much due to back-end serving whole list

Need: 
- [x] refactoring
- [ ] only fetch 'laufend' list on first page load?
- [ ] to work with filters on both map and list view