### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-01-05 16:43+0100\n"
-"PO-Revision-Date: 2022-12-15 10:50+0000\n"
-"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
+"PO-Revision-Date: 2023-01-06 16:37+0000\n"
+"Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
 "Language-Team: German <https://trans.liqd.net/projects/meinberlin/main/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -5188,11 +5188,11 @@ msgstr ""
 
 #: meinberlin/templates/a4modules/includes/module_detail_phase_info.html:18
 msgid "upcoming"
-msgstr ""
+msgstr "anstehend"
 
 #: meinberlin/templates/a4modules/includes/module_detail_phase_info.html:24
 msgid "finished"
-msgstr ""
+msgstr "abgeschlossen"
 
 #: meinberlin/templates/a4modules/module_detail.html:38
 msgid "Previous"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-01-05 16:43+0100\n"
-"PO-Revision-Date: 2022-12-15 10:48+0000\n"
-"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
+"PO-Revision-Date: 2023-01-06 16:37+0000\n"
+"Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
 "Language-Team: German <https://trans.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -1317,11 +1317,11 @@ msgstr "Liste anzeigen"
 
 #: meinberlin/assets/js/swiper_phases.js:27
 msgid "Slider to go back and forth between phases."
-msgstr ""
+msgstr "Schieberegler, um zwischen den Phasen hin und her zu wechseln."
 
 #: meinberlin/assets/js/swiper_phases.js:29
 msgid "Go to slide {{index}}"
-msgstr ""
+msgstr "Gehe zu Phase {{index}}"
 
 #: meinberlin/assets/js/unload_warning.js:16
 msgid "If you leave this page changes you made will not be saved."


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://trans.liqd.net) for [meinBerlin/main](https://trans.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://trans.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://trans.liqd.net/widgets/meinberlin/-/main/horizontal-auto.svg)