### PR TITLE
apps/votes: add more info to task

### DIFF
--- a/meinberlin/apps/votes/tasks.py
+++ b/meinberlin/apps/votes/tasks.py
@@ -6,20 +6,34 @@ from meinberlin.apps.votes.models import VotingToken
 BATCH_SIZE = 100000
 
 
-def generate_voting_tokens(module_id, number_of_tokens):
+def generate_voting_tokens(module_id, number_of_tokens, existing_tokens):
+    module = Module.objects.get(pk=module_id)
+    module_name = module.name
+    project_id = module.project.id
+    project_name = module.project.name
+
     number_to_generate = number_of_tokens
     while number_to_generate > 0:
         if number_to_generate >= BATCH_SIZE:
-            generate_voting_tokens_batch(module_id, BATCH_SIZE)
+            generate_voting_tokens_batch(
+                module_id, BATCH_SIZE, number_of_tokens, module_name,
+                project_id, project_name, existing_tokens
+
+            )
             number_to_generate = number_to_generate - BATCH_SIZE
         else:
-            generate_voting_tokens_batch(module_id, number_to_generate)
+            generate_voting_tokens_batch(
+                module_id, number_to_generate, number_of_tokens, module_name,
+                project_id, project_name, existing_tokens
+            )
             number_to_generate = 0
 
 
 @background(schedule=1)
-def generate_voting_tokens_batch(module_id, number_of_tokens):
+def generate_voting_tokens_batch(
+        module_id, batch_size, number_of_tokens, module_name, project_id,
+        project_name, existing_tokens):
     module = Module.objects.get(pk=module_id)
     VotingToken.objects.bulk_create(
-        [VotingToken(module=module) for i in range(number_of_tokens)]
+        [VotingToken(module=module) for i in range(batch_size)]
     )

--- a/meinberlin/apps/votes/views.py
+++ b/meinberlin/apps/votes/views.py
@@ -151,7 +151,8 @@ class TokenGenerationDashboardView(
             )
         else:
             # make tasks to generate the tokens
-            generate_voting_tokens(self.module.pk, number_of_tokens)
+            generate_voting_tokens(self.module.pk, number_of_tokens,
+                                   existing_tokens)
 
             messages.success(
                 self.request,


### PR DESCRIPTION
We did add the management command to notify us of failed tasks. https://github.com/liqd/a4-meinberlin/pull/1408 And we did add the MAX_ATTEMPTS in the server settings. I think we need to keep the MAX_ATTEMPTS at 1 because we don't want to have emails fail multiple times.
Unluckily there is no way of having different MAX_ATTEMPTS for different tasks (https://github.com/arteria/django-background-tasks/issues/256) and the package seems unmaintained by now (https://github.com/arteria/django-background-tasks/issues/267). So, I would say we leave it like that for now.