### PR TITLE
remove warning message from ModeratorStatus

### DIFF
--- a/changelog/_7770.md
+++ b/changelog/_7770.md
@@ -1,0 +1,3 @@
+## Changed
+
+- removed warning from ModeratorStatus.jsx

--- a/meinberlin/react/contrib/ModeratorStatus.jsx
+++ b/meinberlin/react/contrib/ModeratorStatus.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import django from 'django'
 
 const translated = {
@@ -7,12 +7,6 @@ const translated = {
 }
 
 export const ModeratorStatus = ({ modStatus, modStatusDisplay }) => {
-  useEffect(() => {
-    if (!modStatus || !modStatusDisplay) {
-      console.warn('ModeratorStatus component: Both modStatus and modStatusDisplay props are required.')
-    }
-  }, [modStatus, modStatusDisplay])
-
   if (!modStatus || !modStatusDisplay) {
     return null // Don't render the component if either prop is missing
   }


### PR DESCRIPTION
removing the warning message, since it gets triggered every time ModeratorStatus receives no props. This will trigger warnings every time a card has no status assigned to it.