### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -7,17 +7,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-11 09:35+0200\n"
-"PO-Revision-Date: 2023-06-20 17:32+0000\n"
+"POT-Creation-Date: 2023-06-29 18:11+0200\n"
+"PO-Revision-Date: 2023-07-12 12:26+0000\n"
 "Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main/de/"
-">\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main/de/>"
+"\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Weblate 4.18.2\n"
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
@@ -852,7 +852,7 @@ msgstr "Urheber*in, die im {image_name} angezeigt wird."
 #: adhocracy4/images/fields.py:103
 #, python-brace-format
 msgid "{image_name} alt text"
-msgstr ""
+msgstr "{image_name} Alternativtext"
 
 #: adhocracy4/images/fields.py:106
 msgid ""
@@ -860,16 +860,19 @@ msgid ""
 "is read out by screen readers. Describe the image in max. 80 characters. "
 "Example: A busy square with people in summer."
 msgstr ""
+"Ein Alternativtext dient als textliche Beschreibung des Bildinhalts und wird "
+"von Screenreadern vorgelesen. Beschreiben Sie das Bild in max. 80 Zeichen. "
+"Beispiel: Ein belebter Platz mit Menschen im Sommer."
 
 #: adhocracy4/images/mixins.py:30
 #: adhocracy4/images/mixins.py:35
 msgid "Please add copyright information."
-msgstr ""
+msgstr "Bitte fügen Sie Angaben zum Copyright hinzu."
 
 #: adhocracy4/images/mixins.py:40
 #: adhocracy4/images/mixins.py:45
 msgid "Please add an alternative text for this image"
-msgstr ""
+msgstr "Bitte fügen Sie einen Alternativtext zu diesem Bild hinzu"
 
 #: adhocracy4/images/validators.py:26
 msgid "Unsupported file format. Supported formats are {}."
@@ -2090,6 +2093,8 @@ msgid ""
 "Support the submitted proposals for the participatory budgeting that you "
 "like."
 msgstr ""
+"Unterstützen Sie die eingereichten Vorschläge für den Bürger*innenhaushalt, "
+"die Ihnen gefallen."
 
 #: meinberlin/apps/budgeting/phases.py:101
 msgid ""
@@ -4049,7 +4054,7 @@ msgstr "Neues Vorhaben"
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:36
 #: meinberlin/templates/a4dashboard/includes/project_list_item.html:12
 msgid "Here you can find a decorative picture."
-msgstr ""
+msgstr "Hier befindet sich ein dekoratives Bild."
 
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:39
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html:113
@@ -4057,7 +4062,7 @@ msgstr ""
 #: meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html:69
 #: meinberlin/templates/a4dashboard/includes/project_list_item.html:18
 msgid "copyright missing"
-msgstr ""
+msgstr "fehlende Copyright-Angabe"
 
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:76
 #: meinberlin/apps/plans/templates/meinberlin_plans/plan_dashboard_list.html:78

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,15 +8,15 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-07-11 09:35+0200\n"
-"PO-Revision-Date: 2023-02-10 13:43+0000\n"
+"PO-Revision-Date: 2023-07-12 12:26+0000\n"
 "Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
-"Language-Team: German <https://trans.liqd.net/projects/meinberlin/js/de/>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"X-Generator: Weblate 4.18.2\n"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
@@ -980,7 +980,7 @@ msgstr ""
 
 #: meinberlin/apps/budgeting/assets/SupportBox.jsx:20
 msgid "Support button inactive."
-msgstr ""
+msgstr "Button zum Unterstützen inaktiv."
 
 #: meinberlin/apps/budgeting/assets/VoteButton.jsx:46
 msgid "Voted"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main](https://weblate.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://weblate.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widgets/meinberlin/-/main/horizontal-auto.svg)