### PR TITLE
WIP: [6962] apps/budgeting: shorten expiry age for session when token is entered,…

### DIFF
--- a/meinberlin/apps/budgeting/views.py
+++ b/meinberlin/apps/budgeting/views.py
@@ -21,6 +21,8 @@ from meinberlin.apps.votes.models import VotingToken
 from . import forms
 from . import models
 
+SESSION_EXPIRY_AGE = 10 * 60  # 10 minutes
+
 
 def get_ordering_choices(view):
     choices = (("-created", _("Most recent")),)
@@ -116,6 +118,13 @@ class ProposalListView(idea_views.AbstractIdeaListView, DisplayProjectOrModuleMi
                 request.session["voting_tokens"] = {
                     str(self.module.id): token_form.cleaned_data["token"]
                 }
+            # true for unauthenticated users or
+            # if the 'remember' wasn't checked during login
+            if (
+                not request.user.is_authenticated
+                or request.session.get_expire_at_browser_close()
+            ):
+                request.session.set_expiry(SESSION_EXPIRY_AGE)
             kwargs["valid_token_present"] = True
             self.mode = "list"
         kwargs["token_form"] = token_form


### PR DESCRIPTION
… but only when user didn't log in with remember me

When 'remember' is checked during login, allauth sets the expiry to the set expiry age, while otherwise it is set to 0, causing Django to end the session once the browser is closed. https://github.com/pennersr/django-allauth/blob/30a3473b8010264143f031bb7565eb26faa143e4/allauth/account/forms.py#L206 https://docs.djangoproject.com/en/4.1/topics/http/sessions/#using-sessions-in-views

This longer explanation is also in the commit message. Do you think, we will find it there?

~~Should we merge before I add the tests, so that it can already be tested? edit: well, no, writing tests, I have to investigate if it only works for logged in users if we do it like that. :roll_eyes:~~ Tests are there, should be all fine now. Could you review @Rineee ?