### PR TITLE
templates/email_base.txt: fix non-standard signature delimiter

### DIFF
--- a/changelog/_9993.md
+++ b/changelog/_9993.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- fixed non-standard plain text email signature delimiter to use the established
+  dash dash space delimiter

--- a/meinberlin/templates/email_base.txt
+++ b/meinberlin/templates/email_base.txt
@@ -10,7 +10,7 @@
 
 {% block reason %}{% endblock %}
 
----
+-- 
 {% translate 'meinBerlin is a participation platform operated by' %}
 Liquid Democracy e.V., Am Sudhaus 2, D-12053 Berlin
 


### PR DESCRIPTION
Use the standarized dash dash space to allow email software to auto-detect the signature, reference (https://datatracker.ietf.org/doc/html/rfc3676#section-4.3)

**Describe your changes**
Briefly explain what you did and provide context for a clearer understanding.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog