### PR TITLE
[7861] templates/*_detail: cleaning out old code and old classes from detail pages

### DIFF
--- a/changelog/_9876.md
+++ b/changelog/_9876.md
@@ -1,0 +1,4 @@
+### Change
+
+- removed old breadcrumb code from idea/proposal detail, create and moderate templates
+- removed old class names from idea/proposal detail, create and moderate templates

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_create_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_create_form.html
@@ -20,26 +20,14 @@
 {% endblock %}
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'map' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Submit a new proposal for this project' %}</h1>
 
-        <h1>{% translate 'Submit a new proposal for this project' %}</h1>
-
-        {% if form.errors %}
-        <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
-            {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
-        </div>
-        {% endif %}
-
-        {% include "meinberlin_budgeting/includes/proposal_form.html" with proposal=proposal cancel=module.get_detail_url %}
+    {% if form.errors %}
+    <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
+        {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
     </div>
+    {% endif %}
+
+    {% include "meinberlin_budgeting/includes/proposal_form.html" with proposal=proposal cancel=module.get_detail_url %}
 </div>
 {% endblock %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
@@ -23,46 +23,28 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'map' %}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'proposal' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Moderate proposal' %}</h1>
 
-        <h1>{% translate 'Moderate proposal' %}</h1>
+    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+        {% csrf_token %}
+        {% for form in forms.values %}
+            {{ form.media }}
+        {% endfor %}
 
-        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-            {% csrf_token %}
-            {% for form in forms.values %}
-                {{ form.media }}
-            {% endfor %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
+        {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=forms.moderateable.is_archived %}
+        {% if forms.moderateable.show_tasks %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.completed_tasks add_class='u-top-divider' %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark %}
+        {% else %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark add_class='u-top-divider' %}
+        {% endif %}
 
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
-            {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=forms.moderateable.is_archived %}
-            {% if forms.moderateable.show_tasks %}
-                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.completed_tasks add_class='u-top-divider' %}
-                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark %}
-            {% else %}
-                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark add_class='u-top-divider' %}
-            {% endif %}
-
-            <div class="u-spacer-bottom">
-                <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-                <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-            </div>
-        </form>
-
-    </div>
+        <div class="u-spacer-bottom">
+            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
+            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
+        </div>
+    </form>
 </div>
 {% endblock %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_update_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_update_form.html
@@ -23,31 +23,14 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'map' %}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'proposal' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Edit proposal' %}</h1>
 
-        <h1>{% translate 'Edit proposal' %}</h1>
-
-        {% if form.errors %}
-        <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
-            {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
-        </div>
-        {% endif %}
-
-        {% include "meinberlin_budgeting/includes/proposal_form.html" with proposal=proposal cancel=object.get_absolute_url %}
+    {% if form.errors %}
+    <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
+        {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
     </div>
+    {% endif %}
+
+    {% include "meinberlin_budgeting/includes/proposal_form.html" with proposal=proposal cancel=object.get_absolute_url %}
 </div>
 {% endblock %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/components/breadcrumb.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/components/breadcrumb.html
@@ -4,7 +4,7 @@
           <ol>
               <li><a href="">Project Overview</a></li>
               <li><a href="">Liqd Project</a></li>
-              <li class=""active"" aria-current="page">Brainstorming</li>
+              <li class="active" aria-current="page">Brainstorming</li>
           </ol>
       </nav>
   </div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -22,242 +22,241 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    {% if back %}
-                    <a href="{{ back }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% if back_string %}
-                            {{ back_string }}
-                        {% else %}
-                            {% translate 'map' %}
-                        {% endif %}
-                    </a>
+    <!-- FIXME left in as the back template tag maybe useful but not sure yet, to be removed before release if not used -->
+    <!-- <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
+        <ul>
+            <li>
+                {% if back %}
+                <a href="{{ back }}">
+                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                    {% if back_string %}
+                        {{ back_string }}
                     {% else %}
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back' %}
-                    </a>
+                        {% translate 'map' %}
                     {% endif %}
-                </li>
-            </ul>
-        </nav>
-        <article >
-            <div class="item-detail">
-                <h1 class="item-detail__title">{{ object.name }}</h1>
+                </a>
+                {% else %}
+                <a href="{{ module.get_detail_url }}">
+                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                    {% translate 'back' %}
+                </a>
+                {% endif %}
+            </li>
+        </ul>
+    </nav> -->
+    <article >
+        <div class="item-detail">
+            <h1 class="item-detail__title">{{ object.name }}</h1>
 
-                {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
+            {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
 
-                <div class="item-detail__content">
-                    <div class="item-detail__basic-content">
-                        <img class="item-detail__hero-image" src="{% thumbnail object.image 'item_image' %}" alt="">
-                        {{ object.description | richtext }}
-                    </div>
-
-                    {% block additional_content %}{% endblock %}
+            <div class="item-detail__content">
+                <div class="item-detail__basic-content">
+                    <img class="item-detail__hero-image" src="{% thumbnail object.image 'item_image' %}" alt="">
+                    {{ object.description | richtext }}
                 </div>
 
-                <div class="item-detail__meta lr-bar">
-                    <div class="lr-bar__left">
-                        <strong class="item-detail__creator">{{ object.creator.username }}</strong>
-                        {% if object.modified %}
-                            {% translate 'updated on ' %}{% html_date object.modified class='list-item__date' %}
-                        {% else %}
-                            {% translate 'created on ' %}{% html_date object.created class='list-item__date' %}
-                        {% endif %}
-                    </div>
-                    <div class="lr-bar__right item-detail__ref">
-                        <strong>{% translate 'Reference No.' %}:</strong>
-                        {{ object.reference_number }}
-                    </div>
-                </div>
+                {% block additional_content %}{% endblock %}
+            </div>
 
-                <div class="item-detail__actions lr-bar">
-                    {% block ratings %}
-                        {% if object|has_feature:"rate" %}
-                            <div class="lr-bar__left">
-                                {% react_ratings object %}
-                            </div>
-                        {% endif %}
-                    {% endblock %}
-
-                    {% get_item_change_permission object as change_perm %}
-                    {% has_perm change_perm request.user object as user_may_change %}
-                    {% get_item_permission object 'moderate' as moderate_perm %}
-                    {% has_perm moderate_perm request.user object as is_moderator %}
-
-
-                    <div class="lr-bar__right">
-
-                    {% if request.user.is_authenticated %}
-                        <div class="dropdown">
-                            <button
-                                    title="{% translate 'Actions' %}"
-                                    type="button"
-                                    class="dropdown-toggle btn btn--light btn--small"
-                                    data-bs-toggle="dropdown"
-                                    data-flip="false"
-                                    aria-haspopup="true"
-                                    aria-expanded="false"
-                                    id="idea-{{ object.pk }}-actions"
-                            >
-                                <i class="fa fa-ellipsis-h" aria-label="{% translate 'Actions' %}"></i>
-                            </button>
-                            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="idea-{{ object.pk }}-actions">
-                                {% if user_may_change %}
-                                    {% get_item_update_url object as change_url %}
-                                    <a class="dropdown-item" href="{{ change_url }}">{% translate 'edit' %}</a>
-                                    {% get_item_delete_url object as delete_url %}
-                                    <a class="dropdown-item" href="{{ delete_url }}">{% translate 'delete' %}</a>
-                                {% endif %}
-                                {% get_item_url object 'moderate' False as moderate_url %}
-                                {% if is_moderator and moderate_url %}
-                                    <a class="dropdown-item" href="{{ moderate_url }}">{% translate 'moderate' %}</a>
-                                {% endif %}
-
-                                {% block dropdown_items %}{% endblock %}
-                                <li>
-                                    {% translate 'report' as report_text %}
-                                    {% react_reports object text=report_text class='dropdown-item' %}
-                                </li>
-                            </div>
-                        </div>
+            <div class="item-detail__meta lr-bar">
+                <div class="lr-bar__left">
+                    <strong class="item-detail__creator">{{ object.creator.username }}</strong>
+                    {% if object.modified %}
+                        {% translate 'updated on ' %}{% html_date object.modified class='list-item__date' %}
+                    {% else %}
+                        {% translate 'created on ' %}{% html_date object.created class='list-item__date' %}
                     {% endif %}
-                    </div>
+                </div>
+                <div class="lr-bar__right item-detail__ref">
+                    <strong>{% translate 'Reference No.' %}:</strong>
+                    {{ object.reference_number }}
                 </div>
             </div>
-            {% block vote_button %}{% endblock %}
 
-            {% block moderator_feedback %}
-            {% if object.moderator_feedback_text.feedback_text or object.moderator_status or is_moderator  %}
-                    <section class="detail-info__accordion">
-                        <details class="accordion" open>
-                            <summary class="detail-info__accordion-title">
-                                <h2 class="detail-info__title">{% translate 'Feedback' %}</h2>
-                                    {% if is_moderator %}
-                                        {% get_item_url object 'moderate' False as moderate_url %}
-                                        {% if moderate_url %}
-                                        <div class="detail-info__edit-btn">
-                                            <a
-                                                href="{{ moderate_url }}"
-                                                class="btn btn--small detail-info__btn"
-                                                data-embed-target="external">
-                                                    <i class="fas fa-pencil" aria-hidden="true"></i>
-                                                    {% translate 'Edit' %}
-                                            </a>
-                                        </div>
-                                        {% endif %}
-                                    {% endif %}
-                                {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
-                                    <i class="fa fa-chevron-down detail-info__collapse-btn" aria-hidden="true"></i>
-                                {% endif %}
-                            </summary>
-                            {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
-                            <div class="detail-info__accordion-body">
-                                {% if object.moderator_status %}
-                                    {% with feedback_classification=object.moderator_status|classify|lower %}
-                                        <h3 class="detail-info__section-title">{% translate 'Status' %}</h3>
-                                        <div class="detail-info__status-line--{{ feedback_classification }}"></div>
-                                        <div class="detail-info__status-icon--{{ feedback_classification }}">
-                                            {% if feedback_classification == 'consideration' or feedback_classification == 'qualified' %}
-                                                <i class="fa-solid fa-circle-half-stroke fa-rotate-270"></i>
-                                            {% elif feedback_classification == 'rejected' %}
-                                                <i class="fa-solid fa-circle-xmark"></i>
-                                            {% elif feedback_classification == 'accepted' %}
-                                                <i class="fas fa-check-circle"></i>
-                                            {% endif%}
-                                            <span class="detail-info__status-label">
-                                                {{ object.get_moderator_status_display }}
-                                            </span>
-                                        </div>
-                                    {% endwith %}
-                                {% endif %}
-                                {% if object.moderator_feedback_text.feedback_text %}
-                                <div class="detail-info__section--no-border">
-                                    <strong class="u-spacer-right">
-                                        {{ object.module.project.organisation.name }}
-                                    </strong>
-                                    {% if object.moderator_feedback_text.modified %}
-                                    {% translate 'updated on ' %}{% html_date object.moderator_feedback_text.modified %}
-                                    {% else %}
-                                    {% translate 'created on ' %}{% html_date object.moderator_feedback_text.created %}
-                                    {% endif %}
-                                </div>
-                                {% endif %}
-                                <p class="u-spacer-top-half">
-                                    {{ object.moderator_feedback_text.feedback_text | safe }}
-                                </p>
-                            </div>
+            <div class="item-detail__actions lr-bar">
+                {% block ratings %}
+                    {% if object|has_feature:"rate" %}
+                        <div class="lr-bar__left">
+                            {% react_ratings object %}
+                        </div>
+                    {% endif %}
+                {% endblock %}
+
+                {% get_item_change_permission object as change_perm %}
+                {% has_perm change_perm request.user object as user_may_change %}
+                {% get_item_permission object 'moderate' as moderate_perm %}
+                {% has_perm moderate_perm request.user object as is_moderator %}
+
+
+                <div class="lr-bar__right">
+
+                {% if request.user.is_authenticated %}
+                    <div class="dropdown">
+                        <button
+                                title="{% translate 'Actions' %}"
+                                type="button"
+                                class="dropdown-toggle btn btn--light btn--small"
+                                data-bs-toggle="dropdown"
+                                data-flip="false"
+                                aria-haspopup="true"
+                                aria-expanded="false"
+                                id="idea-{{ object.pk }}-actions"
+                        >
+                            <i class="fa fa-ellipsis-h" aria-label="{% translate 'Actions' %}"></i>
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="idea-{{ object.pk }}-actions">
+                            {% if user_may_change %}
+                                {% get_item_update_url object as change_url %}
+                                <a class="dropdown-item" href="{{ change_url }}">{% translate 'edit' %}</a>
+                                {% get_item_delete_url object as delete_url %}
+                                <a class="dropdown-item" href="{{ delete_url }}">{% translate 'delete' %}</a>
                             {% endif %}
-                        </details>
-                    </section>
-            {% endif %}
-        {% endblock %}
+                            {% get_item_url object 'moderate' False as moderate_url %}
+                            {% if is_moderator and moderate_url %}
+                                <a class="dropdown-item" href="{{ moderate_url }}">{% translate 'moderate' %}</a>
+                            {% endif %}
 
-        {% block moderation_info %}
-            {% if is_moderator and module.blueprint_type in 'PB3,PB2,PB' %}
+                            {% block dropdown_items %}{% endblock %}
+                            <li>
+                                {% translate 'report' as report_text %}
+                                {% react_reports object text=report_text class='dropdown-item' %}
+                            </li>
+                        </div>
+                    </div>
+                {% endif %}
+                </div>
+            </div>
+        </div>
+        {% block vote_button %}{% endblock %}
+
+        {% block moderator_feedback %}
+        {% if object.moderator_feedback_text.feedback_text or object.moderator_status or is_moderator  %}
                 <section class="detail-info__accordion">
                     <details class="accordion" open>
                         <summary class="detail-info__accordion-title">
-                            <h2 class="detail-info__title">{% translate 'Moderation' %}</h2>
-                            {% get_item_url object 'moderate' False as moderate_url %}
-                            {% if moderate_url %}
-                            <div class="detail-info__edit-btn">
-                                <a
-                                    href="{{ moderate_url }}"
-                                    class="btn btn--small detail-info__btn"
-                                    data-embed-target="external">
-                                        <i class="fas fa-pencil" aria-hidden="true"></i>
-                                        {% translate 'Edit' %}
-                                </a>
+                            <h2 class="detail-info__title">{% translate 'Feedback' %}</h2>
+                                {% if is_moderator %}
+                                    {% get_item_url object 'moderate' False as moderate_url %}
+                                    {% if moderate_url %}
+                                    <div class="detail-info__edit-btn">
+                                        <a
+                                            href="{{ moderate_url }}"
+                                            class="btn btn--small detail-info__btn"
+                                            data-embed-target="external">
+                                                <i class="fas fa-pencil" aria-hidden="true"></i>
+                                                {% translate 'Edit' %}
+                                        </a>
+                                    </div>
+                                    {% endif %}
+                                {% endif %}
+                            {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
+                                <i class="fa fa-chevron-down detail-info__collapse-btn" aria-hidden="true"></i>
+                            {% endif %}
+                        </summary>
+                        {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
+                        <div class="detail-info__accordion-body">
+                            {% if object.moderator_status %}
+                                {% with feedback_classification=object.moderator_status|classify|lower %}
+                                    <h3 class="detail-info__section-title">{% translate 'Status' %}</h3>
+                                    <div class="detail-info__status-line--{{ feedback_classification }}"></div>
+                                    <div class="detail-info__status-icon--{{ feedback_classification }}">
+                                        {% if feedback_classification == 'consideration' or feedback_classification == 'qualified' %}
+                                            <i class="fa-solid fa-circle-half-stroke fa-rotate-270"></i>
+                                        {% elif feedback_classification == 'rejected' %}
+                                            <i class="fa-solid fa-circle-xmark"></i>
+                                        {% elif feedback_classification == 'accepted' %}
+                                            <i class="fas fa-check-circle"></i>
+                                        {% endif%}
+                                        <span class="detail-info__status-label">
+                                            {{ object.get_moderator_status_display }}
+                                        </span>
+                                    </div>
+                                {% endwith %}
+                            {% endif %}
+                            {% if object.moderator_feedback_text.feedback_text %}
+                            <div class="detail-info__section--no-border">
+                                <strong class="u-spacer-right">
+                                    {{ object.module.project.organisation.name }}
+                                </strong>
+                                {% if object.moderator_feedback_text.modified %}
+                                {% translate 'updated on ' %}{% html_date object.moderator_feedback_text.modified %}
+                                {% else %}
+                                {% translate 'created on ' %}{% html_date object.moderator_feedback_text.created %}
+                                {% endif %}
                             </div>
                             {% endif %}
-                            <i class="fa fa-chevron-down detail-info__collapse-btn" aria-hidden="true"></i>
-                        </summary>
-                        {% if object.module.moderationtask_set or object.remark.remark %}
-                        <div class="detail-info__accordion-body">
-                            <h3 class="detail-info__section-title">{% translate 'Moderation tasks' %}</h3>
-                            {% if object.module.moderationtask_set.count > 0 %}
-                                <ul class="u-list-reset">
-                                {% for task in object.module.moderationtask_set.all %}
-                                    <li class="detail-info__list-item">
-                                    {% if task in object.completed_tasks.all %}
-                                        <i class="fas fa-circle-check u-success" aria-role="img" aria-label="{% translate 'Done' %}"></i>
-                                        {{ task.name }}
-                                    {% else %}
-                                        <span class="u-muted">{{ task.name }}</span>
-                                    {% endif %}
-                                    </li>
-                                {% endfor %}
-                                </ul>
-                            {% else %}
-                                <p class="u-muted">
-                                    {% translate 'If you want to add moderation tasks here, you can do so in the module settings.' %}
-                                </p>
-                            {% endif %}
-                            <h3 class="detail-info__section-title">{% translate 'Remark' %}</h3>
-                            {% if object.remark.remark %}
-                                <p>
-                                    {{ object.remark.remark }}
-                                </p>
-                            {% else %}
-                                <p class="u-muted">
-                                    {% translate 'No moderation remark has been filled yet.' %}
-                                </p>
-                            {% endif %}
+                            <p class="u-spacer-top-half">
+                                {{ object.moderator_feedback_text.feedback_text | safe }}
+                            </p>
                         </div>
                         {% endif %}
                     </details>
                 </section>
-            {% endif %}
-        {% endblock %}
-            <section>
-                <h2 class="visually-hidden">{% translate 'Comments' %}</h2>
-                {% react_comments_async object %}
+        {% endif %}
+    {% endblock %}
+
+    {% block moderation_info %}
+        {% if is_moderator and module.blueprint_type in 'PB3,PB2,PB' %}
+            <section class="detail-info__accordion">
+                <details class="accordion" open>
+                    <summary class="detail-info__accordion-title">
+                        <h2 class="detail-info__title">{% translate 'Moderation' %}</h2>
+                        {% get_item_url object 'moderate' False as moderate_url %}
+                        {% if moderate_url %}
+                        <div class="detail-info__edit-btn">
+                            <a
+                                href="{{ moderate_url }}"
+                                class="btn btn--small detail-info__btn"
+                                data-embed-target="external">
+                                    <i class="fas fa-pencil" aria-hidden="true"></i>
+                                    {% translate 'Edit' %}
+                            </a>
+                        </div>
+                        {% endif %}
+                        <i class="fa fa-chevron-down detail-info__collapse-btn" aria-hidden="true"></i>
+                    </summary>
+                    {% if object.module.moderationtask_set or object.remark.remark %}
+                    <div class="detail-info__accordion-body">
+                        <h3 class="detail-info__section-title">{% translate 'Moderation tasks' %}</h3>
+                        {% if object.module.moderationtask_set.count > 0 %}
+                            <ul class="u-list-reset">
+                            {% for task in object.module.moderationtask_set.all %}
+                                <li class="detail-info__list-item">
+                                {% if task in object.completed_tasks.all %}
+                                    <i class="fas fa-circle-check u-success" aria-role="img" aria-label="{% translate 'Done' %}"></i>
+                                    {{ task.name }}
+                                {% else %}
+                                    <span class="u-muted">{{ task.name }}</span>
+                                {% endif %}
+                                </li>
+                            {% endfor %}
+                            </ul>
+                        {% else %}
+                            <p class="u-muted">
+                                {% translate 'If you want to add moderation tasks here, you can do so in the module settings.' %}
+                            </p>
+                        {% endif %}
+                        <h3 class="detail-info__section-title">{% translate 'Remark' %}</h3>
+                        {% if object.remark.remark %}
+                            <p>
+                                {{ object.remark.remark }}
+                            </p>
+                        {% else %}
+                            <p class="u-muted">
+                                {% translate 'No moderation remark has been filled yet.' %}
+                            </p>
+                        {% endif %}
+                    </div>
+                    {% endif %}
+                </details>
             </section>
-        </article>
-    </div>
+        {% endif %}
+    {% endblock %}
+        <section>
+            <h2 class="visually-hidden">{% translate 'Comments' %}</h2>
+            {% react_comments_async object %}
+        </section>
+    </article>
 </div>
 {% endblock %}

--- a/meinberlin/apps/documents/templates/meinberlin_documents/paragraph_detail.html
+++ b/meinberlin/apps/documents/templates/meinberlin_documents/paragraph_detail.html
@@ -23,27 +23,26 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ paragraph.chapter.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back to chapter' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <!-- FIXME left in as template tag maybe useful, to be removed before release if not -->
+    <!-- <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
+        <ul>
+            <li>
+                <a href="{{ paragraph.chapter.get_absolute_url }}">
+                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                    {% translate 'back to chapter' %}</a>
+            </li>
+        </ul>
+    </nav> -->
 
-        <article class="item-detail">
-            <h1 class="item-detail__title">
-                {{ paragraph.name }}
-            </h1>
-            <div class="item-detail__content">
-                {{ paragraph.text | richtext }}
-            </div>
-        </article>
+    <article class="item-detail">
+        <h1 class="item-detail__title">
+            {{ paragraph.name }}
+        </h1>
+        <div class="item-detail__content">
+            {{ paragraph.text | richtext }}
+        </div>
+    </article>
 
-        {% react_comments_async paragraph %}
-    </div>
+    {% react_comments_async paragraph %}
 </div>
 {% endblock %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_create_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_create_form.html
@@ -22,33 +22,20 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'go back' %}
-                    </a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Submit a new idea for this project' %}</h1>
 
-        <h1>{% translate 'Submit a new idea for this project' %}</h1>
+    {% if form.errors %}
+        <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">{% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
 
-        {% if form.errors %}
-            <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">{% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    <div class="u-bottom-divider">
+        <h3>{{ module.name }}</h3>
+        {% if module.description %}
+        <p>{{ module.description }}</p>
+        {% else %}
+        <p>{{ project.description }}</p>
         {% endif %}
-
-        <div class="u-bottom-divider">
-            <h3>{{ module.name }}</h3>
-            {% if module.description %}
-            <p>{{ module.description }}</p>
-            {% else %}
-            <p>{{ project.description }}</p>
-            {% endif %}
-        </div>
-        {% include "meinberlin_ideas/includes/idea_form.html" with idea=idea cancel=module.get_detail_url %}
     </div>
+    {% include "meinberlin_ideas/includes/idea_form.html" with idea=idea cancel=module.get_detail_url %}
 </div>
 {% endblock %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_moderate_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_moderate_form.html
@@ -21,38 +21,21 @@
 {% endblock %}
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'go back' %}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back to idea' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Feedback on this idea' %}</h1>
+    <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
+        {% csrf_token %}
+        {% for form in forms.values %}
+            {{ form.media }}
+        {% endfor %}
 
-        <h1>{% translate 'Feedback on this idea' %}</h1>
-        <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
-            {% csrf_token %}
-            {% for form in forms.values %}
-                {{ form.media }}
-            {% endfor %}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
 
 
-            <div class="u-spacer-bottom">
-                <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-                <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-            </div>
-        </form>
-    </div>
+        <div class="u-spacer-bottom">
+            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
+            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
+        </div>
+    </form>
 </div>
 {% endblock %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_update_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_update_form.html
@@ -23,29 +23,12 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'go back' %}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back to idea' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Edit idea' %}</h1>
 
-        <h1>{% translate 'Edit idea' %}</h1>
+    {% if form.errors %}
+        <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">{% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
+    {% endif %}
 
-        {% if form.errors %}
-            <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">{% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}</div>
-        {% endif %}
-
-        {% include "meinberlin_ideas/includes/idea_form.html" with idea=idea cancel=object.get_absolute_url %}
-    </div>
+    {% include "meinberlin_ideas/includes/idea_form.html" with idea=idea cancel=object.get_absolute_url %}
 </div>
 {% endblock %}

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_create_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_create_form.html
@@ -20,16 +20,6 @@
 {% endblock %}
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-        <ul>
-            <li>
-                <a href="{{ module.get_detail_url }}">
-                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                    {% translate 'go back' %}</a>
-            </li>
-        </ul>
-    </nav>
-
     <h1>{% translate 'Submit a new proposal for this project' %}</h1>
 
     {% if form.errors %}

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_moderate_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_moderate_form.html
@@ -2,40 +2,40 @@
 {% load i18n %}
 
 {% block title %}{% blocktranslate with name=object.name %}Moderate {{ name }}{% endblocktranslate %}{% endblock %}
+{% block breadcrumbs %}
+    <div id="layout-grid__area--contentheader">
+        <div id="content-header">
+            <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
+                <ol>
+                    <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
+                    <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
+                    {% if module.is_in_module_cluster  %}
+                        <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
+                    {% endif %}
+                    <li><a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a></li>
+                    <li class="active" aria-current="page">{% translate 'Moderate proposal' %}</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+{% endblock %}
 {% block content %}
 <div class="container">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'go back' %}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back to proposal' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Moderate proposal' %}</h1>
+    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+        {% csrf_token %}
+        {% for form in forms.values %}
+            {{ form.media }}
+        {% endfor %}
 
-        <h1>{% translate 'Moderate proposal' %}</h1>
-        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-            {% csrf_token %}
-            {% for form in forms.values %}
-                {{ form.media }}
-            {% endfor %}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
 
 
-            <div class="u-spacer-bottom">
-                <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-                <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-            </div>
-        </form>
-    </div>
+        <div class="u-spacer-bottom">
+            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
+            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
+        </div>
+    </form>
 </div>
 {% endblock %}

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_update_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_update_form.html
@@ -23,21 +23,6 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-        <ul>
-            <li>
-                <a href="{{ module.get_detail_url }}">
-                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                    {% translate 'go back' %}</a>
-            </li>
-            <li>
-                <a href="{{ object.get_absolute_url }}">
-                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                    {% translate 'back to proposal' %}</a>
-            </li>
-        </ul>
-    </nav>
-
     <h1>{% translate 'Edit proposal' %}</h1>
 
     {% if form.errors %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_create_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_create_form.html
@@ -20,35 +20,23 @@
 {% endblock %}
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'go back' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Submit a new idea for this project' %}</h1>
 
-        <h1>{% translate 'Submit a new idea for this project' %}</h1>
-
-        {% if form.errors %}
-        <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
-            {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
-        </div>
-        {% endif %}
-
-        <div class="u-bottom-divider">
-            <h3>{{ module.name }}</h3>
-            {% if module.description %}
-            <p>{{ module.description }}</p>
-            {% else %}
-            <p>{{ project.description }}</p>
-            {% endif %}
-        </div>
-
-        {% include "meinberlin_mapideas/includes/mapidea_form.html" with cancel=module.get_detail_url %}
+    {% if form.errors %}
+    <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
+        {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
     </div>
+    {% endif %}
+
+    <div class="u-bottom-divider">
+        <h3>{{ module.name }}</h3>
+        {% if module.description %}
+        <p>{{ module.description }}</p>
+        {% else %}
+        <p>{{ project.description }}</p>
+        {% endif %}
+    </div>
+
+    {% include "meinberlin_mapideas/includes/mapidea_form.html" with cancel=module.get_detail_url %}
 </div>
 {% endblock %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html
@@ -21,38 +21,21 @@
 {% endblock %}
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'go back' %}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back to idea' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Moderate idea' %}</h1>
+    <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
+        {% csrf_token %}
+        {% for form in forms.values %}
+            {{ form.media }}
+        {% endfor %}
 
-        <h1>{% translate 'Moderate idea' %}</h1>
-        <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
-            {% csrf_token %}
-            {% for form in forms.values %}
-                {{ form.media }}
-            {% endfor %}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
 
 
-            <div class="u-spacer-bottom">
-                <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-                <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-            </div>
-        </form>
-    </div>
+        <div class="u-spacer-bottom">
+            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
+            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
+        </div>
+    </form>
 </div>
 {% endblock %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_update_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_update_form.html
@@ -23,31 +23,14 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'go back' %}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back to idea' %}</a>
-                </li>
-            </ul>
-        </nav>
+    <h1>{% translate 'Edit idea' %}</h1>
 
-        <h1>{% translate 'Edit idea' %}</h1>
-
-        {% if form.errors %}
-        <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
-            {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
-        </div>
-        {% endif %}
-
-        {% include "meinberlin_mapideas/includes/mapidea_form.html" with cancel=object.get_absolute_url %}
+    {% if form.errors %}
+    <div class="alert alert--danger" aria-live="assertive" aria-atomic="true" id="alert">
+        {% translate 'An error occurred while evaluating your data. Please check the data you entered again.' %}
     </div>
+    {% endif %}
+
+    {% include "meinberlin_mapideas/includes/mapidea_form.html" with cancel=object.get_absolute_url %}
 </div>
 {% endblock %}

--- a/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
+++ b/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
@@ -32,54 +32,41 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back' %}
-                    </a>
-                </li>
-            </ul>
-        </nav>
-        <article class="item-detail">
-            <h1 class="item-detail__title">{{ object.name }}</h1>
+    <article class="item-detail">
+        <h1 class="item-detail__title">{{ object.name }}</h1>
 
-            {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
+        {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
 
+        <div class="item-detail__content">
+            <div class="item-detail__basic-content">
+                <img class="item-detail__hero-image" src="{% thumbnail object.image 'item_image' %}" alt="">
+                {{ object.description | richtext }}
+            </div>
 
-            <div class="item-detail__content">
-                <div class="item-detail__basic-content">
-                    <img class="item-detail__hero-image" src="{% thumbnail object.image 'item_image' %}" alt="">
-                    {{ object.description | richtext }}
+            {% if object.point %}
+                {% get_category_pin_url object as pin_url %}
+                {% map_display_point object.point object.module.areasettings_settings.polygon pin_url %}
+            {% endif %}
+        </div>
+
+        <div class="item-detail__meta lr-bar">
+            <div class="lr-bar__right">
+                <strong>{% translate 'Reference No.' %}:</strong>
+                {{ object.reference_number }}
+            </div>
+        </div>
+
+        <div class="item-detail__actions lr-bar">
+            {% if object|has_feature:"rate" %}
+                <div class="lr-bar__left">
+                    {% react_ratings object %}
                 </div>
-
-                {% if object.point %}
-                    {% get_category_pin_url object as pin_url %}
-                    {% map_display_point object.point object.module.areasettings_settings.polygon pin_url %}
-                {% endif %}
-            </div>
-
-            <div class="item-detail__meta lr-bar">
-                <div class="lr-bar__right">
-                    <strong>{% translate 'Reference No.' %}:</strong>
-                    {{ object.reference_number }}
-                </div>
-            </div>
-
-            <div class="item-detail__actions lr-bar">
-                {% if object|has_feature:"rate" %}
-                    <div class="lr-bar__left">
-                        {% react_ratings object %}
-                    </div>
-                {% endif %}
-            </div>
-        </article>
-        <section>
-            <h2 class="visually-hidden">{% translate 'Comments' %}</h2>
-            {% react_comments_async object %}
-        </section>
-    </div>
+            {% endif %}
+        </div>
+    </article>
+    <section>
+        <h2 class="visually-hidden">{% translate 'Comments' %}</h2>
+        {% react_comments_async object %}
+    </section>
 </div>
 {% endblock %}

--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -45,231 +45,220 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back to overview of projects' %}</a>
-                </li>
-            </ul>
-        </nav>
-        <article class="item-detail">
-            <h1 class="item-detail__title u-break-word">
-                {{ object.title }}
-            </h1>
+    <article class="item-detail">
+        <h1 class="item-detail__title u-break-word">
+            {{ object.title }}
+        </h1>
 
-            <div class="item-detail__labels">
-                <span class="label label--secondary">{{ object.get_status_display }}</span>
-            </div>
+        <div class="item-detail__labels">
+            <span class="label label--secondary">{{ object.get_status_display }}</span>
+        </div>
 
-            <section class="item-detail-2__factsheet">
-                <dl class="item-detail-2__factsheet-table" title="{% translate 'Plan details' %}">
+        <section class="item-detail-2__factsheet">
+            <dl class="item-detail-2__factsheet-table" title="{% translate 'Plan details' %}">
 
-                    {% if object.point_label %}
-                        <div><dt>{% translate 'Location' %}</dt><dd>{{ object.point_label|default:'no val' }}</dd></div>
-                    {% endif %}
-
-                    {% if object.topic_names %}
-                    <div>
-                        <dt>{% translate 'Topic' %}</dt>
-                        <dd>{{ object.topic_names.0 }}{% if object.topic_names.1 %}, {{ object.topic_names.1 }}{% endif %}</dd>
-                    </div>
-                    {% endif %}
-
-                    {% if object.duration %}
-                    <div>
-                        <dt>{% translate 'Duration' %}</dt><dd>{{ object.duration }}</dd>
-                    </div>
-                    {% endif %}
-
-                    {% if object.cost != "Keine Angabe" %}
-                    <div>
-                        <dt>{% translate 'Cost' %}</dt><dd>{{ object.cost }}</dd>
-                    </div>
-                    {% endif %}
-                    <div>
-                        <dt>{% translate 'Level of participation' %}</dt>
-                        <dd>
-                            {{ object.get_participation_display }}
-                            {% if object.published_projects.count %}/
-                                <a href='#participation-plans'>
-                                    {% translate 'see participation projects' %}
-                                </a>
-                            {% endif%}
-                        </dd>
-                    </div>
-                    <div>
-                        <dt>{% translate 'Reference No.' %}</dt>
-                        <dd>{{ object.reference_number }},
-                            {% if object.modified %}
-                                {% translate 'updated on ' %}{% html_date object.modified class='list-item__date' %}
-                            {% else %}
-                                {% translate 'created on ' %}{% html_date object.created class='list-item__date' %}
-                            {% endif %}
-                        </dd>
-                    </div>
-                </dl>
-                {% if object.image %}
-                    <div
-                        class="item-detail__background-image"
-                        style="background-image: url({% thumbnail object.image 'plan_image' %})"
-                        role="img"
-                        aria-label="{% if plan.image_alt_text %}{{ plan.image_alt_text }}{% else %}{% translate 'Here you can find a decorative picture.' %}{% endif %}"
-                    >
-                        <p class="item-detail__copyright copyright">
-                            {% if object.image_copyright %}
-                                © {{ object.image_copyright }}
-                            {% else %}
-                                {% translate 'copyright missing' %}
-                            {% endif %}
-                        </p>
-                    </div>
+                {% if object.point_label %}
+                    <div><dt>{% translate 'Location' %}</dt><dd>{{ object.point_label|default:'no val' }}</dd></div>
                 {% endif %}
-            </section>
 
-            <div class="item-detail-2__content{% if object.participation_explanation != 'Bitte Begründung einfügen' %}--borderless{% endif%}">
-                <div class="item-detail__basic-content">
-                    {% if object.description %}
-                        {{ object.description | transform_collapsibles | richtext }}
-                    {% endif %}
+                {% if object.topic_names %}
+                <div>
+                    <dt>{% translate 'Topic' %}</dt>
+                    <dd>{{ object.topic_names.0 }}{% if object.topic_names.1 %}, {{ object.topic_names.1 }}{% endif %}</dd>
                 </div>
-            </div>
-            {% if object.participation_explanation != "Bitte Begründung einfügen" %}
-            <div class="item-detail-2__info-box">
-                <h2 class="item-detail-2__smalltitle">{% translate 'Level of participation' %}: {{ object.get_participation_display }}</h2>
-
-                {% if object.participation_explanation|length > 300 %}
-                    <div id="collapsibleExplanation" class="collapse show u-no-transition">
-                        {{ object.participation_explanation|truncatechars:160 }}
-                    </div>
-                    <div id="collapsibleExplanation" class="collapse u-no-transition">
-                        {{ object.participation_explanation }}
-                    </div>
-                    <button
-                        class="btn--link collapsible"
-                        type="button" data-bs-toggle="collapse"
-                        data-bs-target="#collapsibleExplanation"
-                        aria-expanded="false"
-                        aria-controls="collapseReadLink"
-                    >
-                        <span class="link--more">
-                            <span class="visually-hidden">{% translate 'toggle to' %}</span>
-                            {% translate 'Read more...' %}
-                        </span>
-                        <span class="link--less">
-                            <span class="visually-hidden">{% translate 'toggle to' %}</span>
-                            {% translate 'Read less' %}
-                        </span>
-                    </button>
-                {% else %}
-                    {{ object.participation_explanation }}
-                {% endif %}
-            </div>
-            {% endif %}
-
-            {% if object.point %}
-                {% map_display_point object.point polygon %}
-            {% endif %}
-
-            {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url or object.organisation.address or object.organisation.url %}
-                <div class="l-tiles-2 u-spacer-bottom">
-                {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url %}
-                    <div>
-                        <h2 class="item-detail-2__smalltitle">{% translate 'Contact for questions' %}</h2>
-                        <address>
-                            {% if object.contact_name %}
-                            <p>{{ object.contact_name }}</p>
-                            {% endif %}
-                            {% if object.contact_address_text %}
-                                <p>{{ object.contact_address_text|linebreaks }}</p>
-                            {% endif %}
-                            {% if object.contact_phone %}
-                                <p><strong>{% translate 'Telephone' %}: </strong>{{ object.contact_phone }}</p>
-                            {% endif %}
-                            {% if object.contact_email %}
-                                <a class="btn btn--secondary" href="mailto:{{ object.contact_email }}">
-                                    {% translate 'Email' %}
-                                </a>
-                            {% endif %}
-                            {% if object.contact_url %}
-                                <a class="btn btn--secondary" target="_blank" href="{{ object.contact_url }}">
-                                    {% translate 'Website' %}
-                                </a>
-                            {% endif %}
-                        </address>
-                    </div>
                 {% endif %}
 
-                {% if object.organisation.address or object.organisation.url %}
-                    <div>
-                        <h2 class="item-detail-2__smalltitle">{% translate 'Responsible body' %}</h2>
-                        <address>
-                            {% if object.organisation.address %}
-                            <p>{{ object.organisation.name }}</p>
-                            <p>{{ object.organisation.address|linebreaks }}</p>
-                            {% endif %}
-                            {% if object.organisation.url %}
-                                <a class="btn btn--secondary" target="_blank" href="{{ object.organisation.url }}">
-                                    {% translate 'Website' %}
-                                </a>
-                            {% endif %}
-                        </address>
-                    </div>
+                {% if object.duration %}
+                <div>
+                    <dt>{% translate 'Duration' %}</dt><dd>{{ object.duration }}</dd>
+                </div>
                 {% endif %}
+
+                {% if object.cost != "Keine Angabe" %}
+                <div>
+                    <dt>{% translate 'Cost' %}</dt><dd>{{ object.cost }}</dd>
+                </div>
+                {% endif %}
+                <div>
+                    <dt>{% translate 'Level of participation' %}</dt>
+                    <dd>
+                        {{ object.get_participation_display }}
+                        {% if object.published_projects.count %}/
+                            <a href='#participation-plans'>
+                                {% translate 'see participation projects' %}
+                            </a>
+                        {% endif%}
+                    </dd>
+                </div>
+                <div>
+                    <dt>{% translate 'Reference No.' %}</dt>
+                    <dd>{{ object.reference_number }},
+                        {% if object.modified %}
+                            {% translate 'updated on ' %}{% html_date object.modified class='list-item__date' %}
+                        {% else %}
+                            {% translate 'created on ' %}{% html_date object.created class='list-item__date' %}
+                        {% endif %}
+                    </dd>
+                </div>
+            </dl>
+            {% if object.image %}
+                <div
+                    class="item-detail__background-image"
+                    style="background-image: url({% thumbnail object.image 'plan_image' %})"
+                    role="img"
+                    aria-label="{% if plan.image_alt_text %}{{ plan.image_alt_text }}{% else %}{% translate 'Here you can find a decorative picture.' %}{% endif %}"
+                >
+                    <p class="item-detail__copyright copyright">
+                        {% if object.image_copyright %}
+                            © {{ object.image_copyright }}
+                        {% else %}
+                            {% translate 'copyright missing' %}
+                        {% endif %}
+                    </p>
                 </div>
             {% endif %}
-
-            {% has_perm 'meinberlin_plans.change_plan' request.user object as user_may_change %}
-            {% if user_may_change %}
-            <div class="item-detail__actions lr-bar">
-                <div class="lr-bar__right">
-                    <div class="dropdown">
-                        <button
-                            title="{% translate 'Actions' %}"
-                            type="button"
-                            class="dropdown-toggle btn btn--light btn--small"
-                            data-bs-toggle="dropdown"
-                            data-flip="false"
-                            aria-haspopup="true"
-                            aria-expanded="false"
-                            id="idea-{{ object.pk }}-actions"
-                        >
-                            <i class="fa fa-ellipsis-h" aria-label="{% translate 'Actions' %}"></i>
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="idea-{{ object.pk }}-actions">
-                            <li>
-                                <a
-                                    href="{% url 'a4dashboard:plan-update' organisation_slug=object.organisation.slug pk=object.pk %}"
-                                    class="dropdown-item"
-                                    data-embed-target="external"
-                                >
-                                    {% translate 'Edit' %}
-                                </a>
-                            </li>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            {% endif %}
-        </article>
-
-        {% if object.published_projects %}
-        <section class="item-detail-2__project-list">
-            <div class="container">
-                <h3 class="item-detail-2__project-title" id="participation-plans">
-                    {% translate "Participation projects" %}
-                </h3>
-                <ul class="u-list-reset participation-tile__list">
-                {% for project in object.published_projects %}
-                    {% include "meinberlin_projects/includes/project_tile.html" with project=project %}
-                {% endfor %}
-                </ul>
-            </div>
         </section>
+
+        <div class="item-detail-2__content{% if object.participation_explanation != 'Bitte Begründung einfügen' %}--borderless{% endif%}">
+            <div class="item-detail__basic-content">
+                {% if object.description %}
+                    {{ object.description | transform_collapsibles | richtext }}
+                {% endif %}
+            </div>
+        </div>
+        {% if object.participation_explanation != "Bitte Begründung einfügen" %}
+        <div class="item-detail-2__info-box">
+            <h2 class="item-detail-2__smalltitle">{% translate 'Level of participation' %}: {{ object.get_participation_display }}</h2>
+
+            {% if object.participation_explanation|length > 300 %}
+                <div id="collapsibleExplanation" class="collapse show u-no-transition">
+                    {{ object.participation_explanation|truncatechars:160 }}
+                </div>
+                <div id="collapsibleExplanation" class="collapse u-no-transition">
+                    {{ object.participation_explanation }}
+                </div>
+                <button
+                    class="btn--link collapsible"
+                    type="button" data-bs-toggle="collapse"
+                    data-bs-target="#collapsibleExplanation"
+                    aria-expanded="false"
+                    aria-controls="collapseReadLink"
+                >
+                    <span class="link--more">
+                        <span class="visually-hidden">{% translate 'toggle to' %}</span>
+                        {% translate 'Read more...' %}
+                    </span>
+                    <span class="link--less">
+                        <span class="visually-hidden">{% translate 'toggle to' %}</span>
+                        {% translate 'Read less' %}
+                    </span>
+                </button>
+            {% else %}
+                {{ object.participation_explanation }}
+            {% endif %}
+        </div>
         {% endif %}
-    </div>
+
+        {% if object.point %}
+            {% map_display_point object.point polygon %}
+        {% endif %}
+
+        {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url or object.organisation.address or object.organisation.url %}
+            <div class="l-tiles-2 u-spacer-bottom">
+            {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url %}
+                <div>
+                    <h2 class="item-detail-2__smalltitle">{% translate 'Contact for questions' %}</h2>
+                    <address>
+                        {% if object.contact_name %}
+                        <p>{{ object.contact_name }}</p>
+                        {% endif %}
+                        {% if object.contact_address_text %}
+                            <p>{{ object.contact_address_text|linebreaks }}</p>
+                        {% endif %}
+                        {% if object.contact_phone %}
+                            <p><strong>{% translate 'Telephone' %}: </strong>{{ object.contact_phone }}</p>
+                        {% endif %}
+                        {% if object.contact_email %}
+                            <a class="btn btn--secondary" href="mailto:{{ object.contact_email }}">
+                                {% translate 'Email' %}
+                            </a>
+                        {% endif %}
+                        {% if object.contact_url %}
+                            <a class="btn btn--secondary" target="_blank" href="{{ object.contact_url }}">
+                                {% translate 'Website' %}
+                            </a>
+                        {% endif %}
+                    </address>
+                </div>
+            {% endif %}
+
+            {% if object.organisation.address or object.organisation.url %}
+                <div>
+                    <h2 class="item-detail-2__smalltitle">{% translate 'Responsible body' %}</h2>
+                    <address>
+                        {% if object.organisation.address %}
+                        <p>{{ object.organisation.name }}</p>
+                        <p>{{ object.organisation.address|linebreaks }}</p>
+                        {% endif %}
+                        {% if object.organisation.url %}
+                            <a class="btn btn--secondary" target="_blank" href="{{ object.organisation.url }}">
+                                {% translate 'Website' %}
+                            </a>
+                        {% endif %}
+                    </address>
+                </div>
+            {% endif %}
+            </div>
+        {% endif %}
+
+        {% has_perm 'meinberlin_plans.change_plan' request.user object as user_may_change %}
+        {% if user_may_change %}
+        <div class="item-detail__actions lr-bar">
+            <div class="lr-bar__right">
+                <div class="dropdown">
+                    <button
+                        title="{% translate 'Actions' %}"
+                        type="button"
+                        class="dropdown-toggle btn btn--light btn--small"
+                        data-bs-toggle="dropdown"
+                        data-flip="false"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        id="idea-{{ object.pk }}-actions"
+                    >
+                        <i class="fa fa-ellipsis-h" aria-label="{% translate 'Actions' %}"></i>
+                    </button>
+                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="idea-{{ object.pk }}-actions">
+                        <li>
+                            <a
+                                href="{% url 'a4dashboard:plan-update' organisation_slug=object.organisation.slug pk=object.pk %}"
+                                class="dropdown-item"
+                                data-embed-target="external"
+                            >
+                                {% translate 'Edit' %}
+                            </a>
+                        </li>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+    </article>
+
+    {% if object.published_projects %}
+    <section class="item-detail-2__project-list">
+        <div class="container">
+            <h3 class="item-detail-2__project-title" id="participation-plans">
+                {% translate "Participation projects" %}
+            </h3>
+            <ul class="u-list-reset participation-tile__list">
+            {% for project in object.published_projects %}
+                {% include "meinberlin_projects/includes/project_tile.html" with project=project %}
+            {% endfor %}
+            </ul>
+        </div>
+    </section>
+    {% endif %}
 </div>
 
 {% endblock %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_bplan_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_bplan_detail.html
@@ -18,7 +18,7 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
+    <div>
         {# As bplan projects don't set the information and the result field, the default project detail, which is shown prior to the first phase, looks bad. #}
         {# This replaces the default project detail by a simple notice that the participation has not started yet. #}
 

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
@@ -22,48 +22,36 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <div class="offset-lg-3 col-lg-6">
-        <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-            <ul>
-                <li>
-                    <a href="{{ module.get_detail_url }}">
-                        <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                        {% translate 'back' %}
-                    </a>
-                </li>
-            </ul>
-        </nav>
-        <article class="item-detail">
-            <h1 class="item-detail__title">{{ object.name }}</h1>
+    <article class="item-detail">
+        <h1 class="item-detail__title">{{ object.name }}</h1>
 
-            {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
+        {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
 
-            <div class="item-detail__content">
-                <div class="item-detail__basic-content">
-                    <img class="item-detail__hero-image" src="{% thumbnail object.image 'item_image' %}" alt="">
-                    {{ object.description | richtext }}
+        <div class="item-detail__content">
+            <div class="item-detail__basic-content">
+                <img class="item-detail__hero-image" src="{% thumbnail object.image 'item_image' %}" alt="">
+                {{ object.description | richtext }}
+            </div>
+        </div>
+
+        <div class="item-detail__meta lr-bar">
+            <div class="lr-bar__right">
+                <strong>{% translate 'Reference No.' %}:</strong>
+                {{ object.reference_number }}
+            </div>
+        </div>
+
+        <div class="item-detail__actions lr-bar">
+            {% if object|has_feature:"rate" %}
+                <div class="lr-bar__left">
+                    {% react_ratings object %}
                 </div>
-            </div>
-
-            <div class="item-detail__meta lr-bar">
-                <div class="lr-bar__right">
-                    <strong>{% translate 'Reference No.' %}:</strong>
-                    {{ object.reference_number }}
-                </div>
-            </div>
-
-            <div class="item-detail__actions lr-bar">
-                {% if object|has_feature:"rate" %}
-                    <div class="lr-bar__left">
-                        {% react_ratings object %}
-                    </div>
-                {% endif %}
-            </div>
-        </article>
-        <section class="offset-lg-3 col-lg-6">
-            <h2 class="visually-hidden">{% translate 'Comments' %}</h2>
-            {% react_comments_async object %}
-        </section>
-    </div>
+            {% endif %}
+        </div>
+    </article>
+    <section class="offset-lg-3 col-lg-6">
+        <h2 class="visually-hidden">{% translate 'Comments' %}</h2>
+        {% react_comments_async object %}
+    </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog

Go to module and create an idea if you don't already have one locally then after creation click on the idea to see the detail view, there should only be 1 set of breadcrumbs, the old should be gone, also removed on all other list based modules (check template locations for names). To check the moderate detail view find 3 dots and click bearbeiten in the menu.
