### PR TITLE
settings/base.py: set ckeditor5 language to de

### DIFF
--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -536,6 +536,7 @@ CKEDITOR_5_ALLOW_ALL_FILE_TYPES = True
 CKEDITOR_5_UPLOAD_FILE_TYPES = ["jpg", "jpeg", "png", "gif", "pdf", "docx"]
 CKEDITOR_5_CONFIGS = {
     "default": {
+        "language": "de",
         "toolbar": [
             "bold",
             "italic",
@@ -555,6 +556,7 @@ CKEDITOR_5_CONFIGS = {
         "link": {"defaultProtocol": "https://"},
     },
     "image-editor": {
+        "language": "de",
         "toolbar": {
             "items": [
                 "bold",
@@ -591,6 +593,7 @@ CKEDITOR_5_CONFIGS = {
         "link": {"defaultProtocol": "https://"},
     },
     "collapsible-image-editor": {
+        "language": "de",
         "toolbar": [
             "bold",
             "italic",
@@ -639,6 +642,7 @@ CKEDITOR_5_CONFIGS = {
         },
     },
     "video-editor": {
+        "language": "de",
         "toolbar": ["mediaEmbed"],
         "mediaEmbed": {
             "removeProviders": [


### PR DESCRIPTION
**Describe your changes**
Set the language for the ckeditor to de / german. The ckeditor interface should now be translated into german. For example in the project information settings in the dashboard.

fixes #5392 

**Tasks**
- [ ] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog