### PR TITLE
remove pollyfills for fetch and promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "css-loader": "6.7.3",
     "datepicker": "git+https://github.com/liqd/datePicker.git",
     "dsgvo-video-embed": "git+https://github.com/liqd/dsgvo-video-embed.git",
-    "es6-promise": "4.2.8",
     "feature-detect": "1.0.0",
     "file-saver": "2.0.5",
     "immutability-helper": "3.1.1",
@@ -62,8 +61,7 @@
     "tether": "2.0.0",
     "timeago.js": "4.0.2",
     "webpack": "5.75.0",
-    "webpack-merge": "5.8.0",
-    "whatwg-fetch": "3.6.2"
+    "webpack-merge": "5.8.0"
   },
   "devDependencies": {
     "@babel/core": "7.20.7",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -241,11 +241,9 @@ module.exports = {
   },
   plugins: [
     new webpack.ProvidePlugin({
-      timeago: 'timeago.js',
       $: 'jquery',
       jQuery: 'jquery',
-      Promise: ['es6-promise', 'Promise'],
-      fetch: ['whatwg-fetch', 'fetch']
+      timeago: 'timeago.js'
     }),
     new MiniCssExtractPlugin({
       filename: '[name].css',


### PR DESCRIPTION
* breaks compatibility with older browsers (especially IE)
* makes maplibre-gl work again