### PR TITLE
[#5000]apps/contrib/helpers: input date string has to be modified (re…

### DIFF
--- a/meinberlin/apps/contrib/assets/helpers.js
+++ b/meinberlin/apps/contrib/assets/helpers.js
@@ -21,6 +21,7 @@ export const toLocaleDate = (
   locale = 'de-DE',
   formatStyle = { dateStyle: 'long' }
 ) => {
-  const date = new Date(isodate)
+  const normalizedDate = isodate.replace(/ /g, 'T')
+  const date = new Date(normalizedDate)
   return new Intl.DateTimeFormat(locale, formatStyle).format(date)
 }


### PR DESCRIPTION
…placing whitespace with T) in order to make older safari working closes #5000 

apparently the Date class is differently implemented for older Safari versions (<16).