### PR TITLE
redesign phase info component

### DIFF
--- a/changelog/_7762.md
+++ b/changelog/_7762.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Implemented redesign for phase info according to BerlinOnline styleguide
+- Refactor files in templates/a4modules
+- Optimized Swiper integration 
+
+### Added
+- Introduced new CSS file assets/scss/components_user_facing/_phase_info.scss for specific styles

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -15,7 +15,7 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_budgeting.add_proposal' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="button button--negative">
+        <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="button">
             {% translate 'Submit proposal' %}
         </a>
     {% endif %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -9,22 +9,27 @@
 
 {% block extra_css %}
     {{ block.super }}
-    <link type="text/css" href="{% static 'a4maps_display_points.css'%}" rel="stylesheet" />
+    <link type="text/css" href="{% static 'a4maps_display_points.css' %}" rel="stylesheet"/>
 {% endblock %}
 
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_budgeting.add_proposal' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="button button--light">
-            {% translate 'Submit proposal' %}
-        </a>
+        <div>
+            <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="button button--light">
+                {% translate 'Submit proposal' %}
+            </a>
+        </div>
     {% endif %}
+{% endblock %}
+
+{% block voting_token_field %}
     {% if module.blueprint_type == 'PB3' %}
         {% has_perm 'meinberlin_budgeting.add_vote' request.user module as vote_allowed %}
         {% if vote_allowed %}
             {% if not valid_token_present %}
                 <form autocomplete="off" method="post">
-                  {% csrf_token %}
+                    {% csrf_token %}
                     <div class="input-group input-group-lg">
                         <label for="id_token" class="visually-hidden-focusable">{% translate 'Voting token form fields' %}</label>
                         {{ token_form.token|add_error_attr:"aria-invalid:true" }}
@@ -32,9 +37,9 @@
                     </div>
                     {% if token_form.token.errors %}
                         <ul class="errorlist" aria-live="assertive" aria-atomic="true">
-                        {% for error in token_form.token.errors %}
-                            <li>{{ error|escape }}</li>
-                        {% endfor %}
+                            {% for error in token_form.token.errors %}
+                                <li>{{ error|escape }}</li>
+                            {% endfor %}
                         </ul>
                     {% endif %}
                 </form>
@@ -42,6 +47,7 @@
         {% endif %}
     {% endif %}
 {% endblock %}
+
 
 {% block phase_content %}
     {% if view.mode == 'map' %}
@@ -55,24 +61,10 @@
             <div class="map-list__controls">
                 <div class="container">
                     <div class="leaflet-control-zoom leaflet-bar leaflet-control">
-                        <a
-                            class="leaflet-control-zoom-in"
-                            id="zoom-in"
-                            href="#"
-                            title="{% translate 'Zoom in' %}"
-                            role="button"
-                            aria-label="{% translate 'Zoom in' %}"
-                        >
+                        <a class="leaflet-control-zoom-in" id="zoom-in" href="#" title="{% translate 'Zoom in' %}" role="button" aria-label="{% translate 'Zoom in' %}">
                             +
                         </a>
-                        <a
-                            class="leaflet-control-zoom-out leaflet-disabled"
-                            id="zoom-out"
-                            href="#"
-                            title="{% translate 'Zoom out' %}"
-                            role="button"
-                            aria-label="{% translate 'Zoom out' %}"
-                        >
+                        <a class="leaflet-control-zoom-out leaflet-disabled" id="zoom-out" href="#" title="{% translate 'Zoom out' %}" role="button" aria-label="{% translate 'Zoom out' %}">
                             -
                         </a>
                     </div>

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -15,7 +15,7 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_budgeting.add_proposal' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="btn btn--primary btn--full u-spacer-bottom btn--huge">
+        <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="button button--light">
             {% translate 'Submit proposal' %}
         </a>
     {% endif %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_list.html
@@ -15,11 +15,9 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_budgeting.add_proposal' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <div>
-            <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="button button--light">
-                {% translate 'Submit proposal' %}
-            </a>
-        </div>
+        <a href="{% url 'meinberlin_budgeting:proposal-create' module_slug=module.slug %}" class="button button--negative">
+            {% translate 'Submit proposal' %}
+        </a>
     {% endif %}
 {% endblock %}
 

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html
@@ -9,7 +9,7 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_ideas.add_idea' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_ideas:idea-create' module_slug=module.slug %}" class="button button--negative">
+        <a href="{% url 'meinberlin_ideas:idea-create' module_slug=module.slug %}" class="button">
             {% translate 'Submit idea' %}
         </a>    
     {% endif %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_list.html
@@ -9,9 +9,9 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_ideas.add_idea' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_ideas:idea-create' module_slug=module.slug %}" class="btn btn--primary btn--full u-spacer-bottom btn--huge">
+        <a href="{% url 'meinberlin_ideas:idea-create' module_slug=module.slug %}" class="button button--negative">
             {% translate 'Submit idea' %}
-        </a>
+        </a>    
     {% endif %}
 {% endblock %}
 

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
@@ -15,7 +15,7 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_kiezkasse.add_proposal' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_kiezkasse:proposal-create' module_slug=module.slug %}" class="btn btn--primary btn--full u-spacer-bottom btn--huge">
+        <a href="{% url 'meinberlin_kiezkasse:proposal-create' module_slug=module.slug %}" class="button button--negative">
             {% translate 'Submit proposal' %}
         </a>
     {% endif %}

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_list.html
@@ -15,7 +15,7 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_kiezkasse.add_proposal' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_kiezkasse:proposal-create' module_slug=module.slug %}" class="button button--negative">
+        <a href="{% url 'meinberlin_kiezkasse:proposal-create' module_slug=module.slug %}" class="button">
             {% translate 'Submit proposal' %}
         </a>
     {% endif %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
@@ -15,7 +15,7 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_mapideas.add_mapidea' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_mapideas:mapidea-create' module_slug=module.slug %}" class="btn btn--primary btn--full u-spacer-bottom btn--huge">
+        <a href="{% url 'meinberlin_mapideas:mapidea-create' module_slug=module.slug %}" class="button button--negative">
             {% translate 'Submit Idea' %}
         </a>
     {% endif %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_list.html
@@ -15,7 +15,7 @@
 {% block project_action %}
     {% has_or_would_have_perm 'meinberlin_mapideas.add_mapidea' request.user module as propose_allowed %}
     {% if propose_allowed %}
-        <a href="{% url 'meinberlin_mapideas:mapidea-create' module_slug=module.slug %}" class="button button--negative">
+        <a href="{% url 'meinberlin_mapideas:mapidea-create' module_slug=module.slug %}" class="button">
             {% translate 'Submit Idea' %}
         </a>
     {% endif %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -199,11 +199,19 @@ assume this will may be updated at somepoint  -->
                         </ul>
                     </div>
                 </div>
-            {% else %} <!-- if just one module and no phase view to dispatch to -->
-            {% include "a4modules/includes/module_detail_phase.html" %}
+            {% else %} 
+                <!-- if just one module and no phase view to dispatch to -->
+                <div class="modul-servicepanel fullwidth panel--heavy phase-info">
+                    <div class="servicepanel__main">
+                        {% include "a4modules/includes/module_detail_phase.html" %}
+                    </div>
+                    <!-- these blocks are only filled when in phase view -->
+                    <div class="servicepanel__right phase-info__cta">
+                        {% block project_action %}{% endblock %}
+                    </div>
+                </div>
             {% endif %}
-            <!-- these blocks are only filled when in phase view -->
-            {% block project_action %}{% endblock %}
+
             
             {% block voting_token_field %}{% endblock %}
             {% block phase_content %}{% endblock %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -203,9 +203,10 @@ assume this will may be updated at somepoint  -->
             {% include "a4modules/includes/module_detail_phase.html" %}
             {% endif %}
             <!-- these blocks are only filled when in phase view -->
-            <div>
-                {% block project_action %}{% endblock %}
-            </div>
+            {% block project_action %}{% endblock %}
+            
+            <!-- is the voting token field necessary here? -->
+            {% block voting_token_field %}{% endblock %}
             {% block phase_content %}{% endblock %}
         </section>
         <section

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -205,7 +205,6 @@ assume this will may be updated at somepoint  -->
             <!-- these blocks are only filled when in phase view -->
             {% block project_action %}{% endblock %}
             
-            <!-- is the voting token field necessary here? -->
             {% block voting_token_field %}{% endblock %}
             {% block phase_content %}{% endblock %}
         </section>

--- a/meinberlin/assets/extra_css/_swiper.scss
+++ b/meinberlin/assets/extra_css/_swiper.scss
@@ -1,0 +1,39 @@
+//style overwrites for detail phase component
+.swiper-navigation {
+    display: flex;
+    align-items: center;
+    background-color: $blue-dark;
+    color: $white;
+    padding-bottom: $spacer;
+}
+
+.swiper-pagination-clickable {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: inherit !important;
+
+    .swiper-pagination-bullet {
+        background: transparent !important;
+        color: $white !important;
+        font-size: small;
+        width: 20px !important;
+        height: 20px !important;
+        border: 1.5px solid $white;
+        opacity: 1;
+    }
+
+    .swiper-pagination-bullet-active {
+        background: $white !important;
+        color: $blue-dark !important;
+    }
+}
+
+.swiper-button-prev {
+    padding-left: 0 !important;
+}
+
+.swiper-button-next::after,
+.swiper-button-prev::after {
+    color: $white !important;
+}

--- a/meinberlin/assets/extra_css/_swiper.scss
+++ b/meinberlin/assets/extra_css/_swiper.scss
@@ -1,4 +1,7 @@
-//Swiper modul-buehne - style overwrites for detail phase component
+.swiper-container {
+    background-color: inherit;
+}
+
 .swiper-navigation {
     display: flex;
     align-items: center;
@@ -14,6 +17,8 @@
     background: inherit !important;
 
     .swiper-pagination-bullet {
+        display: flex;
+        justify-content: center;
         background: transparent !important;
         color: $white !important;
         font-size: small;
@@ -33,7 +38,16 @@
     padding-left: 0 !important;
 }
 
+.swiper-button-prev,
+.swiper-button-next {
+    background-color: inherit !important;
+    height: 0 !important;
+    display: flex;
+    align-items: center;
+}
+
 .swiper-button-next::after,
 .swiper-button-prev::after {
     color: $white !important;
+    font-size: 1.5em !important;
 }

--- a/meinberlin/assets/extra_css/_swiper.scss
+++ b/meinberlin/assets/extra_css/_swiper.scss
@@ -1,8 +1,8 @@
-//style overwrites for detail phase component
+//Swiper modul-buehne - style overwrites for detail phase component
 .swiper-navigation {
     display: flex;
     align-items: center;
-    background-color: $blue-dark;
+    background-color: inherit;
     color: $white;
     padding-bottom: $spacer;
 }

--- a/meinberlin/assets/js/swiper_phases.js
+++ b/meinberlin/assets/js/swiper_phases.js
@@ -1,5 +1,12 @@
-import Swiper from 'swiper/bundle'
-import 'swiper/css/bundle'
+import Swiper from 'swiper'
+
+// Needed due to issue with Swiper, issue link: https://github.com/import-js/eslint-plugin-import/issues/2266
+/* eslint-disable import/no-unresolved */
+import { Navigation, Pagination } from 'swiper/modules'
+import 'swiper/css'
+import 'swiper/css/navigation'
+import 'swiper/css/pagination'
+/* eslint-enable import/no-unresolved */
 
 const createSwiper = ({ rootElement, options }) =>
   new Swiper(rootElement, options)
@@ -10,6 +17,7 @@ const initSwiper = () => {
     options: {
       direction: 'horizontal',
       loop: true,
+      modules: [Navigation, Pagination],
       navigation: {
         nextEl: '.swiper-button-next',
         prevEl: '.swiper-button-prev'
@@ -26,7 +34,7 @@ const initSwiper = () => {
   }
 
   createSwiper(config)
-};
+}
 
 (function () {
   // Check if Swiper is already available globally

--- a/meinberlin/assets/js/swiper_phases.js
+++ b/meinberlin/assets/js/swiper_phases.js
@@ -1,8 +1,9 @@
+import Swiper from 'swiper/bundle'
+import 'swiper/css/bundle'
+
 const createSwiper = ({ rootElement, options }) =>
-// eslint-disable-next-line no-undef
   new Swiper(rootElement, options)
 
-// Initialize Swiper directly with the configuration
 const initSwiper = () => {
   const config = {
     rootElement: '.swiper-container',
@@ -16,13 +17,11 @@ const initSwiper = () => {
       pagination: {
         el: '.swiper-pagination',
         clickable: true,
+        bulletElement: 'button',
         renderBullet: function (index, className) {
-          return (
-            '<button class="' + className + '">' + (index + 1) + '</button>'
-          )
+          return '<button class="' + className + '">' + (index + 1) + '</button>'
         }
-      },
-      a11y: true
+      }
     }
   }
 

--- a/meinberlin/assets/js/swiper_phases.js
+++ b/meinberlin/assets/js/swiper_phases.js
@@ -1,61 +1,42 @@
-// import { Swiper, Pagination, A11y } from 'swiper'
-// import django from 'django'
+const createSwiper = ({ rootElement, options }) =>
+// eslint-disable-next-line no-undef
+  new Swiper(rootElement, options)
 
-// function createSwiper (params) {
-//   const { rootElement, options } = params
-//   return new Swiper(rootElement, options)
-// }
+// Initialize Swiper directly with the configuration
+const initSwiper = () => {
+  const config = {
+    rootElement: '.swiper-container',
+    options: {
+      direction: 'horizontal',
+      loop: true,
+      navigation: {
+        nextEl: '.swiper-button-next',
+        prevEl: '.swiper-button-prev'
+      },
+      pagination: {
+        el: '.swiper-pagination',
+        clickable: true,
+        renderBullet: function (index, className) {
+          return (
+            '<button class="' + className + '">' + (index + 1) + '</button>'
+          )
+        }
+      },
+      a11y: true
+    }
+  }
 
-// // find index for given identifier in slide
-// // possible identifiers: active, upcoming
-// function getIndexOf (identifier, slides) {
-//   return Array.from(slides).findIndex(slide => {
-//     return slide.querySelector('#' + identifier)
-//   })
-// }
+  createSwiper(config)
+};
 
-// // create specific phase swiper
-// function createPhaseSwiper () {
-//   // config contains container/root element's name
-//   // and all settings, which are needed (see swiper docs)
-//   const config = {
-//     rootElement: '.swiper-phases',
-//     options: {
-//       modules: [A11y, Pagination],
-//       a11y: {
-//         containerMessage:
-//           django.gettext('Slider to go back and forth between phases.'),
-//         paginationBulletMessage:
-//           django.gettext('Go to slide {{index}}')
-//       },
-//       pagination: {
-//         el: '.swiper-pagination',
-//         clickable: true,
-//         bulletElement: 'div'
-//       }
-//     }
-//   }
-//   const phaseSwiper = createSwiper(config)
+(function () {
+  // Check if Swiper is already available globally
+  const hasSwiper = typeof Swiper !== 'undefined'
 
-//   // following part is to set initial slide
-//   // FIXME: it is not the right location to invoke the following;
-//   // because double logic (similar as in template), better to set
-//   // flag `initialSlide` in config on creation
-//   const activeSlideIndex = getIndexOf('active-phase', phaseSwiper.slides)
-//   const upcomingSlideIndex = getIndexOf('upcoming-phase', phaseSwiper.slides)
+  // Call swiper initialization if Swiper is available and swiper element found in DOM
+  const hasSwiperContainer = document.querySelector('.swiper-container')
 
-//   if (activeSlideIndex !== -1) {
-//     phaseSwiper.slideTo(activeSlideIndex)
-//   } else if (upcomingSlideIndex !== -1) {
-//     phaseSwiper.slideTo(upcomingSlideIndex)
-//   } else {
-//     const lastFinishedSlideIndex = phaseSwiper.slides.length - 1
-//     phaseSwiper.slideTo(lastFinishedSlideIndex)
-//   }
-// }
-
-// (function () {
-//   // Call swiper initialization if swiper element found in DOM
-//   // const hasPhaseSwiper = document.querySelector('.swiper-phases')
-//   createPhaseSwiper()
-// })()
+  if (hasSwiper && hasSwiperContainer) {
+    initSwiper()
+  }
+})()

--- a/meinberlin/assets/scss/components_user_facing/_phase_info.scss
+++ b/meinberlin/assets/scss/components_user_facing/_phase_info.scss
@@ -1,14 +1,25 @@
 .phase-info {
     background-color: $blue-dark;
     color: $white;
-    padding: 1.8em 0;
-}
-
-.phase-info .modul-buehne {
-    margin: 0;
 }
 
 .phase-info__title {
     color: inherit;
     margin: 0;
+}
+
+.phase-info__cta {
+    // enforce button to stick to bottom of container
+    margin-top: auto;
+}
+
+.phase-info .modul-servicepanel .fa, .modul-servicepanel .far, .modul-servicepanel .fas {
+    // overwrite icon color
+    color: inherit;
+}
+
+@media print, (width <= 37.501rem) {
+    .phase-info .modul-buehne {
+        margin: 0;
+    }
 }

--- a/meinberlin/assets/scss/components_user_facing/_phase_info.scss
+++ b/meinberlin/assets/scss/components_user_facing/_phase_info.scss
@@ -24,13 +24,13 @@
 }
 
 @media print, (width <= 37.501rem) {
-    .phase-info .modul-buehne {
+    .phase-info {
         margin: 0;
     }
 }
 
 @media print, (width >= 37.501rem) and (width <= 73.813rem) {
-    .phase-info .modul-buehne {
+    .phase-info {
         margin: $spacer auto;
     }
 }

--- a/meinberlin/assets/scss/components_user_facing/_phase_info.scss
+++ b/meinberlin/assets/scss/components_user_facing/_phase_info.scss
@@ -1,0 +1,14 @@
+.phase-info {
+    background-color: $blue-dark;
+    color: $white;
+    padding: 1.8em 0;
+}
+
+.phase-info .modul-buehne {
+    margin: 0;
+}
+
+.phase-info__title {
+    color: inherit;
+    margin: 0;
+}

--- a/meinberlin/assets/scss/components_user_facing/_phase_info.scss
+++ b/meinberlin/assets/scss/components_user_facing/_phase_info.scss
@@ -11,15 +11,26 @@
 .phase-info__cta {
     // enforce button to stick to bottom of container
     margin-top: auto;
+
+    .button:after {
+        background-color: $primary;
+        color: inherit;
+    }
 }
 
 .phase-info .modul-servicepanel .fa, .modul-servicepanel .far, .modul-servicepanel .fas {
     // overwrite icon color
-    color: inherit;
+    color: inherit; 
 }
 
 @media print, (width <= 37.501rem) {
     .phase-info .modul-buehne {
         margin: 0;
+    }
+}
+
+@media print, (width >= 37.501rem) and (width <= 73.813rem) {
+    .phase-info .modul-buehne {
+        margin: $spacer auto;
     }
 }

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -49,6 +49,9 @@
 // New styles begin
 @import "../berlin_css/berlin_marketing";
 
+// extra scss / overwrites
+@import "../extra_css/swiper.scss";
+
 @import "styles_user_facing/form";
 @import "styles_user_facing/utility";
 

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -50,7 +50,7 @@
 @import "../berlin_css/berlin_marketing";
 
 // extra scss / overwrites
-@import "../extra_css/swiper.scss";
+@import "../extra_css/swiper";
 
 @import "styles_user_facing/form";
 @import "styles_user_facing/utility";

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -59,6 +59,7 @@
 @import "components_user_facing/input";
 @import "components_user_facing/link--edit";
 @import "components_user_facing/moderator_status";
+@import "components_user_facing/phase_info";
 @import "components_user_facing/pill";
 @import "components_user_facing/searchform-slot";
 @import "components_user_facing/select";

--- a/meinberlin/assets/scss/styles_dashboard/_variables.scss
+++ b/meinberlin/assets/scss/styles_dashboard/_variables.scss
@@ -98,3 +98,4 @@ $enable-dark-mode: false !default;
 
 $purple: #9185be !default;
 $pink: #f6b4cc !default;
+$blue-dark: #022756 !default;

--- a/meinberlin/assets/scss/styles_user_facing/_variables.scss
+++ b/meinberlin/assets/scss/styles_user_facing/_variables.scss
@@ -99,3 +99,4 @@ $enable-dark-mode: false !default;
 
 $purple: #9185be !default;
 $pink: #f6b4cc !default;
+$blue-dark: #022756 !default;

--- a/meinberlin/templates/a4modules/includes/module_detail_phase.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase.html
@@ -7,9 +7,7 @@
     {% include "a4modules/includes/module_detail_phase_info.html" %}
     {% endwith %}
 {% else %}
-    <div class="modul-buehne">
-        {% include "a4modules/includes/module_detail_phase_swiper.html" %}
-    </div>
+    {% include "a4modules/includes/module_detail_phase_swiper.html" %}
 {% endif %}
 {% endwith %}
 

--- a/meinberlin/templates/a4modules/includes/module_detail_phase.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase.html
@@ -1,27 +1,26 @@
 {% load i18n %}
 
+
 {% with phase_count=module.phases.count %}
-<div class="phase-info">
-    {% if phase_count == 1 %}
-        {% with phase=module.phases.first %}
-            {% include "a4modules/includes/module_detail_phase_info.html" %}
-        {% endwith %}
-    {% else %}
+{% if phase_count == 1 %}
+    {% with phase=module.phases.first %}
+    {% include "a4modules/includes/module_detail_phase_info.html" %}
+    {% endwith %}
+{% else %}
     <div class="modul-buehne">
         {% include "a4modules/includes/module_detail_phase_swiper.html" %}
     </div>
-    {% endif %}
-</div>
+{% endif %}
 {% endwith %}
 
-<div class="offset-lg-3 col-lg-6 u-spacer-bottom-double">
 {% if project.is_private %}
     <div>
-        <i class="fas fa-lock u-spacer-right" aria-hidden="true"></i>{% translate 'This project is not publicly visible. Only invited users can see content and actively participate.' %}
+        <span class="fas fa-lock u-spacer-right" aria-hidden="true"></span>
+        {% translate 'This project is not publicly visible. Only invited users can see content and actively participate.' %}
     </div>
 {% elif project.is_semipublic %}
     <div>
-        <i class="fas fa-eye u-spacer-right" aria-hidden="true"></i>{% translate 'This project is publicly visible. Invited users can actively participate.' %}
+        <span class="fas fa-eye u-spacer-right" aria-hidden="true"></span>
+        {% translate 'This project is publicly visible. Invited users can actively participate.' %}
     </div>
 {% endif %}
-</div>

--- a/meinberlin/templates/a4modules/includes/module_detail_phase.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase.html
@@ -1,13 +1,15 @@
 {% load i18n %}
 
 {% with phase_count=module.phases.count %}
-<div class="offset-lg-3 col-lg-6">
+<div class="phase-info">
     {% if phase_count == 1 %}
         {% with phase=module.phases.first %}
             {% include "a4modules/includes/module_detail_phase_info.html" %}
         {% endwith %}
     {% else %}
+    <div class="modul-buehne">
         {% include "a4modules/includes/module_detail_phase_swiper.html" %}
+    </div>
     {% endif %}
 </div>
 {% endwith %}

--- a/meinberlin/templates/a4modules/includes/module_detail_phase_info.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase_info.html
@@ -1,7 +1,13 @@
 {% load i18n contrib_tags %}
 
-<div class="phase-info__item u-spacer-top">
-    <div class="u-align-right">
+<article class="phase-info__item">
+    <section>
+        <h2 class="phase-info__title">{{ phase.name }}</h2>
+        <p>{{ phase.description }}</p>
+    </section>
+    <section role="status" aria-label="{% translate 'Phase status' %}">
+        <span class="fas fa-clock" aria-hidden="true"></span>
+
         {% if phase == module.active_phase %}
             <span
                 class="phase-info__highlight u-bold"
@@ -19,19 +25,13 @@
         {% else %}
             <span
                 class="phase-info__highlight u-secondary u-bold"
+                id="finished"
             >
                 {% translate 'finished' %}
             </span>
-        {% endif %}
-    </div>
-    <div class="phase-info__item__title">
-        <span class="lr-bar__left">{{ phase.name }}</span>
-    </div>
-    <div class="phase-info__item__subtitle">
+        {% endif %} 
+
         {% html_date phase.start_date 'DATETIME_FORMAT' %}
         &ndash; {% html_date phase.end_date 'DATETIME_FORMAT' %}
-    </div>
-    <div class="phase-info__item__description">
-        {{ phase.description }}
-    </div>
-</div>
+    </section>
+</article>

--- a/meinberlin/templates/a4modules/includes/module_detail_phase_info.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase_info.html
@@ -1,6 +1,6 @@
 {% load i18n contrib_tags %}
 
-<article class="phase-info__item">
+<article>
     <section>
         <h2 class="phase-info__title">{{ phase.name }}</h2>
         <p>{{ phase.description }}</p>
@@ -10,21 +10,21 @@
 
         {% if phase == module.active_phase %}
             <span
-                class="phase-info__highlight u-bold"
+                class="u-bold"
                 id="active-phase"
             >
                 {% translate 'active' %}
             </span>
         {% elif phase in module.future_phases %}
             <span
-                class="phase-info__highlight u-secondary u-bold"
+                class="u-secondary u-bold"
                 id="upcoming-phase"
             >
                 {% translate 'upcoming' %}
             </span>
         {% else %}
             <span
-                class="phase-info__highlight u-secondary u-bold"
+                class="u-secondary u-bold"
                 id="finished"
             >
                 {% translate 'finished' %}

--- a/meinberlin/templates/a4modules/includes/module_detail_phase_swiper.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase_swiper.html
@@ -24,9 +24,6 @@
 <!-- End Swiper Template -->
 
 {% block extra_js %}
-<!-- Swiper JS -->
-<script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
-<!-- Your Swiper initialization script -->
-<script src="{% static 'swiper_phases.js' %}"></script>
+    <script src="{% static 'swiper_phases.js' %}" defer></script>
 {% endblock %}
 

--- a/meinberlin/templates/a4modules/includes/module_detail_phase_swiper.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase_swiper.html
@@ -1,13 +1,13 @@
-{% load static %}
+{% load static i18n %}
 <!-- Start Swiper Template -->
-<div role="region" aria-label="Carousel" class="swiper-container swiper">
-    <div role="group" aria-label="Slide controls" class="swiper-navigation">
+<div role="region" aria-label="Slider" class="swiper-container swiper">
+    <div role="group" aria-label="{% trans 'Slide controls' %}" class="swiper-navigation">
         <button
-            aria-label="Show previous slide"
+            aria-label="{% trans 'Show previous slide' %}"
             class="swiper-button-prev"
         ></button>
         <button
-            aria-label="Show next slide"
+            aria-label="{% trans 'Show next slide' %}"
             class="swiper-button-next"
         ></button>
         <div class="swiper-pagination"></div>
@@ -24,6 +24,9 @@
 <!-- End Swiper Template -->
 
 {% block extra_js %}
-    <script src="{% static 'swiper_phases.js' %}"></script>
+<!-- Swiper JS -->
+<script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+<!-- Your Swiper initialization script -->
+<script src="{% static 'swiper_phases.js' %}"></script>
 {% endblock %}
 

--- a/meinberlin/templates/a4modules/includes/module_detail_phase_swiper.html
+++ b/meinberlin/templates/a4modules/includes/module_detail_phase_swiper.html
@@ -1,17 +1,29 @@
 {% load static %}
 <!-- Start Swiper Template -->
-<div class="swiper-phases swiper">
-    <div class="swiper-wrapper">
-        {% for phase in module.phases %}
-            <div class="swiper-slide">
-                {% include "a4modules/includes/module_detail_phase_info.html" %}
-            </div>
-        {% endfor %}
+<div role="region" aria-label="Carousel" class="swiper-container swiper">
+    <div role="group" aria-label="Slide controls" class="swiper-navigation">
+        <button
+            aria-label="Show previous slide"
+            class="swiper-button-prev"
+        ></button>
+        <button
+            aria-label="Show next slide"
+            class="swiper-button-next"
+        ></button>
+        <div class="swiper-pagination"></div>
     </div>
-    <div class="swiper-pagination"></div>
+
+    <ul class="swiper-wrapper">
+        {% for phase in module.phases %}
+        <li class="swiper-slide">
+            {% include "a4modules/includes/module_detail_phase_info.html" %}
+        </li>
+        {% endfor %}
+    </ul>
 </div>
 <!-- End Swiper Template -->
 
 {% block extra_js %}
     <script src="{% static 'swiper_phases.js' %}"></script>
 {% endblock %}
+

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -3,16 +3,20 @@
 
 <!-- Extra blocks to ensure cookie banner for live stream -->
 {% block extra_css %}
-  {{ block.super }}
-    <link rel="stylesheet" href="{% static 'dsgvo_video_embed.css' %}" />
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'dsgvo_video_embed.css' %}"/>
 {% endblock %}
 
 {% block extra_js %}
-  {{ block.super }}
+    {{ block.super }}
     <script type="text/javascript" src="{% static 'dsgvo_video_embed.js' %}"></script>
 {% endblock %}
 
-{% block title %}{{project.name}} &mdash; {{ block.super }}{% endblock %}
+{% block title %}
+    {{ project.name }}
+    &mdash;
+    {{ block.super }}
+{% endblock %}
 
 {% block extra_messages %}
     {{ block.super }}
@@ -30,42 +34,50 @@
 
 <!-- Breadcrumbs are only necessary for multimodule projects with simultaneously running modules since the project detail
      template correctly displays breadcrumbs for other project -->
-{% if module.is_in_module_cluster  %}
+{% if module.is_in_module_cluster %}
     {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="/">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{{ module.name|truncatechars:50 }}</li>
-            </ol>
-        </nav>
-    </div>
+        <div id="layout-grid__area--contentheader">
+            <div id="content-header">
+                <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
+                    <ol>
+                        <li>
+                            <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a>
+                        </li>
+                        <li>
+                            <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
+                        </li>
+                        <li class="active" aria-current="page">{{ module.name|truncatechars:50 }}</li>
+                    </ol>
+                </nav>
+            </div>
+        </div>
     {% endblock %}
 {% endif %}
 
 {% block content %}
 
     <div id="layout-grid__area--herounit">
-        {% if module.is_in_module_cluster  %}
+        {% if module.is_in_module_cluster %}
             <div class="u-align-right u-spacer-bottom-double">
-            {% if module.previous_module_in_cluster %}
-                <a class="button button--light" href="{% url 'module-detail' module.previous_module_in_cluster.slug %}">
-                    <i class="fa fa-chevron-left u-md-up-display-none"></i>
-                    <span class="u-md-down-display-none">{% translate 'Previous' %}</span>
-                </a>
-            {% endif %}
-            <span class="u-spacer-left u-spacer-right">{{ module.readable_index_in_cluster }} {% translate 'of' %} {{ module.module_cluster|length }}</span>
-            {% if module.next_module_in_cluster %}
-                <a class="button button--light" href="{% url 'module-detail' module.next_module_in_cluster.slug %}">
-                    <i class="fa fa-chevron-right u-md-up-display-none"></i>
-                    <span class="u-md-down-display-none">{% translate 'Next' %}</span>
-                </a>
-            {% endif %}
+                {% if module.previous_module_in_cluster %}
+                    <a class="button button--light" href="{% url 'module-detail' module.previous_module_in_cluster.slug %}">
+                        <i class="fa fa-chevron-left u-md-up-display-none"></i>
+                        <span class="u-md-down-display-none">{% translate 'Previous' %}</span>
+                    </a>
+                {% endif %}
+                <span class="u-spacer-left u-spacer-right">{{ module.readable_index_in_cluster }}
+                    {% translate 'of' %}
+                    {{ module.module_cluster|length }}</span>
+                {% if module.next_module_in_cluster %}
+                    <a class="button button--light" href="{% url 'module-detail' module.next_module_in_cluster.slug %}">
+                        <i class="fa fa-chevron-right u-md-up-display-none"></i>
+                        <span class="u-md-down-display-none">{% translate 'Next' %}</span>
+                    </a>
+                {% endif %}
             </div>
         {% endif %}
-        <div class="offset-lg-3 col-lg-6">
+        <div
+            class="offset-lg-3 col-lg-6">
             <!-- Live stream -->
             {% for phase in module.phases %}
                 {% if phase == module.active_phase and live_stream %}
@@ -81,16 +93,20 @@
         </div>
     </div>
 
-    <div id="layout-grid__area--maincontent">
-        <div class="u-full-bleed">
-            <div class="phase-info">
+
+    <section id="layout-grid__area--maincontent">
+        <div class="modul-servicepanel fullwidth panel--heavy phase-info">
+            <div class="servicepanel__main">
                 {% include "a4modules/includes/module_detail_phase.html" %}
+            </div>
+            <div class="servicepanel__right phase-info__cta">
                 {% block project_action %}{% endblock %}
             </div>
         </div>
-            {% block voting_token_field %}{% endblock %}
-            {% block phase_content %}{% endblock %}
-            {% if module.is_in_module_cluster %}
+
+        {% block voting_token_field %}{% endblock %}
+        {% block phase_content %}{% endblock %}
+        {% if module.is_in_module_cluster %}
             <section class="participation-tile__wrapper">
                 <div class="participation-tile__list-container">
                     <h2 class="participation-tile__list-header">{% translate 'More from this online participation:' %}</h2>
@@ -103,7 +119,6 @@
                     </ul>
                 </div>
             </section>
-            {% endif %}
-        </div>
-    </div>
-{% endblock %}
+        {% endif %}
+    </section>
+</div>{% endblock %}

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -83,9 +83,9 @@
 
     <div id="layout-grid__area--maincontent">
             {% include "a4modules/includes/module_detail_phase.html" %}
-            <div class="offset-lg-3 col-lg-6">
-                {% block project_action %}{% endblock %}
-            </div>
+           
+            {% block project_action %}{% endblock %}
+            
             {% block phase_content %}{% endblock %}
             {% if module.is_in_module_cluster %}
             <section class="participation-tile__wrapper">

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -82,10 +82,13 @@
     </div>
 
     <div id="layout-grid__area--maincontent">
-            {% include "a4modules/includes/module_detail_phase.html" %}
-           
-            {% block project_action %}{% endblock %}
-            
+        <div class="u-full-bleed">
+            <div class="phase-info">
+                {% include "a4modules/includes/module_detail_phase.html" %}
+                {% block project_action %}{% endblock %}
+            </div>
+        </div>
+            {% block voting_token_field %}{% endblock %}
             {% block phase_content %}{% endblock %}
             {% if module.is_in_module_cluster %}
             <section class="participation-tile__wrapper">

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "sass-loader": "13.3.2",
     "select2": "4.0.13",
     "shpjs": "4.0.4",
+    "swiper": "11.0.5",
     "timeago.js": "4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# Redesign Phase Info Component

## Test Page
`projekte/module/module-title` (e.g., [Participatory Budgeting Phase 3](http://127.0.0.1:8003/projekte/module/participatory-budgeting-3-phase-3/))

## Changes
- Implemented redesign for the Phase Info Panel component. Uses [Servicepanel](https://styleguide.berlin.de/patterns/09-vertical_marketing-page-modul-servicepanel/09-vertical_marketing-page-modul-servicepanel.html) and custom style overwrites for the swiper.
- Enhanced for both desktop and mobile views with Swiper integration.

## Previews
- Desktop: ![PhaseInfo-Desktop](https://github.com/liqd/a4-meinberlin/assets/8156337/17c92f56-57f3-44a2-8a9d-3f5b451bd927)
- Mobile: <div><img src="https://github.com/liqd/a4-meinberlin/assets/8156337/0f638796-9686-45ad-a6ea-4483340abdd7" width="250"></div>


**Tasks**
- [x] PR name contains story or task reference
- [x] Documentation (docs and inline)
- [x] Changelog
