### PR TITLE
Kl 2022 09 dashboard token perms

### DIFF
--- a/meinberlin/apps/budgeting/dashboard.py
+++ b/meinberlin/apps/budgeting/dashboard.py
@@ -28,7 +28,7 @@ class ExportBudgetingComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/export/budgeting/$',
-             views.ProposalDashboardExportView.as_view(),
+             views.ProposalDashboardExportView.as_view(component=self),
              'budgeting-export-module'),
             (r'^modules/(?P<module_slug>[-\w_]+)/export/budgeting/ideas/$',
              exports.ProposalExportView.as_view(),

--- a/meinberlin/apps/documents/dashboard.py
+++ b/meinberlin/apps/documents/dashboard.py
@@ -58,7 +58,7 @@ class ExportDocumentComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/export/document/$',
-             views.DocumentDashboardExportView.as_view(),
+             views.DocumentDashboardExportView.as_view(component=self),
              'document-export-module'),
             (r'^modules/(?P<module_slug>[-\w_]+)/export/document/comments/$',
              exports.DocumentExportView.as_view(),

--- a/meinberlin/apps/ideas/dashboard.py
+++ b/meinberlin/apps/ideas/dashboard.py
@@ -28,7 +28,7 @@ class ExportIdeaComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/export/idea/$',
-             views.IdeaDashboardExportView.as_view(),
+             views.IdeaDashboardExportView.as_view(component=self),
              'idea-export-module'),
             (r'^modules/(?P<module_slug>[-\w_]+)/export/idea/ideas/$',
              exports.IdeaExportView.as_view(),

--- a/meinberlin/apps/kiezkasse/dashboard.py
+++ b/meinberlin/apps/kiezkasse/dashboard.py
@@ -28,7 +28,7 @@ class ExportKiezkasseComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/export/kiezkasse/$',
-             views.ProposalDashboardExportView.as_view(),
+             views.ProposalDashboardExportView.as_view(component=self),
              'kiezkasse-export-module'),
             (r'^modules/(?P<module_slug>[-\w_]+)/export/kiezkasse/ideas/$',
              exports.ProposalExportView.as_view(),

--- a/meinberlin/apps/mapideas/dashboard.py
+++ b/meinberlin/apps/mapideas/dashboard.py
@@ -28,7 +28,7 @@ class ExportMapIdeaComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/export/mapidea/$',
-             views.MapIdeaDashboardExportView.as_view(),
+             views.MapIdeaDashboardExportView.as_view(component=self),
              'mapidea-export-module'),
             (r'^modules/(?P<module_slug>[-\w_]+)/export/mapidea/ideas/$',
              exports.MapIdeaExportView.as_view(),

--- a/meinberlin/apps/maptopicprio/dashboard.py
+++ b/meinberlin/apps/maptopicprio/dashboard.py
@@ -72,7 +72,7 @@ class ExportMapTopicComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/export/maptopic/$',
-             views.MapTopicDashboardExportView.as_view(),
+             views.MapTopicDashboardExportView.as_view(component=self),
              'maptopic-export-module'),
             (r'^modules/(?P<module_slug>[-\w_]+)/export/maptopic/maptopics/$',
              exports.MapTopicExportView.as_view(),

--- a/meinberlin/apps/topicprio/dashboard.py
+++ b/meinberlin/apps/topicprio/dashboard.py
@@ -67,7 +67,7 @@ class ExportTopicComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/export/topic/$',
-             views.TopicDashboardExportView.as_view(),
+             views.TopicDashboardExportView.as_view(component=self),
              'topic-export-module'),
             (r'^modules/(?P<module_slug>[-\w_]+)/export/topic/maptopics/$',
              exports.TopicExportView.as_view(),

--- a/meinberlin/apps/votes/dashboard.py
+++ b/meinberlin/apps/votes/dashboard.py
@@ -26,7 +26,7 @@ class VotesComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/voting/$',
-             views.VotingDashboardView.as_view(),
+             views.VotingDashboardView.as_view(component=self),
              'voting-tokens'),
             (r'^modules/(?P<module_slug>[-\w_]+)/voting/export-token/$',
              views.TokenExportView.as_view(),
@@ -53,7 +53,7 @@ class GenerateVotesComponent(DashboardComponent):
     def get_urls(self):
         return [
             (r'^modules/(?P<module_slug>[-\w_]+)/voting-codes/$',
-             views.VotingGenerationDashboardView.as_view(),
+             views.VotingGenerationDashboardView.as_view(component=self),
              'voting-token-generation'),
         ]
 

--- a/meinberlin/apps/votes/dashboard.py
+++ b/meinberlin/apps/votes/dashboard.py
@@ -38,6 +38,7 @@ class GenerateVotesComponent(DashboardComponent):
     identifier = 'voting_token_generation'
     weight = 49
     label = _('Generate voting codes')
+    for_superuser_only = True
 
     def is_effective(self, module):
         return module.blueprint_type == 'PB3'

--- a/meinberlin/apps/votes/views.py
+++ b/meinberlin/apps/votes/views.py
@@ -111,7 +111,7 @@ class VotingGenerationDashboardView(
           'You are allowed to generate {} more.'),
         _('Only {} tokens are allowed per module. '
           'You are allowed to generate {} more.'))
-    permission_required = 'a4projects.change_project'
+    permission_required = 'is_superuser'
     template_name = 'meinberlin_votes/voting_code_dashboard.html'
 
     def _get_number_of_tokens(self):

--- a/meinberlin/templates/a4dashboard/includes/nav_modules_item.html
+++ b/meinberlin/templates/a4dashboard/includes/nav_modules_item.html
@@ -23,6 +23,7 @@
         <div class="dashboard-nav__menu-content">
             <ul>
             {% for item in module_menu.menu %}
+                {% if not item.for_superuser_only or request.user.is_superuser %}
                 <li class="dashboard-nav__page">
                     <a href="{{ item.url }}"
                        class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">
@@ -32,6 +33,7 @@
                         {% endif %}
                     </a>
                 </li>
+                {% endif %}
             {% endfor %}
             </ul>
         </div>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@maplibre/maplibre-gl-leaflet": "0.0.17",
     "acorn": "8.8.0",
-    "adhocracy4": "liqd/adhocracy4#08c980754345f97c01712723bedad0bde53d6034",
+    "adhocracy4": "liqd/adhocracy4#42a36ff81053939b7ac5865286f9b9d18a60d094",
     "autoprefixer": "10.4.12",
     "babel-loader": "8.2.5",
     "bootstrap": "5.2.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@08c980754345f97c01712723bedad0bde53d6034#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@42a36ff81053939b7ac5865286f9b9d18a60d094#egg=adhocracy4
 
 # Additional requirements
 bcrypt==4.0.0


### PR DESCRIPTION
I am unhappy with how I did it and with the naming, but I couldn't think of a better (and not also overly complex) way. It should work better with the permissions from the view somehow, but as we don't have the user in the dashboard components, and I didn't want to add that complexity, I did it like that. :woman_shrugging: And I thought, if we ever need more and other perms in the dashboard, we can still improve from here.

Depending on https://github.com/liqd/adhocracy4/pull/1216

Right, and the two first commits are from https://github.com/liqd/a4-meinberlin/pull/4477

So, these both need to be merged first and this cleaned up then.