### PR TITLE
Pm 2024 01 project detail

### DIFF
--- a/meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html
+++ b/meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
 {% load i18n static %}
 
-{% block header %}{% endblock %}
+{% block header %}{% endblock header %}
 
-{% block title %}{% translate "New Module" %} &mdash; {{ block.super }}{% endblock%}
+{% block title %}{% translate "New Module" %} — {{ block.super }}{% endblock title %}
 
 {% block content %}
+{% block menu %}{% endblock menu %}
 <div id="module-blueprint-list">
     <ul class="l-tiles-3">
         {% for blueprint_slug, blueprint in view.blueprints %}
@@ -13,7 +14,7 @@
         {% endfor %}
     </ul>
 </div>
-{% endblock %}
+{% endblock content %}
 
 {% block footer %}
-{% endblock %}
+{% endblock footer %}

--- a/meinberlin/assets/scss/components_user_facing/_phase_info.scss
+++ b/meinberlin/assets/scss/components_user_facing/_phase_info.scss
@@ -1,6 +1,16 @@
 .phase-info {
     background-color: $blue-dark;
     color: $white;
+
+    // copied from BO as fullwidth styling not applying on single module project page
+    position: relative;
+    z-index: 0;
+    left: 50%;
+    right: 50%;
+    width: 100vw;
+    margin-left: -50vw;
+    margin-right: auto;
+    overflow: hidden;
 }
 
 .phase-info__title {
@@ -20,7 +30,7 @@
 
 .phase-info .modul-servicepanel .fa, .modul-servicepanel .far, .modul-servicepanel .fas {
     // overwrite icon color
-    color: inherit; 
+    color: inherit;
 }
 
 @media print, (width <= 37.501rem) {


### PR DESCRIPTION
**Describe your changes**
Briefly explain what you did and provide context for a clearer understanding.

had to copy the fullwidth styling from BO for the phase_info for the single module project pages as the page structure is different so opinionated fullwidth styling not applied (this it's either the tabs)

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog