### PR TITLE
notifications/notify_contact_on_moderator_feedback: change wording as…

### DIFF
--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_contact_on_moderator_feedback.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_contact_on_moderator_feedback.de.email
@@ -10,7 +10,7 @@
 {% block content %}
 {{ object.module.project.organisation.name }} hat auf Ihren Beitrag reagiert.
 
-{% if object.moderator_feedback %}Ihr Beitrag {{ object.get_moderator_feedback_display }}.
+{% if object.moderator_feedback %}Der Status Ihres Beitrags hat sich geändert und steht nun auf “{{ object.get_moderator_feedback_display }}”.
 
 {% endif %}
 {% if object.moderator_statement.statement %}Offizielle Rückmeldung: {{ object.moderator_statement.statement | safe }}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_contact_on_moderator_feedback.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_contact_on_moderator_feedback.en.email
@@ -10,7 +10,7 @@
 {% block content %}
 {{ object.module.project.organisation.name }} reacted on your contribution.
 
-{% if object.moderator_feedback %}Your contribution {{ object.get_moderator_feedback_display }}.
+{% if object.moderator_feedback %}The status of your contribution has been changed and is now “{{ object.get_moderator_feedback_display }}".
 
 {% endif %}
 {% if object.moderator_statement.statement %}Official feedback: {{ object.moderator_statement.statement | safe }}


### PR DESCRIPTION
… in notify_creator email

This belongs to story #6704, I only changed the wording in the notify_creator_on_moderator_feedback there..

I think those 2 emails are a bit confusing, maybe we should get rid of the notify_creator one (and instead add the creator to receivers if there is no contact)? We would just need a solution for the footer then.. :/