### PR TITLE
Ks 2022 09 add module types

### DIFF
--- a/meinberlin/apps/bplan/views.py
+++ b/meinberlin/apps/bplan/views.py
@@ -60,6 +60,7 @@ class BplanProjectCreateView(ExternalProjectCreateView):
         ],
         image='',
         settings_model=None,
+        type='BP'
     )
 
 

--- a/meinberlin/apps/dashboard/blueprints.py
+++ b/meinberlin/apps/dashboard/blueprints.py
@@ -24,6 +24,7 @@ blueprints = [
          ],
          image='images/brainstorming.svg',
          settings_model=None,
+         type='BS',
      )),
     ('map-brainstorming',
      ProjectBlueprint(
@@ -37,6 +38,7 @@ blueprints = [
          ],
          image='images/map-brainstorming.svg',
          settings_model=('a4maps', 'AreaSettings'),
+         type='MBS',
      )),
     ('idea-collection',
      ProjectBlueprint(
@@ -50,6 +52,7 @@ blueprints = [
          ],
          image='images/agenda-setting.svg',
          settings_model=None,
+         type='IC',
      )),
     ('map-idea-collection',
      ProjectBlueprint(
@@ -64,6 +67,7 @@ blueprints = [
          ],
          image='images/map-idea-collection.svg',
          settings_model=('a4maps', 'AreaSettings'),
+         type='MIC',
      )),
     ('participatory-budgeting',
      ProjectBlueprint(
@@ -78,6 +82,7 @@ blueprints = [
          ],
          image='images/participatory-budgeting-1.svg',
          settings_model=('a4maps', 'AreaSettings'),
+         type='PB',
      )),
     ('participatory-budgeting-2-phases',
      ProjectBlueprint(
@@ -93,6 +98,7 @@ blueprints = [
          ],
          image='images/participatory-budgeting-2.svg',
          settings_model=('a4maps', 'AreaSettings'),
+         type='PB2',
      )),
     ('participatory-budgeting-3-phases',
      ProjectBlueprint(
@@ -111,6 +117,7 @@ blueprints = [
          # The icon has to be updated:
          image='images/participatory-budgeting-3.svg',
          settings_model=('a4maps', 'AreaSettings'),
+         type='PB3',
      )),
     ('kiezkasse',
      ProjectBlueprint(
@@ -126,6 +133,7 @@ blueprints = [
          ],
          image='images/kiezkasse.svg',
          settings_model=('a4maps', 'AreaSettings'),
+         type='KK',
      )),
     ('prioritization',
      ProjectBlueprint(
@@ -139,6 +147,7 @@ blueprints = [
          ],
          image='images/priorization.svg',
          settings_model=None,
+         type='TP',
      )),
     ('map-topic-prioritization',
      ProjectBlueprint(
@@ -153,6 +162,7 @@ blueprints = [
          ],
          image='images/place-priotization.svg',
          settings_model=('a4maps', 'AreaSettings'),
+         type='MTP',
      )),
     ('text-review',
      ProjectBlueprint(
@@ -166,6 +176,7 @@ blueprints = [
          ],
          image='images/text-review.svg',
          settings_model=None,
+         type='TR',
      )),
     ('poll',
      ProjectBlueprint(
@@ -179,6 +190,7 @@ blueprints = [
          ],
          image='images/poll.svg',
          settings_model=None,
+         type='PO',
      )),
     ('interactive-event',
      ProjectBlueprint(
@@ -193,5 +205,6 @@ blueprints = [
          ],
          image='images/interactive-event.svg',
          settings_model=None,
+         type='IE',
      )),
 ]

--- a/meinberlin/apps/dashboard/views.py
+++ b/meinberlin/apps/dashboard/views.py
@@ -65,6 +65,7 @@ class ModuleCreateView(ProjectMixin,
             weight=weight,
             project=project,
             is_draft=True,
+            blueprint_type=self.blueprint.type,
         )
         module.save()
         signals.module_created.send(sender=None,

--- a/meinberlin/apps/extprojects/views.py
+++ b/meinberlin/apps/extprojects/views.py
@@ -53,6 +53,7 @@ class ExternalProjectCreateView(ProjectCreateView):
         ],
         image='',
         settings_model=None,
+        type='EP',
     )
 
 

--- a/meinberlin/apps/projectcontainers/views.py
+++ b/meinberlin/apps/projectcontainers/views.py
@@ -29,6 +29,7 @@ class ContainerCreateView(ProjectCreateView):
         content=[],
         image='',
         settings_model=None,
+        type='PC',
     )
 
 

--- a/meinberlin/apps/projects/migrations/0003_determine_and_add_blueprint_types_to_modules.py
+++ b/meinberlin/apps/projects/migrations/0003_determine_and_add_blueprint_types_to_modules.py
@@ -1,0 +1,61 @@
+from django.conf import settings
+from django.db import migrations
+
+from adhocracy4.dashboard.blueprints import get_blueprints
+from meinberlin.apps.bplan.views import BplanProjectCreateView
+from meinberlin.apps.extprojects.views import ExternalProjectCreateView
+from meinberlin.apps.projectcontainers.views import ContainerCreateView
+
+
+def determine_and_add_blueprint_types_to_modules(apps, schema_editor):
+    """Determine the blueprint type of existing modules by their phase set
+    and add accordingly.
+
+    Run this migration after types have been added to blueprints and
+    'A4_BLUEPRINT_TYPES have been added to settings.'
+    """
+    if hasattr(settings, 'A4_BLUEPRINT_TYPES'):
+        blueprints = [blueprint[1] for blueprint in get_blueprints()]
+        blueprints.append(BplanProjectCreateView.blueprint)
+        blueprints.append(ExternalProjectCreateView.blueprint)
+        blueprints.append(ContainerCreateView.blueprint)
+
+        # create dictionary with concatenated phase identifiers as keys
+        # and type as values
+        phase_identifiers_to_blueprint_type = {
+            '-'.join([phase.identifier for phase in blueprint.content]):
+                blueprint.type
+            for blueprint in blueprints
+        }
+
+        Module = apps.get_model('a4modules', 'Module')
+        for module in Module.objects.all():
+            phase_identifiers_str = \
+                '-'.join([phase.type for phase in module.phase_set.all()])
+            if phase_identifiers_str in phase_identifiers_to_blueprint_type \
+               and not module.blueprint_type:
+                module.blueprint_type = \
+                    phase_identifiers_to_blueprint_type[phase_identifiers_str]
+                module.save()
+
+
+def remove_blueprint_types(apps, schema_editor):
+    Module = apps.get_model('a4modules', 'Module')
+    for module in Module.objects.all():
+        module.blueprint_type = ''
+        module.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('meinberlin_projects', '0002_custom_project_types'),
+        ('a4modules', '0006_module_blueprint_type'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            determine_and_add_blueprint_types_to_modules,
+            remove_blueprint_types
+        ),
+    ]

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -536,6 +536,25 @@ A4_PROJECT_TOPICS = (
     ('TRA', _('Traffic'))
 )
 
+A4_BLUEPRINT_TYPES = [
+    ('BS', 'brainstorming'),
+    ('MBS', 'map brainstorming'),
+    ('IC', 'idea collection'),
+    ('MIC', 'map idea collection'),
+    ('PB', 'participatory budgeting (1 phase)'),
+    ('PB2', 'participatory budgeting (2 phase)'),
+    ('PB3', 'participatory budgeting (3 phase)'),
+    ('KK', 'kiezkasse'),
+    ('TP', 'topic prioritization'),
+    ('MTP', 'map topic prioritization'),
+    ('TR', 'text review'),
+    ('PO', 'poll'),
+    ('IE', 'interactive event'),
+    ('EP', 'external project'),
+    ('BP', 'bebauungsplan'),
+    ('PC', 'project container'),
+]
+
 A4_MAP_ATTRIBUTION = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 A4_MAP_BOUNDING_BOX = ([[52.3517, 13.8229], [52.6839, 12.9543]])
 

--- a/tests/dashboard/test_dashboard_views_module_create.py
+++ b/tests/dashboard/test_dashboard_views_module_create.py
@@ -1,0 +1,37 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from adhocracy4.modules.models import Module
+
+
+@pytest.mark.django_db
+def test_module_create(client, project, user):
+    organisation = project.organisation
+    organisation.initiators.add(user)
+
+    module_create_url = reverse(
+        'a4dashboard:module-create',
+        kwargs={
+            'project_slug': project.slug,
+            'blueprint_slug': 'idea-collection'
+        }
+    )
+
+    client.login(username=user, password='password')
+    response = client.post(module_create_url)
+    assert response.status_code == status.HTTP_302_FOUND
+    assert Module.objects.all().count() == 1
+    module = Module.objects.first()
+    assert response.url == reverse(
+        'a4dashboard:dashboard-module_basic-edit',
+        kwargs={'module_slug': module.slug}
+    )
+    assert module.project == project
+    assert module.weight == 1
+    assert module.blueprint_type == 'IC'
+
+    client.post(module_create_url)
+    assert Module.objects.all().count() == 2
+    module = Module.objects.last()
+    assert module.weight == 2


### PR DESCRIPTION
Also see https://github.com/liqd/adhocracy4/pull/1207, which should be merged first. This PR is not really dependent on it, but without the A4 changes, new external projects/project containers/bplans wont get a type when saving.