### PR TITLE
periodic task fix for footer update

### DIFF
--- a/meinberlin/apps/contrib/tasks.py
+++ b/meinberlin/apps/contrib/tasks.py
@@ -28,7 +28,7 @@ def download_footer(footer_url, filepath) -> bool:
         return True
 
 
-@shared_task
+@shared_task(name="periodic_footer_update")
 def periodic_footer_update() -> bool:
     """The task is called inline by contrib templatetag
     'get_external_footer'.


### PR DESCRIPTION
**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog

I found out that we cannot have both django admin dashboard configured tasks and from the settings. Also if we switch to settings configuration of periodic tasks, the following files will be created. So if we want to switch to that configuration, we need to update the celerybeat command with a path to save the following files in the admin repo. Let me know your preferences, knowing that:
- from django admin dashboard is more accessible, and can add it immediately, but need to add them manually in every environments.  
- for settings configuration, we need to update admin repo, and then only devs can add these tasks in django settings.py
```
        celerybeat-schedule.bak
	celerybeat-schedule.dat
	celerybeat-schedule.dir
```

