### PR TITLE
assets/details: hide the default arrow on safari fixes #4720

### DIFF
--- a/meinberlin/assets/scss/components/_details.scss
+++ b/meinberlin/assets/scss/components/_details.scss
@@ -2,6 +2,11 @@ details summary {
     cursor: pointer;
 }
 
+// Hides the default arrow on safari
+details summary:-webkit-details-marker {
+    display: none;
+}
+
 details summary > * {
     display: inline;
 }


### PR DESCRIPTION
might fix it, don't know?!