### PR TITLE
ci: remove frontend coverage app

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
       - name: Setup Postgres
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -85,11 +85,6 @@ jobs:
         run: |
           npm test
           npm run lint
-      - name: Frontend Coverage
-        uses: artiomtr/jest-coverage-report-action@v2.0-rc.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'pull_request'
       - name: Deploy
         if: github.ref == 'refs/heads/main'
         env:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help:
 
 .PHONY: install
 install:
-	npm install --no-save --legacy-peer-deps
+	npm install --no-save
 	npm run build
 	if [ ! -f $(VIRTUAL_ENV)/bin/python3 ]; then python3 -m venv $(VIRTUAL_ENV); fi
 	$(VIRTUAL_ENV)/bin/python3 -m pip install --upgrade -r requirements/dev.txt
@@ -169,7 +169,7 @@ compilemessages:
 .PHONY: release
 release: export DJANGO_SETTINGS_MODULE ?= meinberlin.config.settings.build
 release:
-	npm install --silent --legacy-peer-deps
+	npm install --silent
 	npm run build:prod
 	$(VIRTUAL_ENV)/bin/python3 -m pip install -r requirements.txt -q
 	$(VIRTUAL_ENV)/bin/python3 manage.py compilemessages -v0


### PR DESCRIPTION
* remove the way to slow frontend coverage report
* switch to node 18
* remove the `legacy-peer-deps` workaround