### PR TITLE
deps: remove obsolete eslint-n as no node.js only npm used

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,18 +23,12 @@
     "standard-jsx",
     "plugin:jsx-a11y/recommended",
     "plugin:react/recommended",
-    "plugin:import/recommended",
-    "plugin:n/recommended"
+    "plugin:import/recommended"
   ],
   "rules": {
     "jsx-quotes": [2, "prefer-double"],
     "jsx-a11y/no-onchange": "off",
     "react/prop-types": "off",
-    "n/no-missing-require": "off",
-    "n/no-unsupported-features/es-syntax": "off",
-    "n/no-missing-import": "off",
-    "n/no-unpublished-import": "off",
-    "n/no-extraneous-import": "off",
     "no-restricted-syntax": ["error", "TemplateLiteral"]
   },
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jest": "27.2.3",
     "eslint-plugin-jsx-a11y": "6.7.1",
-    "eslint-plugin-n": "15.7.0",
     "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-react": "7.32.2",
     "husky": "8.0.3",


### PR DESCRIPTION
**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
