### PR TITLE
[4853]apps/budgeting/list-item/labels: char limit for ampel labels re…

### DIFF
--- a/meinberlin/assets/scss/components/_list_item.scss
+++ b/meinberlin/assets/scss/components/_list_item.scss
@@ -78,6 +78,13 @@
         max-width: 25ch; // cuts label text after approx 30char
         text-overflow: ellipsis;
         white-space: nowrap;
+
+        &.label--consideration,
+        &.label--qualified,
+        &.label--rejected,
+        &.label--accepted {
+            max-width: none;
+        }
     }
 }
 


### PR DESCRIPTION
…moved. other labels 25 chars limit kept.

closes #4853 