### PR TITLE
Ks 2022 09 budgeting search filter

### DIFF
--- a/meinberlin/apps/budgeting/api.py
+++ b/meinberlin/apps/budgeting/api.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins
 from rest_framework import viewsets
+from rest_framework.filters import SearchFilter
 from rest_framework.pagination import PageNumberPagination
 
 from adhocracy4.api.mixins import ModuleMixin
@@ -112,12 +113,14 @@ class ProposalViewSet(ModuleMixin,
     permission_classes = (ViewSetRulesPermission,)
     filter_backends = (DjangoFilterBackend,
                        OrderingFilterWithDailyRandom,
-                       IdeaCategoryFilterBackend,)
+                       IdeaCategoryFilterBackend,
+                       SearchFilter,)
     filter_fields = ('is_archived', 'category',)
     ordering_fields = ('created',
                        'comment_count',
                        'positive_rating_count',
                        'daily_random',)
+    search_fields = ('name', 'ref_number')
 
     def get_permission_object(self):
         return self.module
@@ -127,5 +130,6 @@ class ProposalViewSet(ModuleMixin,
             .filter(module=self.module) \
             .annotate_comment_count() \
             .annotate_positive_rating_count() \
+            .annotate_reference_number() \
             .order_by('-created')
         return proposals


### PR DESCRIPTION
I am not very happy with all of the cases in the annotation, but I think there is no way to use a python function in an annotation, so this is the solution I came up with.. happy for any improvements!

@khamui I did not (yet) add the search filter to the other filters in the api as there is no real information, right? 

The search works with url/?search=my+search+term, so spaces work with '+'. You can just look at the filtered list in the browser, eg. http://localhost:8003/api/modules/$moduleId/proposals/?search=something+here should work.