### PR TITLE
assets/herounit-image-with-aside: add title styling and fix copyright

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_copyright.scss
+++ b/meinberlin/assets/scss/components_user_facing/_copyright.scss
@@ -1,4 +1,4 @@
-.image__copyright--aside {
+.image__copyright.image__copyright--aside {
     position: relative;
     right: revert;
     bottom: revert;

--- a/meinberlin/assets/scss/components_user_facing/_herounit-image-with-aside.scss
+++ b/meinberlin/assets/scss/components_user_facing/_herounit-image-with-aside.scss
@@ -1,0 +1,3 @@
+.herounit-image-with-aside .title {
+    margin-bottom: 0.5em;
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -56,6 +56,7 @@
 @import "components_user_facing/control-bar";
 @import "components_user_facing/copyright";
 @import "components_user_facing/follow";
+@import "components_user_facing/herounit-image-with-aside";
 @import "components_user_facing/input";
 @import "components_user_facing/link--edit";
 @import "components_user_facing/moderator_status";


### PR DESCRIPTION
…d more specific target for copyright fixes #5366

**Describe your changes**
Briefly explain what you did and provide context for a clearer understanding.

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog

fix can be seen on project detail http://localhost:8003/projekte/liqd-project/ if project has a header image with copyright

fixed image copyright so can be seen issue - needs image and copyright #5366 

expected outcome:
![screenshot(29)](https://github.com/liqd/a4-meinberlin/assets/5871230/fe2d0d6f-3028-4129-8fb2-0c87c8507dcc)
