### PR TITLE
Celery beat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ help:
 	@echo "  make celery-worker-start		-- starts the celery worker in the foreground"
 	@echo "  make celery-worker-status		-- lists all registered tasks and active worker nodes"
 	@echo "  make celery-worker-dummy-task	-- calls the dummy task and prints result from redis"
+	@echo "  make celery-beat		-- starts the celery beat in the foreground"
 	@echo
 
 .PHONY: install
@@ -263,3 +264,7 @@ celery-worker-status:
 .PHONY: celery-worker-dummy-task
 celery-worker-dummy-task:
 	$(VIRTUAL_ENV)/bin/celery --app meinberlin call dummy_task | awk '{print "celery-task-meta-"$$0}' | xargs redis-cli get | python3 -m json.tool
+
+.PHONY: celery-beat
+celery-beat:
+	$(VIRTUAL_ENV)/bin/celery --app meinberlin beat --loglevel INFO -S django

--- a/README.md
+++ b/README.md
@@ -43,25 +43,46 @@ make watch
 
 ### Use Celery for task queues
 
-For a celery worker to pick up tasks you need to make sure that:
+For celery to register and run tasks you need to make sure that:
 
 - the redis server is running
 - the celery config parameter "always eager" is disabled (add `CELERY_TASK_ALWAYS_EAGER = False` to your `local.py`)
 
-To start a celery worker node in the foreground, call:
+To start a celery worker in the foreground, run:
 
 ```
 make celery-worker-start
 ```
+Stop celery with ctr+C
 
-To inspect all registered tasks, list the running worker nodes, call:
+To inspect all registered tasks, list the running worker nodes, run:
 
 ```
 make celery-worker-status
 ```
 
-To send a dummy task to the queue and report the result, call:
+To send a dummy task to the queue and report the result, run:
 
 ```
 make celery-worker-dummy-task
 ```
+
+See more info about Celery in the [docs](./docs/celery.md)
+
+### Use Celery beat for scheduled tasks in development
+
+For celery to run scheduled tasks you need to make sure that:
+
+- the redis server is running
+- the celery worker is running (see previous step)
+
+To start celery beat in the foreground, run:
+
+```
+make celery-beat
+```
+Stop celery beat with ctr+C
+
+### To add scheduled tasks (same for all environments) check the [docs](./docs/celerybeat.md)
+
+In case of settings.TIME_ZONE change, tasks need to be synced with the new time. [See HOWTO](https://django-celery-beat.readthedocs.io/en/latest/#important-warning-about-time-zones)

--- a/changelog/2222.md
+++ b/changelog/2222.md
@@ -1,0 +1,3 @@
+### Added
+
+- celery beat for configuring scheduled tasks from django admin

--- a/docs/celery.md
+++ b/docs/celery.md
@@ -4,7 +4,7 @@ We want to upgrade Django from the current version to at least 4. But our curren
 
 ## Developer Notes
 
-### configuration
+### Configuration
 
 The celery configuration file is `meinberlin/config/celery.py`.
 
@@ -25,7 +25,7 @@ CELERY_TASK_ALWAYS_EAGER = False
 
 and install and run the redis server on your system.
 
-### tasks
+### Tasks
 
 Celery is set up to autodiscover tasks. To register a task import the shared task decorator from celery and apply it to your task function.
 
@@ -44,10 +44,11 @@ $ celery --app meinberlin call dummy_task
 b5351175-335d-4be0-b1fa-06278a613ccf
 ```
 
-### makefile
+### Makefile
 
 We added three makefile commands:
 
-- `celery-worker-start` to start a worker node in the foreground
-- `celery-worker-status` to inspect registered tasks and running worker nodes
-- `celery-worker-dummy-task` to call the dummy task
+- `celery-worker-start` to start a worker in the foreground
+- `celery-worker-status` to inspect registered tasks and running workers
+- `celery-worker-dummy-task` to run the dummy task
+- `celery-beat` to run the dummy task

--- a/docs/celerybeat.md
+++ b/docs/celerybeat.md
@@ -1,0 +1,22 @@
+## Background
+
+Celery beat enables celery tasks to be scheduled in specific date and time for periodic/repetitive jobs or for scheduling one time tasks
+
+### Configuration
+
+Scheduled tasks are configured via the django admin in Periodic Tasks:
+To add/update a new scheduled task:
+- go to Periodic Tasks > Periodic tasks - add a new task from top right side.
+- give a name for the task
+- choose a task from the "Task (registered)"
+- tick the enabled box
+- add or choose a crontab schedule. [See crontab notation system](https://devhints.io/cron)
+- add a start datetime
+- check the box for one-off task if the task should run once
+- save
+
+### Makefile
+
+We added the makefile command:
+
+- `celery-beat` to start celery beat in the foreground. Requires celery worker to be running, [see](docs/celery.md)

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = (
     "ckeditor",
     "ckeditor_uploader",
     "django_filters",
+    "django_celery_beat",
     "easy_thumbnails",
     "rest_framework",
     "rules.apps.AutodiscoverRulesConfig",
@@ -577,3 +578,4 @@ CELERY_BROKER_URL = "redis://localhost:6379"
 CELERY_RESULT_BACKEND = "redis://localhost:6379"
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_RESULT_EXTENDED = True
+CELERY_TIMEZONE = "Europe/Berlin"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@ git+https://github.com/liqd/adhocracy4.git@db03f3478931a39013fa50de183d5042a6cc2
 
 # Additional requirements
 brotli==1.0.9
+django-celery-beat==2.5.0
 django-cloudflare-push==0.2.2
 django_csp==3.7
 redis==5.0.0


### PR DESCRIPTION
Celery tasks can become scheduled/periodic. Periodic tasks can be enabled via django admin
@goapunk salt has celerybeat enabled via the settings, so it should work directly without additional celery beat command:
https://github.com/liqd/admin/blob/13c6c912272de9b208a257c735397ac1fbbc38a7/salt/weblate/settings.py#L925