### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-03 13:23+0100\n"
-"PO-Revision-Date: 2023-02-25 15:52+0000\n"
-"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
+"PO-Revision-Date: 2023-03-03 12:42+0000\n"
+"Last-Translator: SandisStudi <s.uscins@liqd.net>\n"
 "Language-Team: German <https://trans.liqd.net/projects/meinberlin/main/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"X-Generator: Weblate 4.16\n"
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
@@ -766,11 +766,11 @@ msgstr "Negative Bewertungen"
 
 #: adhocracy4/exports/views.py:91
 msgid "yes"
-msgstr ""
+msgstr "Ja"
 
 #: adhocracy4/exports/views.py:92
 msgid "no"
-msgstr ""
+msgstr "Nein"
 
 #: adhocracy4/filters/widgets.py:76
 #: meinberlin/apps/budgeting/api.py:133 meinberlin/apps/projects/views.py:40
@@ -1872,11 +1872,11 @@ msgstr "Kommentar"
 
 #: meinberlin/apps/budgeting/exports.py:102
 msgid "Support"
-msgstr ""
+msgstr "Unterstützung"
 
 #: meinberlin/apps/budgeting/exports.py:128
 msgid "Votes"
-msgstr ""
+msgstr "Stimmen"
 
 #: meinberlin/apps/budgeting/forms.py:35
 msgid ""


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://trans.liqd.net) for [meinBerlin/main](https://trans.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://trans.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://trans.liqd.net/widgets/meinberlin/-/main/horizontal-auto.svg)