### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-09-28 08:35+0200\n"
-"PO-Revision-Date: 2022-11-02 14:08+0000\n"
+"PO-Revision-Date: 2022-11-04 17:08+0000\n"
 "Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
 "Language-Team: German <https://trans.liqd.net/projects/meinberlin/main/de/>\n"
 "Language: de_DE\n"
@@ -1783,7 +1783,7 @@ msgstr "am beliebtesten"
 
 #: meinberlin/apps/budgeting/api.py:123
 msgid "Most support"
-msgstr ""
+msgstr "meist unterstützt"
 
 #: meinberlin/apps/budgeting/api.py:124 meinberlin/apps/budgeting/views.py:23
 #: meinberlin/apps/ideas/views.py:38 meinberlin/apps/kiezkasse/views.py:19

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-10-25 16:09+0200\n"
-"PO-Revision-Date: 2022-11-02 14:08+0000\n"
+"PO-Revision-Date: 2022-11-04 17:08+0000\n"
 "Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
 "Language-Team: German <https://trans.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
@@ -874,7 +874,7 @@ msgstr "Vorschläge durchsuchen"
 
 #: meinberlin/apps/budgeting/assets/ListItemBadges.jsx:6
 msgid "More"
-msgstr ""
+msgstr "Mehr"
 
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:5
 msgid "Positive Ratings"
@@ -886,7 +886,7 @@ msgstr "Negative Bewertungen"
 
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:7
 msgid "Support"
-msgstr ""
+msgstr "Unterstützung"
 
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:8
 msgid "Comments"
@@ -906,7 +906,7 @@ msgstr ""
 
 #: meinberlin/apps/budgeting/assets/SupportBox.jsx:8
 msgid "Click to support"
-msgstr ""
+msgstr "Zum Unterstützen klicken"
 
 #: meinberlin/apps/budgeting/assets/VoteButton.jsx:40
 msgid "Voted"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://trans.liqd.net) for [meinBerlin/main](https://trans.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://trans.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://trans.liqd.net/widgets/meinberlin/-/main/horizontal-auto.svg)