### PR TITLE
ampel redesign fixes

### DIFF
--- a/meinberlin/assets/scss/styles_user_facing/_variables.scss
+++ b/meinberlin/assets/scss/styles_user_facing/_variables.scss
@@ -35,9 +35,9 @@ $link-hover-color-btn: darken($link-color-btn, 15%) !default;
 $border-color: #ccc !default;
 $input-border-color: $border-color !default;
 
-$feedback-color-accepted: #0a820a !default;
-$feedback-color-rejected: #dc3818 !default;
-$feedback-color-consideration: #ffae00 !default;
+$feedback-color-accepted: #00A982 !default;
+$feedback-color-rejected: #E40622 !default;
+$feedback-color-consideration: #FFE60C !default;
 
 $em-spacer: 1em !default;
 $spacer: 1rem !default;


### PR DESCRIPTION
## Ampel (Moderator Status): update color variables
Fixes https://github.com/liqd/a4-meinberlin/issues/5367

<img src="https://github.com/liqd/a4-meinberlin/assets/8156337/80eb710c-8446-4e86-8cac-1ed043938007)" alt="moderator-status-colors" width="300"/>



Can be tested on http://localhost:8003/projekte/module/idea-collection/ 

### Steps
once moderation is added to idea, check if moderator status colors on list item card match the redesign