### PR TITLE
[7760] add topic prio list with viewset

### DIFF
--- a/changelog/7760.md
+++ b/changelog/7760.md
@@ -1,0 +1,4 @@
+## Added
+
+- viewset for topicprio list and filtering with template tag
+- react list component utilising card component to topicprio list template with webpack entrypoint and template tag

--- a/meinberlin/apps/topicprio/api.py
+++ b/meinberlin/apps/topicprio/api.py
@@ -1,0 +1,231 @@
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+from django.db.models import Model
+from django.db.models import QuerySet
+from django.utils.translation import gettext_lazy as _
+from rest_framework import mixins
+from rest_framework import viewsets
+from rest_framework.filters import BaseFilterBackend
+from rest_framework.filters import SearchFilter
+from rest_framework.pagination import BasePagination
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.serializers import ModelSerializer
+
+from adhocracy4.api.mixins import ModuleMixin
+from adhocracy4.categories import get_category_icon_url
+from adhocracy4.categories import has_icons
+from adhocracy4.categories.models import Category
+from adhocracy4.categories.models import CategoryAlias
+from adhocracy4.labels.models import Label
+from adhocracy4.labels.models import LabelAlias
+from adhocracy4.modules.models import Module
+from meinberlin.apps.contrib.api import APIPagination
+from meinberlin.apps.contrib.filters import DefaultsRestFilterSet
+from meinberlin.apps.contrib.filters import NoExceptionFilterBackend
+from meinberlin.apps.contrib.filters import OrderingFilterWithDailyRandom
+from meinberlin.apps.topicprio.filters import TopicFilterSet
+from meinberlin.apps.topicprio.models import Topic
+from meinberlin.apps.topicprio.serializers import TopicSerializer
+
+
+class TopicFilterInfoMixin:
+    """Add the filter information to the API response.
+    Any class extending this need to import the following mixins:
+        rest_framework.mixins.ListModelMixin
+        adhocracy4.api.mixins.ModuleMixin (or some other mixin that fetches the module)
+    """
+
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        filters = {}
+
+        # category filter
+        category_choices, category_icons = self.get_category_choices_and_icons()
+        if category_choices:
+            filters["category"] = {
+                "label": self.get_category_label(),
+                "choices": category_choices,
+            }
+            if category_icons:
+                filters["category"]["icons"] = category_icons
+
+        # label filter
+        label_choices = self.get_label_choices()
+        if label_choices:
+            filters["labels"] = {
+                "label": self.get_label_label(),
+                "choices": label_choices,
+            }
+
+        # ordering filter
+        ordering_choices = self.get_ordering_choices(request)
+        default_ordering = self.get_default_ordering()
+        filters["ordering"] = {
+            "label": _("Ordering"),
+            "choices": ordering_choices,
+            "default": default_ordering,
+        }
+
+        response = super().list(request, args, kwargs)
+        response.data["filters"] = filters
+        return response
+
+    def get_category_choices_and_icons(
+        self,
+    ) -> Tuple[List[Tuple[str, str]], Dict[str, str]]:
+        """Create the list of categories and icons for this module.
+        Returns:
+            A tuple with the category choices and category icons.
+        """
+        category_choices = category_icons = None
+        categories = Category.objects.filter(module=self.module)
+        if categories:
+            category_choices = [
+                ("", _("All")),
+            ]
+            if has_icons(self.module):
+                category_icons = []
+            for category in categories:
+                category_choices += ((str(category.pk), category.name),)
+                if has_icons(self.module):
+                    icon_name = getattr(category, "icon", None)
+                    icon_url = get_category_icon_url(icon_name)
+                    category_icons += ((str(category.pk), icon_url),)
+        return category_choices, category_icons
+
+    def get_category_label(self) -> str:
+        """Get the category label for this module
+        Returns:
+            category alias if set, otherwise translation of "Category".
+        """
+        category_alias = CategoryAlias.get_category_alias(self.module)
+        if category_alias:
+            return category_alias.title
+        return _("Category")
+
+    def get_label_choices(self) -> List[Tuple[str, str]]:
+        """Get the list of label choices.
+        Returns:
+            List of tuples containing the label pk and name
+        """
+        label_choices = None
+        labels = Label.objects.filter(module=self.module)
+        if labels:
+            label_choices = [
+                ("", _("All")),
+            ]
+            for label in labels:
+                label_choices += ((str(label.pk), label.name),)
+
+        return label_choices
+
+    def get_label_label(self) -> str:
+        """Get the label alias.
+        Returns:
+            label alias if set, otherwise translation of "Label".
+        """
+        label_alias = LabelAlias.get_label_alias(self.module)
+        if label_alias:
+            return label_alias.title
+        return _("Label")
+
+    def get_ordering_choices(self, request: Request) -> List[Tuple[str, str]]:
+        """Get the ordering choices.
+        Arguments:
+            request: may be used in subclasses.
+        Returns:
+            List of tuples containing the ordering and the name of the ordering.
+        """
+        ordering_choices = [
+            ("-comment_count", _("Most commented")),
+            ("dailyrandom", _("Random")),
+        ]
+
+        # only show sort by rating when rating is allowed at anytime in module
+        # like "view_rate_count" from PermissionInfoMixin
+        if self.module.has_feature("rate", self.model):
+            ordering_choices += (("-positive_rating_count", _("Most popular")),)
+
+        return ordering_choices
+
+    def get_default_ordering(self) -> str:
+        """Return current default of ordering filter."""
+        return "dailyrandom"
+
+
+class PermissionInfoMixin:
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        """Add the permission information to the API response.
+
+        Any class extending this need to import the following mixins:
+            rest_framework.mixins.ListModelMixin
+            adhocracy4.api.mixins.ModuleMixin (or some other mixin that fetches the module)
+        """
+        response = super().list(request, args, kwargs)
+        permissions = {
+            "view_comment_count": self.module.has_feature("comment", self.model),
+            "view_rate_count": self.module.has_feature("rate", self.model),
+        }
+
+        response.data["permissions"] = permissions
+        return response
+
+
+class BaseTopicViewSet(
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Base class for all Topic ViewSets.
+    Any class extending this needs to import or extend the following mixins:
+        adhocracy4.api.mixins.ModuleMixin
+        meinberlin.apps.Topics.api.TopicFilterInfoMixin
+        meinberlin.apps.Topics.api.PermissionInfoMixin
+    These imports are not included in this base class as their order
+    of import might need to change in a subclass.
+    """
+
+    model: Model = Topic
+    # pagination converts list into dict which is needed for permissions mixin
+    pagination_class: BasePagination = APIPagination
+    serializer_class: ModelSerializer = TopicSerializer
+    filter_backends: List[BaseFilterBackend] = (
+        NoExceptionFilterBackend,
+        OrderingFilterWithDailyRandom,
+        SearchFilter,
+    )
+    # this is used by TopicFilterBackend
+    filterset_class: DefaultsRestFilterSet = TopicFilterSet
+
+    ordering_fields: List[str] = (
+        "comment_count",
+        "positive_rating_count",
+        "dailyrandom",
+    )
+    search_fields: List[str] = ["name"]
+
+    @property
+    def ordering(self) -> List[str]:
+        return ["dailyrandom"]
+
+    def get_permission_object(self) -> Module:
+        return self.module
+
+    def get_queryset(self) -> QuerySet:
+        Topics = (
+            self.model.objects.filter(module=self.module)
+            .annotate_comment_count()
+            .annotate_negative_rating_count()
+            .annotate_positive_rating_count()
+            .order_by("-created")
+        )
+        return Topics
+
+
+class TopicViewSet(
+    ModuleMixin, TopicFilterInfoMixin, PermissionInfoMixin, BaseTopicViewSet
+):
+    """Provides a basic ViewSet for Topics."""
+
+    pass

--- a/meinberlin/apps/topicprio/filters.py
+++ b/meinberlin/apps/topicprio/filters.py
@@ -1,0 +1,16 @@
+from django_filters import rest_framework as rest_filters
+
+from adhocracy4.categories.models import Category
+from adhocracy4.labels.models import Label
+from meinberlin.apps.contrib.filters import DefaultsRestFilterSet
+
+
+class TopicFilterSet(DefaultsRestFilterSet):
+    """Base class which provides a FilterSet for topics.
+    Use with TopicFilterBackend.
+    """
+
+    category = rest_filters.ModelChoiceFilter(queryset=Category.objects.all())
+    labels = rest_filters.ModelChoiceFilter(queryset=Label.objects.all())
+
+    defaults = {}

--- a/meinberlin/apps/topicprio/serializers.py
+++ b/meinberlin/apps/topicprio/serializers.py
@@ -1,0 +1,50 @@
+from rest_framework import serializers
+
+from meinberlin.apps.topicprio.models import Topic
+
+
+class TopicSerializer(serializers.ModelSerializer):
+    comment_count = serializers.SerializerMethodField()
+    negative_rating_count = serializers.SerializerMethodField()
+    positive_rating_count = serializers.SerializerMethodField()
+    url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Topic
+        fields = (
+            "comment_count",
+            "name",
+            "negative_rating_count",
+            "positive_rating_count",
+            "pk",
+            "url",
+        )
+        read_only_fields = (
+            "comment_count",
+            "name",
+            "negative_rating_count",
+            "positive_rating_count",
+            "pk",
+            "url",
+        )
+
+    def get_comment_count(self, topic: Topic) -> int:
+        if hasattr(topic, "comment_count"):
+            return topic.comment_count
+        else:
+            return 0
+
+    def get_positive_rating_count(self, topic: Topic) -> int:
+        if hasattr(topic, "positive_rating_count"):
+            return topic.positive_rating_count
+        else:
+            return 0
+
+    def get_negative_rating_count(self, topic: Topic) -> int:
+        if hasattr(topic, "negative_rating_count"):
+            return topic.negative_rating_count
+        else:
+            return 0
+
+    def get_url(self, topic: Topic) -> str:
+        return topic.get_absolute_url()

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/includes/topic_list_item.html
@@ -1,4 +1,0 @@
-{% extends "meinberlin_ideas/includes/idea_list_item.html" %}
-
-{% block creator_info %}
-{% endblock %}

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_list.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_list.html
@@ -1,5 +1,10 @@
 {% extends extends %}
-{% load i18n module_tags rules static maps_tags %}
+{% load i18n module_tags react_topics rules static maps_tags %}
+
+{% block extra_js %}
+    <script type="text/javascript" src="{% static 'topics.js' %}"></script>
+    {{ block.super }}
+{% endblock %}
 
 {% block phase_content %}
     <div class="container u-spacer-top-double">
@@ -11,16 +16,10 @@
         <div class="container">
             <div class="offset-lg-2 col-lg-8">
                 {% if object_list.count > 0 %}
-                    <ul class="u-list-reset">
-                        {% for object in object_list %}
-                            {% include "meinberlin_topicprio/includes/topic_list_item.html" with object=object %}
-                        {% endfor %}
-                    </ul>
+                    {% react_topics view.module %}
                 {% else %}
                     {% translate "Nothing to show" %}
                 {% endif %}
-
-                {% include "meinberlin_contrib/includes/pagination.html" %}
             </div>
         </div>
     </div>

--- a/meinberlin/apps/topicprio/templatetags/react_topics.py
+++ b/meinberlin/apps/topicprio/templatetags/react_topics.py
@@ -1,0 +1,21 @@
+import json
+
+from django import template
+from django.urls import reverse
+from django.utils.html import format_html
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def react_topics(context, module):
+    topics_api_url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    attributes = {
+        "topics_api_url": topics_api_url,
+    }
+
+    return format_html(
+        '<div data-mb-widget="topics" ' 'data-attributes="{attributes}"></div>',
+        attributes=json.dumps(attributes),
+    )

--- a/meinberlin/assets/scss/components/_card.scss
+++ b/meinberlin/assets/scss/components/_card.scss
@@ -11,6 +11,10 @@
     &:first-child {
         margin-left: 0;
     }
+
+    b {
+        margin-right: 0.25 * $spacer;
+    }
 }
 
 .card__footer--light {

--- a/meinberlin/config/urls.py
+++ b/meinberlin/config/urls.py
@@ -35,6 +35,7 @@ from meinberlin.apps.plans.api import PlansListViewSet
 from meinberlin.apps.projectcontainers.api import ProjectContainerListViewSet
 from meinberlin.apps.projects.api import PrivateProjectListViewSet
 from meinberlin.apps.projects.api import ProjectListViewSet
+from meinberlin.apps.topicprio.api import TopicViewSet
 from meinberlin.apps.users.decorators import user_is_project_admin
 from meinberlin.apps.votes.api import TokenVoteViewSet
 from meinberlin.apps.votes.routers import TokenVoteDefaultRouter
@@ -61,6 +62,7 @@ module_router.register(r"documents", DocumentViewSet, basename="chapters")
 module_router.register(r"questions", LiveQuestionViewSet, basename="questions")
 module_router.register(r"proposals", ProposalViewSet, basename="proposals")
 module_router.register(r"ideas", IdeaViewSet, basename="ideas")
+module_router.register(r"topics", TopicViewSet, basename="topics")
 
 likes_router = LikesDefaultRouter()
 likes_router.register(r"likes", LikesViewSet, basename="likes")

--- a/meinberlin/react/contrib/Card.jsx
+++ b/meinberlin/react/contrib/Card.jsx
@@ -19,6 +19,7 @@ export const Card = (props) => {
       </header>
       <section className="card__footer--light">
         <CardStats
+          item={item}
           permissions={permissions}
           positiveCount={item.positive_rating_count}
           negativeCount={item.negative_rating_count}

--- a/meinberlin/react/contrib/CardStats.jsx
+++ b/meinberlin/react/contrib/CardStats.jsx
@@ -15,19 +15,19 @@ export const CardStats = (props) => {
       {/* ratings visible to admins in 1 and 2 phase budgeting due to `has_perm`  */}
       {permissions.view_rate_count && (
         <>
-          <p className="card__stat">{props.positiveCount} {positiveRatingsStr}</p>
-          <p className="card__stat">{props.negativeCount} {negativeRatingsStr}</p>
+          <p className="card__stat"><b>{props.positiveCount}</b>{positiveRatingsStr}</p>
+          <p className="card__stat"><b>{props.negativeCount}</b>{negativeRatingsStr}</p>
         </>
       )}
 
       {permissions.view_support_count && (
-        <p className="card__stat">{props.positiveCount} {supportStr}</p>
+        <p className="card__stat"><b>{props.positiveCount}</b>{supportStr}</p>
       )}
       {permissions.view_vote_count && (
-        <p className="card__stat">{props.voteCount} {votesStr}</p>
+        <p className="card__stat"><b>{props.voteCount}</b>{votesStr}</p>
       )}
       {permissions.view_comment_count && (
-        <p className="card__stat">{props.commentCount} {commentsStr}</p>
+        <p className="card__stat"><b>{props.commentCount}</b>{commentsStr}</p>
       )}
     </div>
   )

--- a/meinberlin/react/contrib/__tests__/Card.jest.jsx
+++ b/meinberlin/react/contrib/__tests__/Card.jest.jsx
@@ -23,9 +23,14 @@ test('Card component with item name and link and comment count', () => {
   render(
     <Card item={proposal} permissions={permissions} />
   )
+
+  const comments = screen.getByText('Comments', { exact: false })
+
+  expect(comments.textContent).toEqual('7Comments')
   expect(screen.getByText('My idea')).toBeTruthy()
   expect(screen.getByText('Item details')).toBeTruthy()
-  expect(screen.getByText('7 Comments')).toBeTruthy()
+  expect(screen.queryByText('Likes')).toBeNull()
+  expect(screen.queryByText('Votes')).toBeNull()
 })
 
 test('Renders a link to item details', () => {
@@ -49,9 +54,13 @@ test('Renders a link to item details', () => {
   render(
     <Card item={proposal} permissions={permissions} />
   )
+
+  const comments = screen.getByText('Comments', { exact: false })
+  const dislikes = screen.getByText('Dislikes', { exact: false })
+
+  expect(comments.textContent).toEqual('7Comments')
+  expect(dislikes.textContent).toEqual('1Dislikes')
+  expect(screen.getByText('Likes')).toBeTruthy()
   expect(screen.getByText('My idea')).toBeTruthy()
   expect(screen.getByText('Item details')).toBeTruthy()
-  expect(screen.getByText('7 Comments')).toBeTruthy()
-  expect(screen.getByText('2 Likes')).toBeTruthy()
-  expect(screen.getByText('1 Dislikes')).toBeTruthy()
 })

--- a/meinberlin/react/contrib/__tests__/CardStats.jest.jsx
+++ b/meinberlin/react/contrib/__tests__/CardStats.jest.jsx
@@ -19,10 +19,14 @@ test('2 phase: rating phase - can view comments and ratings count', () => {
       voteCount="7"
     />
   )
-  expect(screen.getByText('4 Likes')).toBeTruthy()
-  expect(screen.getByText('1 Dislikes')).toBeTruthy()
-  expect(screen.getByText('18 Comments')).toBeTruthy()
-  expect(screen.queryByText('7 Votes')).toBeNull()
+  const comments = screen.getByText('Comments', { exact: false })
+  const dislikes = screen.getByText('Dislikes', { exact: false })
+  // don't do same check for likes count as it also finds the
+  // dislikes as non exact string but 1 count is enough
+  expect(comments.textContent).toEqual('18Comments')
+  expect(dislikes.textContent).toEqual('1Dislikes')
+  expect(screen.getByText('Likes')).toBeTruthy()
+  expect(screen.queryByText('Votes')).toBeNull()
 })
 
 test('3 phase: support phase - can view comments and support count', () => {
@@ -42,10 +46,14 @@ test('3 phase: support phase - can view comments and support count', () => {
       voteCount="7"
     />
   )
-  expect(screen.getByText('4 Support')).toBeTruthy()
-  expect(screen.queryByText('1 Dislikes')).toBeNull()
-  expect(screen.getByText('18 Comments')).toBeTruthy()
-  expect(screen.queryByText('7 Votes')).toBeNull()
+  const comments = screen.getByText('Comments', { exact: false })
+  const likes = screen.getByText('Support', { exact: false })
+
+  expect(comments.textContent).toEqual('18Comments')
+  expect(likes.textContent).toEqual('4Support')
+  expect(screen.queryByText('Dislikes')).toBeNull()
+  expect(screen.queryByText('Likes')).toBeNull()
+  expect(screen.queryByText('Votes')).toBeNull()
 })
 
 test('3 phase: finished - can view comments and vote count', () => {
@@ -65,8 +73,12 @@ test('3 phase: finished - can view comments and vote count', () => {
       voteCount="7"
     />
   )
-  expect(screen.queryByText('4 Likes')).toBeNull()
-  expect(screen.queryByText('1 Dislikes')).toBeNull()
-  expect(screen.getByText('18 Comments')).toBeTruthy()
-  expect(screen.getByText('7 Votes')).toBeTruthy()
+  const comments = screen.getByText('Comments', { exact: false })
+  const votes = screen.getByText('Votes', { exact: false })
+
+  expect(comments.textContent).toEqual('18Comments')
+  expect(votes.textContent).toEqual('7Votes')
+
+  expect(screen.queryByText('Likes')).toBeNull()
+  expect(screen.queryByText('Dislikes')).toBeNull()
 })

--- a/meinberlin/react/topicprio/TopicPrioList.jsx
+++ b/meinberlin/react/topicprio/TopicPrioList.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react'
+import django from 'django'
+import { Card } from '../contrib/Card'
+
+export const TopicPrioList = (props) => {
+  const [data, setData] = useState([])
+  const [meta, setMeta] = useState([])
+
+  const translations = {
+    list: django.gettext('Topics list'),
+    pillList: django.gettext('Topic tags')
+  }
+
+  const fetchTopics = () => {
+    const url = props.topics_api_url
+    fetch(url)
+      .then(resp => resp.json())
+      .then(json => {
+        setData(json.results)
+        setMeta({
+          permissions: json.permissions
+        })
+      })
+      .catch(error => console.log(error))
+  }
+
+  useEffect(() => {
+    fetchTopics()
+  }, [])
+
+  const renderList = (data) => {
+    return (
+      <>
+        {data && data.map((topic, idx) =>
+          <li id={'item_' + topic.pk} key={'budgeting-topic-' + idx}>
+            <Card
+              item={topic}
+              permissions={meta?.permissions}
+            />
+          </li>)}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <h2 className="visually-hidden">{translations.list}</h2>
+      <ul className="u-list-reset">
+        {renderList(data)}
+      </ul>
+    </>
+  )
+}

--- a/meinberlin/react/topicprio/__tests__/TopicPrioList.jest.jsx
+++ b/meinberlin/react/topicprio/__tests__/TopicPrioList.jest.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, act, screen } from '@testing-library/react'
+import { TopicPrioList } from '../TopicPrioList'
+import { BrowserRouter } from 'react-router-dom'
+
+// permissions
+const permissions = {
+  view_rate_count: true,
+  view_comment_count: true
+}
+
+test('Topic Prioritisation list - check render with required stats',
+  async () => {
+    // sample data (one proposal item)
+    const mockedResults = [
+      {
+        comment_count: 6,
+        created: '2021-11-11T15:36:57.941072+01:00',
+        creator: 'admin',
+        is_archived: false,
+        name: 'This is a topic',
+        negative_rating_count: 1,
+        pk: 7,
+        positive_rating_count: 3,
+        url: '/topic/2021-00007/'
+      }
+    ]
+
+    // mimicking fetch response
+    const mockedFetch = Promise.resolve({
+      json: () => Promise.resolve({ results: mockedResults, permissions })
+    })
+
+    // overwrite global.fetch with mock function
+    global.fetch = jest.fn().mockImplementation(() => mockedFetch)
+
+    render(<BrowserRouter><TopicPrioList /></BrowserRouter>)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+
+    // waiting for async fetching ends --> without this, the
+    // act(...) console.error will appear
+    await act(() => mockedFetch)
+
+    const comments = screen.getByText('Comments', { exact: false })
+    const dislikes = screen.getByText('Dislikes', { exact: false })
+
+    expect(screen.getByText('This is a topic')).toBeTruthy()
+    expect(screen.getByText('Likes')).toBeTruthy()
+    expect(comments.textContent).toEqual('6Comments')
+    expect(dislikes.textContent).toEqual('1Dislikes')
+
+    // reverse overwrite of global.fetch
+    await global.fetch.mockClear()
+  })

--- a/meinberlin/react/topicprio/react_topics_init.jsx
+++ b/meinberlin/react/topicprio/react_topics_init.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { widget as ReactWidget } from 'adhocracy4'
+import { TopicPrioList } from './TopicPrioList.jsx'
+
+function init () {
+  ReactWidget.initialise('mb', 'topics',
+    function (el) {
+      const props = JSON.parse(el.getAttribute('data-attributes'))
+      const root = createRoot(el)
+      root.render(
+        <React.StrictMode>
+          <TopicPrioList {...props} />
+        </React.StrictMode>
+      )
+    }
+  )
+}
+
+document.addEventListener('DOMContentLoaded', init, false)

--- a/tests/topicprio/test_topic_api.py
+++ b/tests/topicprio/test_topic_api.py
@@ -1,0 +1,33 @@
+import pytest
+from django.urls import reverse
+
+from adhocracy4.test.helpers import freeze_phase
+from adhocracy4.test.helpers import freeze_pre_phase
+from adhocracy4.test.helpers import setup_phase
+from meinberlin.apps.topicprio import phases
+
+
+@pytest.mark.django_db
+def test_topic_list_mixins(apiclient, phase_factory, topic_factory):
+    prioritize_phase, module, project, topic = setup_phase(
+        phase_factory, topic_factory, phases.PrioritizePhase
+    )
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    response = apiclient.get(url)
+
+    # permission info
+    assert "permissions" in response.data
+    with freeze_pre_phase(prioritize_phase):
+        response = apiclient.get(url)
+        assert response.data["permissions"]["view_rate_count"]
+        assert response.data["permissions"]["view_comment_count"]
+
+    with freeze_phase(prioritize_phase):
+        response = apiclient.get(url)
+        assert response.data["permissions"]["view_rate_count"]
+        assert response.data["permissions"]["view_comment_count"]
+
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})

--- a/tests/topicprio/test_topic_api_filtering.py
+++ b/tests/topicprio/test_topic_api_filtering.py
@@ -1,0 +1,432 @@
+import pytest
+from dateutil.parser import parse
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from freezegun import freeze_time
+
+from adhocracy4.test.helpers import freeze_phase
+from adhocracy4.test.helpers import setup_phase
+from meinberlin.apps.topicprio import phases
+
+
+@pytest.mark.django_db
+def test_topic_list_filter_mixin(
+    apiclient,
+    group_factory,
+    phase_factory,
+    topic_factory,
+    category_factory,
+    category_alias_factory,
+    label_factory,
+    label_alias_factory,
+):
+    prioritize_phase, module, project, topic = setup_phase(
+        phase_factory, topic_factory, phases.PrioritizePhase
+    )
+
+    group_pro = group_factory()
+    project.group = group_pro
+    project.save()
+
+    category1 = category_factory(module=module)
+    category2 = category_factory(module=module)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    response = apiclient.get(url)
+
+    # filter info
+    assert "filters" in response.data
+    assert len(response.data["filters"]) == 2
+
+    assert "category" in response.data["filters"]
+    assert response.data["filters"]["category"]["label"] == _("Category")
+    assert response.data["filters"]["category"]["choices"][0] == ("", _("All"))
+    assert (str(category1.pk), category1.name) in response.data["filters"]["category"][
+        "choices"
+    ]
+    assert (str(category2.pk), category2.name) in response.data["filters"]["category"][
+        "choices"
+    ]
+    # with category alias
+    category_alias = category_alias_factory(module=module)
+    response = apiclient.get(url)
+    assert "category" in response.data["filters"]
+    assert response.data["filters"]["category"]["label"] == category_alias.title
+
+    assert "ordering" in response.data["filters"]
+    assert response.data["filters"]["ordering"]["label"] == _("Ordering")
+    assert "labels" not in response.data["filters"]
+
+    # with labels
+    label1 = label_factory(module=module)
+    label2 = label_factory(module=module)
+    response = apiclient.get(url)
+    assert "filters" in response.data
+    assert len(response.data["filters"]) == 3
+    assert "labels" in response.data["filters"]
+    assert response.data["filters"]["labels"]["label"] == _("Label")
+    assert (str(label1.pk), label1.name) in response.data["filters"]["labels"][
+        "choices"
+    ]
+    assert (str(label2.pk), label2.name) in response.data["filters"]["labels"][
+        "choices"
+    ]
+    # with label_alias
+    label_alias = label_alias_factory(module=module)
+    response = apiclient.get(url)
+    assert "labels" in response.data["filters"]
+    assert response.data["filters"]["labels"]["label"] == label_alias.title
+
+    # ordering choices in different phases
+
+    # module has already finished without freeze_time
+    assert response.data["filters"]["ordering"]["choices"] == [
+        ("-comment_count", _("Most commented")),
+        ("dailyrandom", _("Random")),
+        ("-positive_rating_count", _("Most popular")),
+    ]
+    assert response.data["filters"]["ordering"]["default"] == "dailyrandom"
+
+    with freeze_phase(prioritize_phase):
+        response = apiclient.get(url)
+    assert response.data["filters"]["ordering"]["choices"] == [
+        ("-comment_count", _("Most commented")),
+        ("dailyrandom", _("Random")),
+        ("-positive_rating_count", _("Most popular")),
+    ]
+    assert response.data["filters"]["ordering"]["default"] == "dailyrandom"
+
+
+@pytest.mark.django_db
+def test_topic_category_filter(
+    apiclient, module, topic_factory, category_factory, phase_factory
+):
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+
+    category1 = category_factory(module=module)
+    category2 = category_factory(module=module)
+
+    topic_cat1 = topic_factory(module=module, category=category1)
+    topic_factory(module=module, category=category2)
+    topic_factory(module=module, category=category2)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    response = apiclient.get(url)
+    assert len(response.data["results"]) == 3
+
+    querystring = "?category=" + str(category1.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["pk"] == topic_cat1.pk
+
+    querystring = "?category=" + str(category2.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 2
+
+
+@pytest.mark.django_db
+def test_topic_category_alias_filter(
+    apiclient,
+    module,
+    topic_factory,
+    category_factory,
+    category_alias_factory,
+    phase_factory,
+):
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+
+    category_alias = category_alias_factory(module=module)
+    category1 = category_factory(module=module)
+    category2 = category_factory(module=module)
+
+    topic_cat1 = topic_factory(module=module, category=category1)
+    topic_factory(module=module, category=category2)
+    topic_factory(module=module, category=category2)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    response = apiclient.get(url)
+    "category" in response.data["filters"]
+    assert response.data["filters"]["category"]["label"] == category_alias.title
+
+    assert len(response.data["results"]) == 3
+
+    querystring = "?category=" + str(category1.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["pk"] == topic_cat1.pk
+
+    querystring = "?category=" + str(category2.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 2
+
+
+@pytest.mark.django_db
+def test_topic_label_filter(
+    apiclient, module, topic_factory, label_factory, phase_factory
+):
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+
+    label1 = label_factory(module=module)
+    label2 = label_factory(module=module)
+
+    topic_1 = topic_factory(module=module)
+    topic_1.labels.set([label1])
+    topic_2 = topic_factory(module=module)
+    topic_2.labels.set([label1, label2])
+    topic_factory(module=module)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    response = apiclient.get(url)
+    assert len(response.data["results"]) == 3
+
+    querystring = "?labels=" + str(label1.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 2
+
+    querystring = "?labels=" + str(label2.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["pk"] == topic_2.pk
+
+
+@pytest.mark.django_db
+def test_topic_search_filter(apiclient, module, topic_factory, phase_factory):
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+
+    now = parse("2022-01-02 18:00:00 UTC")
+    yesterday = now - timezone.timedelta(days=1)
+    last_week = now - timezone.timedelta(days=7)
+
+    topic_1 = topic_factory(pk=1, module=module, name="liqd topic", created=now)
+    topic_factory(pk=2, module=module, name="other topic", created=last_week)
+    topic_factory(
+        pk=3, module=module, name="liqd has a lot of creativity", created=yesterday
+    )
+    topic_factory(pk=4, module=module, name="topic from 2021", created=yesterday)
+    topic_factory(pk=5, module=module, name="blabla", created=yesterday)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    response = apiclient.get(url)
+    assert len(response.data["results"]) == 5
+
+    querystring = "?search=liqd+topic"
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["pk"] == topic_1.pk
+
+    querystring = "?search=liqd"
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 2
+
+    querystring = "?search=2021"
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+
+    querystring = "?search=2021-00"
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 0
+
+    querystring = "?search="
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 5
+
+
+@pytest.mark.django_db
+def test_topics_ordering_filter(
+    apiclient,
+    module,
+    topic_factory,
+    comment_factory,
+    rating_factory,
+    phase_factory,
+):
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+
+    topic_factory(pk=3, module=module)
+    topic_popular = topic_factory(pk=4, module=module)
+    rating_factory(content_object=topic_popular)
+    rating_factory(content_object=topic_popular)
+
+    topic_commented = topic_factory(pk=5, module=module)
+    comment_factory(content_object=topic_commented)
+
+    topic_factory(pk=6, module=module)
+
+    topic_2_popular = topic_factory(pk=7, module=module)
+    rating_factory(content_object=topic_2_popular)
+
+    topic_factory(pk=8, module=module)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    # positive rating
+    querystring = "?ordering=-positive_rating_count"
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 6
+    assert response.data["results"][0]["pk"] == topic_popular.pk
+    assert response.data["results"][1]["pk"] == topic_2_popular.pk
+
+    # most commented
+    querystring = "?ordering=-comment_count"
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 6
+    assert response.data["results"][0]["pk"] == topic_commented.pk
+
+    # daily random
+    querystring = "?ordering=dailyrandom"
+    url_tmp = url + querystring
+    with freeze_time("2020-01-01 00:00:00 UTC"):
+        response = apiclient.get(url_tmp)
+    ordered_pks = [topic["pk"] for topic in response.data["results"]]
+    assert ordered_pks == [4, 5, 8, 3, 6, 7]
+    with freeze_time("2022-01-01 00:00:00 UTC"):
+        response = apiclient.get(url_tmp)
+    ordered_pks = [topic["pk"] for topic in response.data["results"]]
+    assert ordered_pks == [4, 7, 6, 5, 3, 8]
+
+
+@pytest.mark.django_db
+def test_topics_default_ordering_filter(
+    apiclient,
+    module,
+    phase_factory,
+    topic_factory,
+    rating_factory,
+):
+    prioritize_phase = phase_factory(
+        phase_content=phases.PrioritizePhase(),
+        module=module,
+        start_date=parse("2022-01-01 00:00:00 UTC"),
+        end_date=parse("2022-01-01 10:00:00 UTC"),
+    )
+    voting_phase = phase_factory(
+        phase_content=phases.PrioritizePhase(),
+        module=module,
+        start_date=parse("2022-01-01 14:00:00 UTC"),
+        end_date=parse("2022-01-01 18:00:00 UTC"),
+    )
+
+    between_phases = parse("2022-01-01 12:00:00 UTC")
+    module_ended = parse("2022-01-01 19:00:00 UTC")
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    topic_factory(pk=1, module=module)
+    topic_2 = topic_factory(pk=2, module=module)
+    topic_3 = topic_factory(pk=3, module=module)
+
+    rating_factory(content_object=topic_2, value=1)
+    rating_factory(content_object=topic_2, value=1)
+    rating_factory(content_object=topic_3, value=1)
+
+    # dailyrandom is default during collect
+    # dailyrandom order for '2022-01-01' is [2, 1, 3]
+    with freeze_phase(prioritize_phase):
+        response = apiclient.get(url)
+    ordered_pks = [topic["pk"] for topic in response.data["results"]]
+    assert ordered_pks == [2, 1, 3]
+
+    # dailyrandom is default between collect and feedback
+    with freeze_time(between_phases):
+        response = apiclient.get(url)
+    ordered_pks = [topic["pk"] for topic in response.data["results"]]
+    assert ordered_pks == [2, 1, 3]
+
+    # dailyrandom is default during feedback
+    with freeze_phase(voting_phase):
+        response = apiclient.get(url)
+    ordered_pks = [topic["pk"] for topic in response.data["results"]]
+    assert ordered_pks == [2, 1, 3]
+
+    # daily_random is default after phases have ended
+    with freeze_time(module_ended):
+        response = apiclient.get(url)
+    ordered_pks = [topic["pk"] for topic in response.data["results"]]
+    assert ordered_pks == [2, 1, 3]
+
+
+@pytest.mark.django_db
+def test_topic_filter_combinations(
+    apiclient,
+    module,
+    topic_factory,
+    category_factory,
+    comment_factory,
+    rating_factory,
+    label_factory,
+    phase_factory,
+):
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+
+    category1 = category_factory(module=module)
+    category2 = category_factory(module=module)
+    label1 = label_factory(module=module)
+    label2 = label_factory(module=module)
+
+    now = parse("2022-01-01 18:00:00 UTC")
+    yesterday = now - timezone.timedelta(days=1)
+    last_week = now - timezone.timedelta(days=7)
+
+    topic_factory(pk=1, module=module, created=now)
+    topic_factory(pk=2, module=module, created=last_week, name="liqd topic")
+
+    topic_popular_labels = topic_factory(pk=4, module=module, created=yesterday)
+    topic_popular_labels.labels.set([label1, label2])
+    rating_factory(content_object=topic_popular_labels)
+    rating_factory(content_object=topic_popular_labels)
+
+    topic_commented = topic_factory(pk=5, module=module, created=yesterday)
+    comment_factory(content_object=topic_commented)
+
+    topic_factory(pk=6, module=module, created=yesterday, category=category1)
+
+    topic_cat2_popular = topic_factory(
+        pk=7, module=module, created=yesterday, category=category2
+    )
+    rating_factory(content_object=topic_cat2_popular)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+
+    # combinations
+    querystring = "?category=" + str(category2.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["pk"] == topic_cat2_popular.pk
+
+    querystring = "?search=2022-"
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 0
+
+    querystring = "?ordering=-positive_rating_count&labels=" + str(label1.pk)
+    url_tmp = url + querystring
+    response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["pk"] == topic_popular_labels.pk
+
+    querystring = "?ordering=dailyrandom&category=" + str(category2.pk)
+    url_tmp = url + querystring
+    with freeze_time("2020-01-01 00:00:00 UTC"):
+        response = apiclient.get(url_tmp)
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["pk"] == topic_cat2_popular.pk

--- a/tests/topicprio/test_topics_api_pagination.py
+++ b/tests/topicprio/test_topics_api_pagination.py
@@ -1,0 +1,33 @@
+import pytest
+from django.urls import reverse
+
+from meinberlin.apps.topicprio import phases
+
+
+@pytest.mark.django_db
+def test_topic_list_pagination(apiclient, module, topic_factory, phase_factory):
+    phase_factory(phase_content=phases.PrioritizePhase(), module=module)
+
+    url = reverse("topics-list", kwargs={"module_pk": module.pk})
+    response = apiclient.get(url)
+    pagesize = response.data["page_size"]
+    num_props = pagesize * 3 + 1
+
+    for i in range(num_props):
+        topic_factory(module=module)
+
+    response = apiclient.get(url)
+
+    assert "count" in response.data
+    assert "page_count" in response.data
+    assert response.data["count"] == num_props
+    assert response.data["next"].endswith("?page=2")
+    assert not response.data["previous"]
+    assert response.data["page_count"] == 4
+    assert len(response.data["results"]) == pagesize
+
+    url_tmp = url + "?page=4"
+    response = apiclient.get(url_tmp)
+    assert not response.data["next"]
+    assert response.data["previous"].endswith("?page=3")
+    assert len(response.data["results"]) == 1

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -105,6 +105,9 @@ module.exports = {
     react_map_teaser: {
       import: './meinberlin/react/plans/react_map_teaser.jsx'
     },
+    topics: {
+      import: './meinberlin/react/topicprio/react_topics_init.jsx'
+    },
     wagtail: {
       import: './meinberlin/assets/js/wagtail.js'
     },


### PR DESCRIPTION
**Tasks**
- [x] PR name contains story or task reference
- [x] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog

As topics are different to ideas and have less things I didn't extend the idea view set but gave topics it's own that can also be used in topic maps, but if this isn't correct please let me know!