### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-06-29 18:11+0200\n"
-"PO-Revision-Date: 2023-07-12 12:26+0000\n"
-"Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
+"PO-Revision-Date: 2023-08-09 08:12+0000\n"
+"Last-Translator: SandisStudi <s.uscins@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main/de/>"
 "\n"
 "Language: de_DE\n"
@@ -2222,7 +2222,7 @@ msgstr "Code eingeben"
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:49
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:31
 msgid "Map of proposals"
-msgstr ""
+msgstr "Karte mit Vorschlägen"
 
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:62
 #: meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html:64
@@ -3073,7 +3073,7 @@ msgstr "Idee anlegen"
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html:23
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:73
 msgid "Idea list"
-msgstr ""
+msgstr "Liste mit Ideen"
 
 #: meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html:30
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:72
@@ -3192,7 +3192,7 @@ msgstr ""
 
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html:65
 msgid "Proposal list"
-msgstr ""
+msgstr "Liste mit Vorschlägen"
 
 #: meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_moderate_form.html:4
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html:4
@@ -3370,7 +3370,7 @@ msgstr "Idee anlegen"
 
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html:30
 msgid "Map of ideas"
-msgstr ""
+msgstr "Karte mit Ideen"
 
 #: meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html:23
 msgid "Moderate idea"
@@ -3435,7 +3435,7 @@ msgstr "Ort hinzufügen"
 
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_list.html:22
 msgid "Map of topics"
-msgstr ""
+msgstr "Karte mit Themen"
 
 #: meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_update_form.html:8
 msgid "Edit place"
@@ -3766,7 +3766,7 @@ msgstr "Projektlinks"
 
 #: meinberlin/apps/plans/exports.py:69
 msgid "Draft"
-msgstr ""
+msgstr "Entwurf"
 
 #: meinberlin/apps/plans/forms.py:45
 msgid "Please locate the plan on the map."

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-07-11 09:35+0200\n"
-"PO-Revision-Date: 2023-07-12 12:26+0000\n"
+"PO-Revision-Date: 2023-08-09 08:12+0000\n"
 "Last-Translator: Jonathan Ostertag <j.ostertag@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
@@ -271,7 +271,7 @@ msgstr ""
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:30
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:30
 msgid "Delete comment"
-msgstr ""
+msgstr "Kommentar löschen"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:35
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:35
@@ -796,7 +796,7 @@ msgstr[1] "%s Teilnehmer*innen haben geantwortet."
 #: adhocracy4/polls/static/PollDetail/PollResults.jsx:77
 #: adhocracy4/polls/static/PollDetail/PollResults.jsx:77
 msgid "no one has answered this question"
-msgstr ""
+msgstr "Keine Person hat diese Frage beantwortet"
 
 #: adhocracy4/polls/static/PollDetail/PollResults.jsx:107
 #: adhocracy4/polls/static/PollDetail/PollResults.jsx:107
@@ -816,7 +816,7 @@ msgstr "Für eine negative Bewertung hier klicken"
 #: adhocracy4/reports/static/reports/ReportModal.jsx:7
 #: adhocracy4/reports/static/reports/ReportModal.jsx:7
 msgid "Report sent"
-msgstr ""
+msgstr "Meldung gesendet"
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:8
 #: adhocracy4/reports/static/reports/ReportModal.jsx:8
@@ -854,7 +854,7 @@ msgstr[1] "Sie haben noch %s Stimmen."
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:21
 msgid "Proposals list"
-msgstr ""
+msgstr "Liste mit Vorschlägen"
 
 #: meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx:22
 #: meinberlin/apps/plans/assets/PlansList.jsx:11
@@ -963,11 +963,11 @@ msgstr "Seitennummerierung"
 
 #: meinberlin/apps/budgeting/assets/Pagination.jsx:7
 msgid "next page"
-msgstr ""
+msgstr "Nächste Seite"
 
 #: meinberlin/apps/budgeting/assets/Pagination.jsx:8
 msgid "prev page"
-msgstr ""
+msgstr "Vorherige Seite"
 
 #: meinberlin/apps/budgeting/assets/SupportBox.jsx:18
 msgid "Click to support."


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main](https://weblate.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://weblate.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widgets/meinberlin/-/main/horizontal-auto.svg)