### PR TITLE
apps/item detail templates: use label/badges from model property and …

### DIFF
--- a/meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx
+++ b/meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx
@@ -7,7 +7,6 @@ import { ListItemStats } from './ListItemStats'
 
 const updatedOnStr = django.gettext('updated on')
 const createdOnStr = django.gettext('created on')
-const BADGES_LIMIT = 3
 
 export const BudgetingProposalListItem = (props) => {
   const { proposal, permissions, tokenvoteApiUrl } = props
@@ -22,33 +21,6 @@ export const BudgetingProposalListItem = (props) => {
         safeLocale
       )}`
 
-  const normalizeBadgesData = () => {
-    const tmpList = []
-    if (proposal.moderator_feedback) {
-      tmpList.push({ type: 'modFeedback', value: proposal.moderator_feedback })
-    }
-    if (proposal.budget) {
-      tmpList.push({ type: 'budget', value: proposal.budget })
-    }
-    if (proposal.point_label) {
-      tmpList.push({ type: 'pointLabel', value: proposal.point_label })
-    }
-    if (proposal.category) {
-      tmpList.push({ type: 'category', value: proposal.category })
-    }
-    if (proposal.labels && proposal.labels.length !== 0) {
-      for (let i = 0; i < proposal.labels.length; i++) {
-        tmpList.push({ type: 'label', value: proposal.labels[i] })
-      }
-    }
-    return tmpList
-  }
-
-  const badges = normalizeBadgesData()
-  const numOfMoreBadges = badges.length > BADGES_LIMIT
-    ? badges.length - BADGES_LIMIT
-    : -1
-
   return (
     <li className="list-item">
       <ListItemStats
@@ -61,8 +33,8 @@ export const BudgetingProposalListItem = (props) => {
         <a href={proposal.url}>{proposal.name}</a>
       </h2>
       <ListItemBadges
-        badges={badges.slice(0, BADGES_LIMIT)}
-        numOfMoreBadges={numOfMoreBadges}
+        badges={proposal.item_badges_for_list}
+        numOfMoreBadges={proposal.additional_item_badges_for_list_count}
         proposalUrl={proposal.url}
       />
       <div className="list-item__vote">

--- a/meinberlin/apps/budgeting/assets/ListItemBadges.jsx
+++ b/meinberlin/apps/budgeting/assets/ListItemBadges.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { intComma } from './helpers'
 import { SpacedSpan } from './SpacedSpan'
 import django from 'django'
 
@@ -12,31 +11,16 @@ export const ListItemBadges = props => {
   // on if it is moderator_feedback or on of the others (category, label etc.)
   const getClass = (badge) => {
     const labelClass = 'label label--big'
-    if (badge.type !== 'modFeedback') {
+    if (badge[0] !== 'moderator_feedback') {
       return labelClass
     }
-    const modTypeClass = `label--${badge.value[0].toLowerCase()}`
+    const modTypeClass = `label--${badge[2].toLowerCase()}`
     return `${labelClass} ${modTypeClass}`
-  }
-
-  // returning the value.name in case of category or label
-  // in case of budget format as intComma
-  // in case of modFeedback second item in array
-  const getBadgeText = (badge) => {
-    if (badge.type === 'pointLabel') {
-      return badge.value
-    } else if (badge.type === 'budget') {
-      return intComma(badge.value) + '€'
-    } else if (badge.type === 'modFeedback') {
-      return badge.value[1]
-    } else if (badge.type === 'category' || badge.type === 'label') {
-      return badge.value.name
-    }
   }
 
   // only return icon for pointLabels
   const hasPointLabelIcon = (type) => {
-    if (type !== 'pointLabel') {
+    if (type !== 'point_label') {
       return
     }
     return <i className="fas fa-map-marker-alt" aria-hidden="true" />
@@ -47,15 +31,15 @@ export const ListItemBadges = props => {
       {props.badges.map((badge, idx) => {
         return (
           <SpacedSpan
-            key={`badge_${badge.type}_${idx}`}
+            key={`badge_${idx}`}
             className={getClass(badge)}
           >
-            {hasPointLabelIcon(badge.type)}
-            {getBadgeText(badge)}
+            {hasPointLabelIcon(badge[0])}
+            {badge[1]}
           </SpacedSpan>
         )
       })}
-      {props.numOfMoreBadges >= 0 &&
+      {props.numOfMoreBadges > 0 &&
         <SpacedSpan className="label__link label--big">
           <a
             href={props.proposalUrl}

--- a/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalList.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalList.jest.jsx
@@ -34,8 +34,6 @@ test('Budgeting Proposal List with one list item', async () => {
   // sample data (one proposal item)
   const mockedResults = [
     {
-      budget: 0,
-      category: { id: 3, name: 'candalf' },
       comment_count: 0,
       created: '2021-11-11T15:36:57.941072+01:00',
       creator: 'admin',
@@ -45,7 +43,10 @@ test('Budgeting Proposal List with one list item', async () => {
       pk: 7,
       positive_rating_count: 0,
       url: '/budgeting/2021-00007/',
-      moderator_feedback: ['CONSIDERATION', 'wird ueberprueft']
+      additional_item_badges_for_list_count: 1,
+      item_badges_for_list: [
+        ['moderator_feedback', 'wird ueberprueft', 'CONSIDERATION'],
+        ['budget', '20€'], ['category', 'candalf']]
     }
   ]
 

--- a/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalListItem.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalListItem.jest.jsx
@@ -14,7 +14,10 @@ test('render list item with vote button', () => {
     url: 'www',
     creator: 'creator',
     created: '2021-11-11T15:37:19.490201+01:00',
-    moderator_feedback: ['CONSIDERATION', 'wird ueberprueft'],
+    additional_item_badges_for_list_count: 0,
+    item_badges_for_list: [
+      ['moderator_feedback', 'wird ueberprueft', 'CONSIDERATION'],
+      ['budget', '20€'], ['category', 'candalf']],
     reference_number: '2021-12345'
   }
   render(<BudgetingProposalListItem proposal={proposal} permissions={permissions} />)
@@ -32,7 +35,10 @@ test('render list item with stats', () => {
     url: 'www',
     creator: 'creator',
     created: '2021-11-11T15:37:19.490201+01:00',
-    moderator_feedback: ['CONSIDERATION', 'wird ueberprueft'],
+    additional_item_badges_for_list_count: 0,
+    item_badges_for_list: [
+      ['moderator_feedback', 'wird ueberprueft', 'CONSIDERATION'],
+      ['budget', '20€'], ['category', 'candalf']],
     reference_number: '2021-12345'
   }
   render(

--- a/meinberlin/apps/budgeting/assets/__tests__/ListItemBadges.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/ListItemBadges.jest.jsx
@@ -3,59 +3,29 @@ import { render, screen } from '@testing-library/react'
 import { ListItemBadges } from '../ListItemBadges'
 
 // testing data:
-const categoryBadge = [{
-  type: 'category',
-  value: { id: 0, name: 'category1' }
-}]
-
-const labelsBadges = [
-  {
-    type: 'label',
-    value: { id: 0, name: 'label1' }
-  },
-  {
-    type: 'label',
-    value: { id: 1, name: 'label2' }
-  },
-  {
-    type: 'label',
-    value: { id: 2, name: 'label3' }
-  }
+const someBadges = [
+  ['category', 'category1'],
+  ['label', 'label1'],
+  ['label', 'label2']
 ]
 
-const pointLabelBadge = [{
-  type: 'pointLabel',
-  value: 'labelwithicon'
-}]
+const pointLabelBadge = [
+  ['point_label', 'labelwithicon']
+]
 
-const budgetBadge = [{
-  type: 'budget',
-  value: '20000'
-}]
-
-const modFeedbackBadge = [{
-  type: 'modFeedback',
-  value: ['CONSIDERATION', 'Under consideration']
-}]
-
-test('displaying category badge', () => {
-  render(
-    <ListItemBadges
-      badges={categoryBadge}
-    />
-  )
-  expect(screen.getByText('category1')).toBeTruthy()
-})
+const modFeedbackBadge = [
+  ['moderator_feedback', 'Under consideration', 'CONSIDERATION']
+]
 
 test('displaying 3 labels', () => {
   render(
     <ListItemBadges
-      badges={labelsBadges}
+      badges={someBadges}
     />
   )
+  expect(screen.getByText('category1')).toBeTruthy()
   expect(screen.getByText('label1')).toBeTruthy()
   expect(screen.getByText('label2')).toBeTruthy()
-  expect(screen.getByText('label3')).toBeTruthy()
 })
 
 test('displaying point label badge', () => {
@@ -65,17 +35,6 @@ test('displaying point label badge', () => {
     />
   )
   expect(screen.getByText('labelwithicon')).toBeTruthy()
-})
-
-test('displaying budget badge with thousand separator', () => {
-  render(
-    <ListItemBadges
-      badges={budgetBadge}
-    />
-  )
-  expect(
-    screen.queryByText('20,000€') || screen.queryByText('20.000€')
-  ).toBeTruthy()
 })
 
 test('displaying moderator feedback badge', () => {
@@ -90,7 +49,7 @@ test('displaying moderator feedback badge', () => {
 test('displaying first 3 badges and add more link', () => {
   render(
     <ListItemBadges
-      badges={[...categoryBadge, ...labelsBadges]}
+      badges={someBadges}
       numOfMoreBadges={1}
     />
   )

--- a/meinberlin/apps/budgeting/assets/helpers.js
+++ b/meinberlin/apps/budgeting/assets/helpers.js
@@ -10,14 +10,6 @@ export const toLocaleDate = (isodate, locale = 'de-DE') => {
   return new Intl.DateTimeFormat(locale, formatStyle).format(date)
 }
 
-// intComma returns a number separated by
-// a comma or period depending on the locale
-// input: 20000
-// output: 20.000 or 20,000
-export const intComma = (number) => {
-  return Number(number).toLocaleString()
-}
-
 // wrapSpaces returns the given value
 // wrapped by a space before and after
 // input: "0"

--- a/meinberlin/apps/budgeting/serializers.py
+++ b/meinberlin/apps/budgeting/serializers.py
@@ -1,45 +1,17 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
-from adhocracy4.categories.models import Category
-from adhocracy4.labels.models import Label
 from meinberlin.apps.votes.models import TokenVote
 from meinberlin.apps.votes.models import VotingToken
 
 from .models import Proposal
 
 
-class CategoryField(serializers.Field):
-
-    def to_internal_value(self, category):
-        if category:
-            return Category.objects.get(pk=category)
-        else:
-            return None
-
-    def to_representation(self, category):
-        return {'id': category.pk, 'name': category.name}
-
-
-class LabelListingField(serializers.StringRelatedField):
-
-    def to_internal_value(self, label):
-        return Label.objects.get(pk=label)
-
-    def to_representation(self, label):
-        return {'id': label.pk, 'name': label.name}
-
-
 class ProposalSerializer(serializers.ModelSerializer):
 
-    budget = serializers.SerializerMethodField()
-    category = CategoryField()
     comment_count = serializers.SerializerMethodField()
     creator = serializers.SerializerMethodField()
-    labels = LabelListingField(many=True)
-    moderator_feedback = serializers.SerializerMethodField()
     negative_rating_count = serializers.SerializerMethodField()
-    point_label = serializers.SerializerMethodField()
     positive_rating_count = serializers.SerializerMethodField()
     session_token_voted = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
@@ -48,20 +20,18 @@ class ProposalSerializer(serializers.ModelSerializer):
     class Meta:
         model = Proposal
         fields = (
-            'budget', 'category', 'comment_count', 'created',
-            'creator', 'is_archived', 'labels', 'moderator_feedback',
+            'additional_item_badges_for_list_count', 'comment_count',
+            'created', 'creator', 'is_archived', 'item_badges_for_list',
             'modified', 'name', 'negative_rating_count', 'pk',
-            'point_label', 'positive_rating_count',
-            'reference_number', 'session_token_voted', 'url',
-            'vote_allowed'
+            'positive_rating_count', 'reference_number',
+            'session_token_voted', 'url', 'vote_allowed'
         )
         read_only_fields = (
-            'budget', 'category', 'comment_count', 'created',
-            'creator', 'is_archived', 'labels', 'moderator_feedback',
+            'additional_item_badges_for_list_count', 'comment_count',
+            'created', 'creator', 'is_archived', 'item_badges_for_list',
             'modified', 'name', 'negative_rating_count', 'pk',
-            'point_label', 'positive_rating_count',
-            'reference_number', 'session_token_voted', 'url',
-            'vote_allowed'
+            'positive_rating_count', 'reference_number',
+            'session_token_voted', 'url', 'vote_allowed'
         )
 
     def get_creator(self, proposal):
@@ -87,26 +57,6 @@ class ProposalSerializer(serializers.ModelSerializer):
 
     def get_url(self, proposal):
         return proposal.get_absolute_url()
-
-    def get_moderator_feedback(self, proposal):
-        if hasattr(proposal, 'moderator_feedback') and\
-                proposal.get_moderator_feedback_display():
-            return (proposal.moderator_feedback,
-                    proposal.get_moderator_feedback_display())
-        else:
-            return None
-
-    def get_point_label(self, proposal):
-        if hasattr(proposal, 'point_label') and proposal.point_label != '':
-            return (proposal.point_label)
-        else:
-            return None
-
-    def get_budget(self, proposal):
-        if hasattr(proposal, 'budget') and proposal.budget != 0:
-            return proposal.budget
-        else:
-            return None
 
     def get_session_token_voted(self, proposal):
         """Serialize if proposal has been voted.

--- a/meinberlin/apps/budgeting/serializers.py
+++ b/meinberlin/apps/budgeting/serializers.py
@@ -32,33 +32,37 @@ class LabelListingField(serializers.StringRelatedField):
 
 class ProposalSerializer(serializers.ModelSerializer):
 
-    creator = serializers.SerializerMethodField()
-    comment_count = serializers.SerializerMethodField()
-    positive_rating_count = serializers.SerializerMethodField()
-    negative_rating_count = serializers.SerializerMethodField()
-    category = CategoryField()
-    labels = LabelListingField(many=True)
-    url = serializers.SerializerMethodField()
-    moderator_feedback = serializers.SerializerMethodField()
-    session_token_voted = serializers.SerializerMethodField()
-    vote_allowed = serializers.SerializerMethodField()
     budget = serializers.SerializerMethodField()
+    category = CategoryField()
+    comment_count = serializers.SerializerMethodField()
+    creator = serializers.SerializerMethodField()
+    labels = LabelListingField(many=True)
+    moderator_feedback = serializers.SerializerMethodField()
+    negative_rating_count = serializers.SerializerMethodField()
     point_label = serializers.SerializerMethodField()
+    positive_rating_count = serializers.SerializerMethodField()
+    session_token_voted = serializers.SerializerMethodField()
+    url = serializers.SerializerMethodField()
+    vote_allowed = serializers.SerializerMethodField()
 
     class Meta:
         model = Proposal
-        fields = ('budget', 'category', 'comment_count', 'created', 'modified',
-                  'creator', 'is_archived', 'labels', 'name',
-                  'negative_rating_count', 'positive_rating_count', 'url',
-                  'pk', 'moderator_feedback', 'point_label',
-                  'reference_number', 'session_token_voted', 'vote_allowed')
-        read_only_fields = ('budget', 'category', 'comment_count', 'created',
-                            'modified', 'creator', 'is_archived', 'labels',
-                            'name', 'negative_rating_count',
-                            'positive_rating_count', 'url', 'pk',
-                            'moderator_feedback', 'point_label',
-                            'reference_number', 'session_token_voted',
-                            'vote_allowed')
+        fields = (
+            'budget', 'category', 'comment_count', 'created',
+            'creator', 'is_archived', 'labels', 'moderator_feedback',
+            'modified', 'name', 'negative_rating_count', 'pk',
+            'point_label', 'positive_rating_count',
+            'reference_number', 'session_token_voted', 'url',
+            'vote_allowed'
+        )
+        read_only_fields = (
+            'budget', 'category', 'comment_count', 'created',
+            'creator', 'is_archived', 'labels', 'moderator_feedback',
+            'modified', 'name', 'negative_rating_count', 'pk',
+            'point_label', 'positive_rating_count',
+            'reference_number', 'session_token_voted', 'url',
+            'vote_allowed'
+        )
 
     def get_creator(self, proposal):
         return proposal.creator.username

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
@@ -7,13 +7,6 @@
     {{ block.super }}
 {% endblock %}
 
-{% block additional_labels %}
-    {{ block.super }}
-    <span class="label label--big test">
-        {% if proposal.budget == 0 %}{% translate 'budget not specified' %}{% else %}{{ proposal.budget|intcomma }}€{% endif %}
-    </span>
-{% endblock %}
-
 {% block ratings %}
     {% if module.blueprint_type == 'PB3' and proposal|has_feature:"support" %}
         {% has_or_would_have_perm 'meinberlin_budgeting.support_proposal' request.user proposal as may_support_proposal %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_labels.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_labels.html
@@ -1,0 +1,12 @@
+{% load contrib_tags %}
+
+<div class="item-detail__labels">
+    {% for badge in object.item_badges  %}
+        <span class="label label--big {% if badge.0 == 'moderator_feedback' %}label--{{badge.2|classify|lower }}{% endif %}">
+            {% if badge.0 == 'point_label' %}
+                <i class="fas fa-map-marker-alt" aria-hidden="true"></i>
+            {% endif %}
+            {{ badge.1 }}
+        </span>
+    {% endfor %}
+</div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -21,22 +21,7 @@
         <div class="item-detail">
             <h1 class="item-detail__title">{{ object.name }}</h1>
 
-            <div class="item-detail__labels">
-                {% if object.moderator_feedback %}
-                    <span class="label label--big label--{{ object.moderator_feedback|classify|lower }}">
-                        {{ object.get_moderator_feedback_display }}
-                    </span>
-                {% endif %}
-                {% if object.category %}
-                    <div class="label label--big">{{ object.category }}</div>
-                {% endif %}
-                {% block additional_labels %}{% endblock %}
-                {% if object.labels %}
-                    {% for label in object.labels.all %}
-                        <div class="label label--big">{{ label.name }}</div>
-                    {% endfor %}
-                {% endif %}
-            </div>
+            {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
 
             <div class="item-detail__content">
                 <div class="item-detail__basic-content">

--- a/meinberlin/apps/ideas/models.py
+++ b/meinberlin/apps/ideas/models.py
@@ -68,7 +68,62 @@ class IdeaQuerySet(query.RateableQuerySet, query.CommentableQuerySet):
         )
 
 
-class AbstractIdea(module_models.Item, Moderateable):
+class ItemBadgesPropertyMixin():
+    """Use with idea items to display badges in list and detail view."""
+
+    @property
+    def item_badges(self):
+        """List all badges an idea item can have."""
+        labels = []
+        if hasattr(self, 'moderator_feedback') and self.moderator_feedback:
+            labels.append(
+                ['moderator_feedback',
+                 self.get_moderator_feedback_display(),
+                 self.moderator_feedback]
+            )
+        if hasattr(self, 'budget'):
+            if self.budget == 0:
+                labels.append(
+                    ['budget',
+                     _('budget not specified')]
+                )
+            else:
+                labels.append(
+                    ['budget',
+                     intcomma(self.budget) + '€']
+                )
+        if hasattr(self, 'point_label') and self.point_label:
+            labels.append(
+                ['point_label',
+                 self.point_label]
+            )
+        if hasattr(self, 'category') and self.category:
+            labels.append(
+                ['category',
+                 self.category]
+            )
+        if hasattr(self, 'labels') and self.labels:
+            for label in self.labels.all():
+                labels.append(
+                    ['label',
+                     label.name]
+                )
+        return labels
+
+    @property
+    def item_badges_for_list(self):
+        return self.item_badges[:BADGES_LIMIT]
+
+    @property
+    def additional_item_badges_for_list_count(self):
+        count = 0
+        if len(self.item_badges) > BADGES_LIMIT:
+            count = len(self.item_badges) - BADGES_LIMIT
+        return count
+
+
+class AbstractIdea(module_models.Item, Moderateable,
+                   ItemBadgesPropertyMixin):
     item_ptr = models.OneToOneField(to=module_models.Item,
                                     parent_link=True,
                                     related_name='%(app_label)s_%(class)s',
@@ -106,50 +161,6 @@ class AbstractIdea(module_models.Item, Moderateable):
             item_content_type=content_type,
             item_object_id=self.id
         ).first()
-
-    @property
-    def item_badges(self):
-        """List all badges an idea item can have."""
-        labels = []
-        if hasattr(self, 'moderator_feedback') and self.moderator_feedback:
-            labels.append(
-                ['moderator_feedback',
-                 self.get_moderator_feedback_display(),
-                 self.moderator_feedback]
-            )
-        if hasattr(self, 'budget') and self.budget > 0:
-            labels.append(
-                ['budget',
-                 intcomma(self.budget) + '€']
-            )
-        if hasattr(self, 'point_label') and self.point_label:
-            labels.append(
-                ['point_label',
-                 self.point_label]
-            )
-        if hasattr(self, 'category') and self.category:
-            labels.append(
-                ['category',
-                 self.category]
-            )
-        if hasattr(self, 'labels') and self.labels:
-            for label in self.labels.all():
-                labels.append(
-                    ['label',
-                     label.name]
-                )
-        return labels
-
-    @property
-    def item_badges_for_list(self):
-        return self.item_badges[:BADGES_LIMIT]
-
-    @property
-    def additional_item_badges_for_list_count(self):
-        count = 0
-        if len(self.item_badges) > BADGES_LIMIT:
-            count = len(self.item_badges) - BADGES_LIMIT
-        return count
 
     class Meta:
         abstract = True

--- a/meinberlin/apps/ideas/models.py
+++ b/meinberlin/apps/ideas/models.py
@@ -100,7 +100,7 @@ class ItemBadgesPropertyMixin():
         if hasattr(self, 'category') and self.category:
             labels.append(
                 ['category',
-                 self.category]
+                 self.category.name]
             )
         if hasattr(self, 'labels') and self.labels:
             for label in self.labels.all():

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_detail.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_detail.html
@@ -1,7 +1,1 @@
 {% extends "meinberlin_mapideas/mapidea_detail.html" %}
-{% load rules i18n humanize contrib_tags %}
-
-{% block additional_labels %}
-    {{ block.super }}
-    <span class="label label--big">{{ proposal.budget|intcomma }}€</span>
-{% endblock %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_detail.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_detail.html
@@ -11,12 +11,6 @@
     <link type="text/css" href="{% static 'a4maps_display_point.css'%}" rel="stylesheet" />
 {% endblock %}
 
-{% block additional_labels %}
-    {% if object.point_label %}
-        <span class="label label--big"><i class="fas fa-map-marker-alt" aria-hidden="true"></i> {{ object.point_label }}</span>
-    {% endif %}
-{% endblock %}
-
 {% block additional_content %}
     {% if object.point %}
         {% get_category_pin_url object as pin_url %}

--- a/meinberlin/apps/maptopicprio/models.py
+++ b/meinberlin/apps/maptopicprio/models.py
@@ -14,13 +14,15 @@ from adhocracy4.maps import fields as map_fields
 from adhocracy4.models import query
 from adhocracy4.modules import models as module_models
 from adhocracy4.ratings import models as rating_models
+from meinberlin.apps.ideas.models import ItemBadgesPropertyMixin
 
 
 class MapTopicQuerySet(query.RateableQuerySet, query.CommentableQuerySet):
     pass
 
 
-class MapTopic(module_models.Item):
+class MapTopic(module_models.Item,
+               ItemBadgesPropertyMixin):
     item_ptr = models.OneToOneField(to=module_models.Item,
                                     parent_link=True,
                                     related_name='%(app_label)s_%(class)s',

--- a/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
+++ b/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
@@ -29,19 +29,7 @@
         <div class="item-detail">
             <h1 class="item-detail__title">{{ object.name }}</h1>
 
-            <div class="item-detail__labels">
-                {% if object.category %}
-                    <div class="label label--big">{{ object.category }}</div>
-                {% endif %}
-                {% if object.point_label %}
-                    <span class="label label--big"><i class="fas fa-map-marker-alt" aria-hidden="true"></i> {{ object.point_label }}</span>
-                {% endif %}
-                {% if object.labels %}
-                    {% for label in object.labels.all %}
-                    <div class="label label--big">{{ label.name }}</div>
-                    {% endfor %}
-                {% endif %}
-            </div>
+            {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
 
 
             <div class="item-detail__content">

--- a/meinberlin/apps/topicprio/models.py
+++ b/meinberlin/apps/topicprio/models.py
@@ -13,13 +13,15 @@ from adhocracy4.labels import models as labels_models
 from adhocracy4.models import query
 from adhocracy4.modules import models as module_models
 from adhocracy4.ratings import models as rating_models
+from meinberlin.apps.ideas.models import ItemBadgesPropertyMixin
 
 
 class TopicQuerySet(query.RateableQuerySet, query.CommentableQuerySet):
     pass
 
 
-class Topic(module_models.Item):
+class Topic(module_models.Item,
+            ItemBadgesPropertyMixin):
     item_ptr = models.OneToOneField(
         to=module_models.Item,
         parent_link=True,

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
@@ -19,19 +19,7 @@
         <div class="item-detail">
             <h1 class="item-detail__title">{{ object.name }}</h1>
 
-            {% if object.category or object.labels %}
-                <div class="item-detail__labels">
-                    {% if object.category %}
-                    <div class="label label--big">{{ object.category }}</div>
-                    {% endif %}
-
-                    {% if object.labels %}
-                    {% for label in object.labels.all %}
-                    <div class="label label--big">{{ label.name }}</div>
-                    {% endfor %}
-                    {% endif %}
-                </div>
-            {% endif %}
+            {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
 
             <div class="item-detail__content">
                 <div class="item-detail__basic-content">


### PR DESCRIPTION
…move badge properties to mixin to use in topics

I used the badge properties also in the detail views. But we need to check what to do with the budget badges on the tile. 

So, questions for you @CarolingerSeilchenspringer :
We did use different solutions for all the different badges and all different idea derivates. With redoing the badges on the list, I put them into the same order and added the same behaviour everywhere:
- order (detail view and list): moderator feedback, budget, point_label, category, labels
- behaviour on the list: after three badges, the others are counted and put behind the badges as link "... more"
That is fine, right?

But for the detail view, we only added the "budget not specified" to budgeting proposals, not kiezkasse. I also changed that and kiezkasse proposals are the same now. Also fine (just improving), right?

But finally the question we need a decision on: so far the budget is not displayed in the list when it is 0. https://meinberlin-dev.liqd.net/projekte/module/kiezkasse-4/?mode=list It would be easier if we could change that and also display the 0-label on the list: 
![Screenshot from 2022-10-19 17-05-36](https://user-images.githubusercontent.com/8178179/196734975-06aed730-5f89-4251-80dd-9a438dfb59cb.png)
But we can also remove it from the list. And keep it like it is now. Please tell us @CarolingerSeilchenspringer 