### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-06 12:46+0100\n"
-"PO-Revision-Date: 2023-02-01 15:43+0000\n"
+"PO-Revision-Date: 2023-02-08 10:43+0000\n"
 "Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
 "Language-Team: German <https://trans.liqd.net/projects/meinberlin/main/de/>\n"
 "Language: de_DE\n"
@@ -1835,7 +1835,7 @@ msgstr "zufällig"
 
 #: meinberlin/apps/budgeting/api.py:208
 msgid "Most votes"
-msgstr ""
+msgstr "meiste Stimmen"
 
 #: meinberlin/apps/budgeting/exports.py:46
 msgid "Contact E-Mail"
@@ -2100,6 +2100,8 @@ msgid ""
 "This idea received a total of <span class=\"u-primary\">%(amount)s</span> "
 "votes"
 msgstr ""
+"Dieser Vorschlag hat <span class=\"u-primary\">%(amount)s</span> Stimmen "
+"erhalten"
 
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:19
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:18
@@ -4770,10 +4772,10 @@ msgid ""
 "encrypted. To generate the codes, please contact %(contact_email)s."
 msgstr ""
 "Für die Abstimmung in der dritten Phase benötigen alle Teilnehmer*innen "
-"einen eigenen Abstimmungscode. Hier können Sie die Codes in Paketen von "
-"%(export_size)s pro Excel-Datei herunterladen. Jede Datei kann nur ein Mal "
-"heruntergeladen werden, danach werden die Codes verschlüsselt. Um die Codes "
-"zu erstellen, wenden Sie sich bitte an %(contact_email)s."
+"einen eigenen Abstimmungscode. Hier können Sie die Codes in Paketen von bis "
+"zu %(export_size)s pro Excel-Datei herunterladen. Jede Datei kann nur ein "
+"Mal heruntergeladen werden, danach werden die Codes verschlüsselt. Um die "
+"Codes zu erstellen, wenden Sie sich bitte an %(contact_email)s."
 
 #: meinberlin/apps/votes/templates/meinberlin_votes/token_export_dashboard.html:8
 #: meinberlin/apps/votes/templates/meinberlin_votes/token_generation_dashboard.html:8

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-06 12:47+0100\n"
-"PO-Revision-Date: 2023-01-19 03:00+0000\n"
+"PO-Revision-Date: 2023-02-08 10:43+0000\n"
 "Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
 "Language-Team: German <https://trans.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
@@ -837,11 +837,11 @@ msgstr "Keine Ergebnisse"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:22
 msgid "Are you finished?"
-msgstr ""
+msgstr "Sind sie fertig?"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:23
 msgid "End session"
-msgstr ""
+msgstr "Sitzung beenden"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:24
 msgid ""
@@ -849,10 +849,13 @@ msgid ""
 "enter a new code. If you want to change the votes you have already cast, you "
 "can re-enter your code as long as the voting phase is running. "
 msgstr ""
+"Um Ihre abgegebene Stimme zu speichern müssen Sie nichts weiter tun. Beenden "
+"Sie die Sitzung, um einen neuen Code einzugeben. Um Ihre Stimme zu ändern, "
+"können Sie Ihren Code erneut eingeben, solange die Abstimmungsphase läuft. "
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:25
 msgid "Do you want to end the session?"
-msgstr ""
+msgstr "Möchten Sie diese Sitzung beenden?"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalListItem.jsx:8
 msgid "updated on"
@@ -864,7 +867,7 @@ msgstr "erstellt am"
 
 #: meinberlin/apps/budgeting/assets/ControlBar.jsx:14
 msgid "Search, filter and sort the ideas list"
-msgstr ""
+msgstr "Suchen, Filtern und Sortieren der Vorschläge in der Liste"
 
 #: meinberlin/apps/budgeting/assets/ControlBar.jsx:19
 #, javascript-format
@@ -901,7 +904,7 @@ msgstr "Vorschläge durchsuchen"
 
 #: meinberlin/apps/budgeting/assets/ControlBarSearchTerm.jsx:5
 msgid "Remove filters"
-msgstr ""
+msgstr "Filter entfernen"
 
 #: meinberlin/apps/budgeting/assets/ListItemBadges.jsx:5
 msgid "More"
@@ -925,7 +928,7 @@ msgstr "Kommentare"
 
 #: meinberlin/apps/budgeting/assets/ListItemStats.jsx:11
 msgid "Total votes"
-msgstr ""
+msgstr "Gesamtzahl der Stimmen"
 
 #: meinberlin/apps/budgeting/assets/Pagination.jsx:6
 msgid "Page navigation"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://trans.liqd.net) for [meinBerlin/main](https://trans.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://trans.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://trans.liqd.net/widgets/meinberlin/-/main/horizontal-auto.svg)