### PR TITLE
assets/a4-comments: small styling fixes after functional re-write

### DIFF
--- a/meinberlin/assets/scss/components/_a4-comments.scss
+++ b/meinberlin/assets/scss/components/_a4-comments.scss
@@ -1,10 +1,13 @@
-.a4-comments__box {
-    > .a4-comments__list > div > div {
-        border-top: solid 1px $border-color;
-    }
+.a4-comments__comment {
+    border-top: solid 1px $border-color;
 }
 
-.a4-comments__box--user {
+.a4-comments__text--highlighted {
+    border-left: solid 2px $primary;
+    padding-left: 0.5 * $spacer;
+}
+
+.a4-comments__box {
     margin-top: 0.75 * $spacer;
 }
 
@@ -43,12 +46,22 @@
     @extend .l-flex-row;
 }
 
-.a4-comments__child--list {
-    > .row {
-        padding-left: $spacer * 1.6;
-        border-left: 1px solid $primary;
-    }
+// edit form for parent comments
+.a4-comments__box .general-form .row {
+    @extend .l-flex-row;
 
+    flex-direction: row-reverse;
+
+    .cancel-button {
+        margin-right: 0.5 * $spacer;
+    }
+}
+
+.a4-comments__child--list {
+    padding-left: 2 * $spacer;
+    border-left: 1px solid $primary;
+
+    // edit form for child comments
     .general-form {
         padding-top: $spacer;
         margin-bottom: $spacer * 2;
@@ -125,10 +138,6 @@
     @extend .btn--light;
 }
 
-.a4-comments__dropdown-container {
-    padding-right: 0;
-}
-
 .a4-comments__dropdown {
     text-align: right !important;
     margin-right: -0.7 * $spacer;
@@ -143,6 +152,11 @@
             color: $text-color !important;
         }
     }
+}
+
+.a4-comments__dropdown-container .a4-comments__dropdown {
+    margin-left: auto;
+    padding-right: 0.75 * $spacer;
 }
 
 // No user images in mB

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "6.4.0",
     "@maplibre/maplibre-gl-leaflet": "0.0.20",
     "acorn": "8.10.0",
-    "adhocracy4": "liqd/adhocracy4#e9200571b8bf2d502036c57a40c6bdf9fb459f65",
+    "adhocracy4": "liqd/adhocracy4#4287464",
     "autoprefixer": "10.4.17",
     "bootstrap": "5.2.3",
     "copy-webpack-plugin": "11.0.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@e9200571b8bf2d502036c57a40c6bdf9fb459f65#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@4287464#egg=adhocracy4
 
 # Additional requirements
 beautifulsoup4==4.11.2


### PR DESCRIPTION
**Describe your changes**
Briefly explain what you did and provide context for a clearer understanding.

Noticed a few structural issues on main, I believe from some small refactoring done some time ago so have added a few fixes, it's a4 dependent: https://github.com/liqd/adhocracy4/pull/1522

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog

Broken version when editing comment:
![screenshot(37)](https://github.com/liqd/a4-meinberlin/assets/5871230/6e5c3953-faab-479f-9ff9-374feec4b8d2)

what it should look like on stage:
![screenshot(38)](https://github.com/liqd/a4-meinberlin/assets/5871230/2de2e571-b410-4356-aa1c-90c59acacf2a)

