### PR TITLE
[7697] add extra context in paragraph detail view

### DIFF
--- a/changelog/7697.md
+++ b/changelog/7697.md
@@ -1,0 +1,3 @@
+### Added
+
+- extra context in paragraph detail view

--- a/meinberlin/apps/documents/views.py
+++ b/meinberlin/apps/documents/views.py
@@ -67,6 +67,13 @@ class ParagraphDetailView(
     model = models.Paragraph
     permission_required = "meinberlin_documents.view_paragraph"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        chapter = self.get_object().chapter
+        context["chapter"] = chapter
+        context["project"] = chapter.project
+        return context
+
 
 class DocumentDashboardExportView(DashboardExportView):
     template_name = "a4exports/export_dashboard.html"

--- a/tests/documents/test_document_api.py
+++ b/tests/documents/test_document_api.py
@@ -690,3 +690,16 @@ def test_initiator_can_update_and_create_paragraph(apiclient, module):
 
     paragraphs_all_count = document_models.Paragraph.objects.all().count()
     assert paragraphs_all_count == 2
+
+
+@pytest.mark.django_db
+def test_initiator_retreive_paragraph(apiclient, module, paragraph):
+    project = module.project
+    paragraph = document_models.Paragraph.objects.first()
+    initiator = project.organisation.initiators.first()
+    apiclient.force_authenticate(user=initiator)
+    url = reverse("meinberlin_documents:paragraph-detail", kwargs={"pk": paragraph.pk})
+    response = apiclient.get(url, format="json")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.context["project"] == project
+    assert response.context["chapter"] == paragraph.chapter


### PR DESCRIPTION
Add project and chapter in paragraph context so breadcrumb template block can be abstracted for all templates.