### PR TITLE
[6421] apps/budgeting: only sent moderated email to contact saved in form, n…

### DIFF
--- a/meinberlin/apps/ideas/views.py
+++ b/meinberlin/apps/ideas/views.py
@@ -197,9 +197,10 @@ class AbstractIdeaModerateView(
             statement.save()
             moderateable.moderator_statement = statement
             moderateable.save()
-            NotifyCreatorOnModeratorFeedback.send(self.object)
             if hasattr(self.object, 'contact_email'):
                 NotifyContactOnModeratorFeedback.send(self.object)
+            else:
+                NotifyCreatorOnModeratorFeedback.send(self.object)
         return objects
 
     def get_instance(self, name):

--- a/meinberlin/apps/notifications/emails.py
+++ b/meinberlin/apps/notifications/emails.py
@@ -15,14 +15,6 @@ def _exclude_actor(receivers, actor):
     return [receiver for receiver in receivers if not receiver == actor]
 
 
-def _exclude_creator(receivers, creator):
-    if not creator:
-        return receivers
-
-    return [receiver for receiver in receivers
-            if not receiver == creator.email]
-
-
 def _exclude_moderators(receivers, action):
     if hasattr(action, 'project'):
         moderator_ids = action.project.moderators.values_list('id', flat=True)
@@ -77,7 +69,6 @@ class NotifyContactOnModeratorFeedback(Email):
 
     def get_receivers(self):
         receivers = [self.object.contact_email]
-        receivers = _exclude_creator(receivers, self.object.creator)
         return receivers
 
     def get_context(self):

--- a/tests/budgeting/test_views_integration.py
+++ b/tests/budgeting/test_views_integration.py
@@ -180,13 +180,10 @@ def test_moderate_view(client, phase_factory, proposal_factory, user,
         response = client.post(url, data)
         assert redirect_target(response) == 'proposal-detail'
 
-        # was the NotifyCreatorOnModeratorFeedback and
-        # NotifyContactOnModeratorFeedback sent?
-        assert len(mail.outbox) == 2
-        assert mail.outbox[0].to == [item.creator.email]
-        assert mail.outbox[1].to == [item.contact_email]
+        # was the NotifyContactOnModeratorFeedback sent?
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [item.contact_email]
         assert mail.outbox[0].subject.startswith('Rückmeldung')
-        assert mail.outbox[1].subject.startswith('Rückmeldung')
 
 
 @pytest.mark.django_db
@@ -217,10 +214,10 @@ def test_moderate_view_same_creator_contact(
         response = client.post(url, data)
         assert redirect_target(response) == 'proposal-detail'
 
-        # was only the NotifyCreatorOnModeratorFeedback and
-        # not NotifyContactOnModeratorFeedback sent?
+        # was the NotifyContactOnModeratorFeedback sent,
+        # even though the contact email is the same as the creator's?
         assert len(mail.outbox) == 1
-        assert mail.outbox[0].to == [item.creator.email]
+        assert mail.outbox[0].to == [item.contact_email]
         assert mail.outbox[0].subject.startswith('Rückmeldung')
 
 


### PR DESCRIPTION
…ot to creator

@CarolingerSeilchenspringer and me decided to always sent the notification to the contact from the proposal, because we don't need to worry that the creator has disabled notifications then.