### PR TITLE
[6669]apps/budgeting/moderator-feedback: detail-info title fontsize s…

### DIFF
--- a/meinberlin/assets/scss/components/_detail_info.scss
+++ b/meinberlin/assets/scss/components/_detail_info.scss
@@ -43,6 +43,7 @@
 }
 
 .detail-info__title {
+    font-size: $font-size-lg;
     margin: 0;
     flex-grow: 2;
 }


### PR DESCRIPTION
…maller

we tried the option to use h1 (with "original" font-size) and h2 for the boxes' titles. But they appear very big. So we decided to overwrite this h2 font size.

fixes #4818 