### PR TITLE
[6609 ]Ks 2022 10 support btw phases

### DIFF
--- a/meinberlin/apps/budgeting/api.py
+++ b/meinberlin/apps/budgeting/api.py
@@ -13,6 +13,7 @@ from adhocracy4.categories import has_icons
 from adhocracy4.categories.models import Category
 from adhocracy4.labels.models import Label
 from adhocracy4.modules.predicates import module_is_between_phases
+from adhocracy4.phases.predicates import has_feature_active
 from meinberlin.apps.contrib.filters import IdeaCategoryFilterBackend
 from meinberlin.apps.contrib.filters import OrderingFilterWithDailyRandom
 from meinberlin.apps.contrib.templatetags.contrib_tags import \
@@ -184,6 +185,9 @@ class PermissionInfoMixin:
         )
         permissions['view_comment_count'] = (
             self.module.has_feature('comment', Proposal)
+        )
+        permissions['view_vote_count'] = has_feature_active(
+            self.module, Proposal, 'vote'
         )
 
         response = super().list(request, args, kwargs)

--- a/meinberlin/apps/budgeting/api.py
+++ b/meinberlin/apps/budgeting/api.py
@@ -144,16 +144,14 @@ class PermissionInfoMixin:
         fetches the module
         """
         permissions = {}
-
-        permissions['view_support_count'] = has_feature_active(
-            self.module, Proposal, 'support'
-        )
+        user = request.user
+        permissions['view_support_count'] = user.has_perm(
+            'meinberlin_budgeting.view_support', self.module)
         permissions['view_rate_count'] = self.module.has_feature(
             'rate', Proposal
         )
         permissions['view_comment_count'] = (
             self.module.has_feature('comment', Proposal)
-            and not has_feature_active(self.module, Proposal, 'vote')
         )
 
         response = super().list(request, args, kwargs)

--- a/meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx
+++ b/meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx
@@ -77,7 +77,7 @@ export const BudgetingProposalList = (props) => {
 
   return (
     <>
-      {(props.is_voting_phase && meta?.token_info) &&
+      {(meta?.permissions.view_vote_count && meta?.token_info) &&
         <div className="module-content--light">
           <div className="container">
             <div className="offset-lg-3 col-lg-6">

--- a/meinberlin/apps/budgeting/assets/SupportBox.jsx
+++ b/meinberlin/apps/budgeting/assets/SupportBox.jsx
@@ -68,6 +68,7 @@ export const SupportBox = (props) => {
       <button
         aria-label={translations.support}
         className={`rating-button rating-up ${userSupported ? 'is-selected' : ''}`}
+        disabled={props.isReadOnly}
         onClick={handleSupport}
       >
         <i className="far fa-thumbs-up" aria-hidden="true" />

--- a/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalList.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalList.jest.jsx
@@ -6,13 +6,14 @@ import { BrowserRouter } from 'react-router-dom'
 const permissions = {
   view_support_count: false,
   view_rate_count: true,
-  view_comment_count: true
+  view_comment_count: true,
+  view_vote_count: true
 }
 
 test('Budgeting Proposal List without list item (empty)', async () => {
   // mimicking fetch response with empty list
   const mockedFetchEmpty = Promise.resolve({
-    json: () => Promise.resolve({ results: [] })
+    json: () => Promise.resolve({ results: [], permissions })
   })
 
   // overwrite global.fetch with mock function

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_detail.html
@@ -9,8 +9,8 @@
 
 {% block ratings %}
     {% if module.blueprint_type == 'PB3' and proposal|has_feature:"support" %}
-        {% has_or_would_have_perm 'meinberlin_budgeting.support_proposal' request.user proposal as may_support_proposal %}
-        {% if may_support_proposal %}
+        {% has_or_would_have_perm 'meinberlin_budgeting.view_support' request.user module as may_view_support %}
+        {% if may_view_support %}
         <div class="lr-bar__left">
             {% react_support proposal %}
         </div>

--- a/meinberlin/apps/budgeting/templatetags/react_proposals.py
+++ b/meinberlin/apps/budgeting/templatetags/react_proposals.py
@@ -5,9 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.html import format_html
 
-from adhocracy4.phases.predicates import has_feature_active
-from meinberlin.apps.budgeting.models import Proposal
-
 register = template.Library()
 
 
@@ -25,9 +22,6 @@ def react_proposals(context, module):
 
     attributes = {'proposals_api_url': proposals_api_url,
                   'tokenvote_api_url': tokenvote_api_url,
-                  'is_voting_phase': has_feature_active(module,
-                                                        Proposal,
-                                                        'vote')
                   }
 
     return format_html(

--- a/meinberlin/apps/budgeting/templatetags/react_proposals_vote.py
+++ b/meinberlin/apps/budgeting/templatetags/react_proposals_vote.py
@@ -5,8 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.html import format_html
 
-from adhocracy4.phases.predicates import has_feature_active
-from meinberlin.apps.budgeting.models import Proposal
 from meinberlin.apps.votes.models import TokenVote
 from meinberlin.apps.votes.models import VotingToken
 from meinberlin.apps.votes.serializers import VotingTokenSerializer
@@ -16,8 +14,6 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def react_proposals_vote(context, module, proposal):
-    proposals_api_url = reverse('proposals-list',
-                                kwargs={'module_pk': module.pk})
     proposal_ct = ContentType.objects.get(app_label='meinberlin_budgeting',
                                           model='proposal')
     tokenvote_api_url = reverse('tokenvotes-list',
@@ -45,11 +41,7 @@ def react_proposals_vote(context, module, proposal):
         except VotingToken.DoesNotExist:
             pass
 
-    attributes = {'proposals_api_url': proposals_api_url,
-                  'tokenvote_api_url': tokenvote_api_url,
-                  'is_voting_phase': has_feature_active(module,
-                                                        Proposal,
-                                                        'vote'),
+    attributes = {'tokenvote_api_url': tokenvote_api_url,
                   'objectID': proposal.pk,
                   'session_token_voted': session_token_voted,
                   'token_info': token_info

--- a/meinberlin/apps/budgeting/templatetags/react_support.py
+++ b/meinberlin/apps/budgeting/templatetags/react_support.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.html import format_html
 
 from adhocracy4.ratings import models as rating_models
+from adhocracy4.rules.discovery import NormalUser
 
 register = template.Library()
 
@@ -29,6 +30,12 @@ def react_support(context, obj):
             user_supported = bool(user_support.value)
             user_support_id = user_support.pk
 
+    permission = '{ct.app_label}.support_{ct.model}'.format(ct=contenttype)
+    has_support_permission = user.has_perm(permission, obj)
+    would_have_support_permission = NormalUser().would_have_perm(
+        permission, obj
+    )
+
     attributes = {
         'contentType': contenttype.pk,
         'objectId': obj.pk,
@@ -36,6 +43,8 @@ def react_support(context, obj):
         'support': obj.positive_rating_count,
         'userSupported': user_supported,
         'userSupportId': user_support_id,
+        'isReadOnly': (not has_support_permission and
+                       not would_have_support_permission),
         'style': 'ideas',
     }
 

--- a/meinberlin/apps/budgeting/views.py
+++ b/meinberlin/apps/budgeting/views.py
@@ -20,6 +20,8 @@ def get_ordering_choices(view):
     choices = (('-created', _('Most recent')),)
     if view.module.has_feature('rate', models.Proposal):
         choices += ('-positive_rating_count', _('Most popular')),
+    elif view.module.has_feature('support', models.Proposal):
+        choices += ('-positive_rating_count', _('Most support')),
     choices += ('-comment_count', _('Most commented')), \
                ('dailyrandom', _('Random')),
     return choices

--- a/tests/budgeting/test_proposals_api_filtering.py
+++ b/tests/budgeting/test_proposals_api_filtering.py
@@ -373,7 +373,9 @@ def test_proposal_ordering_filter(
                   kwargs={'module_pk': module.pk})
 
     # queryset is ordered by created
-    response = apiclient.get(url)
+    querystring = '?ordering=-created'
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
     assert len(response.data['results']) == 8
     assert response.data['results'][0]['pk'] == proposal_new.pk
     assert response.data['results'][-1]['pk'] == proposal_old.pk
@@ -419,7 +421,7 @@ def test_proposal_filter_combinations(
     yesterday = now - timezone.timedelta(days=1)
     last_week = now - timezone.timedelta(days=7)
 
-    proposal_new = proposal_factory(pk=1, module=module, created=now)
+    proposal_factory(pk=1, module=module, created=now)
     proposal_old = proposal_factory(pk=2,
                                     module=module,
                                     created=last_week,
@@ -461,12 +463,6 @@ def test_proposal_filter_combinations(
 
     url = reverse('proposals-list',
                   kwargs={'module_pk': module.pk})
-
-    # queryset is ordered by created
-    response = apiclient.get(url)
-    assert len(response.data['results']) == 8
-    assert response.data['results'][0]['pk'] == proposal_new.pk
-    assert response.data['results'][-1]['pk'] == proposal_old.pk
 
     # combinations
     querystring = '?is_archived=true&category=' + str(category2.pk)


### PR DESCRIPTION
This is supposed to implement the following behaviour:
- show support (on, list, map and detail) during support phase and btw support and voting phase
- support button only active during support phase 
- add 'most support' to ordering filter during support phase and btw support and voting phase
- make 'most support' default ordering filter only btw support and voting phase

Notes: 
- do not test as admin
- old participatory budgeting with rating phase doesnt fully work anymore (map pop up does not show rating), but ok with Caro

I did not add the tests yet as did not want to test unapproved code..

fixes #4109
fixes #4597