### PR TITLE
apps/projects: fix comment count not including child comments

### DIFF
--- a/changelog/_5220.md
+++ b/changelog/_5220.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix contribution count on module tiles didn't include child comments (#5220)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,8 @@
 import re
 
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.models import Site
+
 
 class pytest_regex:
     """Assert that a given string meets some expectations."""
@@ -12,3 +15,11 @@ class pytest_regex:
 
     def __repr__(self):
         return self._regex.pattern
+
+
+def clear_query_cache():
+    """Clear the cache for GenericRelations.
+    Required for django_assert_num_queries to work correctly, as otherwise
+    some queries will be cached. Call directly before django_assert_num_queries."""
+    ContentType.objects.clear_cache()
+    Site.objects.clear_cache()

--- a/tests/projects/conftest.py
+++ b/tests/projects/conftest.py
@@ -1,6 +1,11 @@
 from pytest_factoryboy import register
 
+from meinberlin.test.factories import budgeting
+from meinberlin.test.factories import ideas
+
 from . import factories as invites
 
 register(invites.ModeratorInviteFactory)
 register(invites.ParticipantInviteFactory)
+register(ideas.IdeaFactory)
+register(budgeting.ProposalFactory)

--- a/tests/projects/test_project_tags.py
+++ b/tests/projects/test_project_tags.py
@@ -2,6 +2,13 @@ import factory
 import pytest
 
 from adhocracy4.test.helpers import render_template
+from adhocracy4.test.helpers import setup_phase
+from meinberlin.apps.budgeting import phases as budgeting_phases
+from meinberlin.apps.ideas import phases as idea_phases
+from meinberlin.apps.projects.templatetags.meinberlin_project_tags import (
+    get_num_entries,
+)
+from tests.helpers import clear_query_cache
 
 
 @pytest.mark.django_db
@@ -49,3 +56,74 @@ def test_is_a4_project(project, external_project, bplan):
         template, {"project": external_project}
     )
     assert "is no a4 project" == render_template(template, {"project": bplan})
+
+
+@pytest.mark.django_db
+def test_get_num_entries(
+    django_assert_num_queries,
+    module_factory,
+    phase_factory,
+    idea_factory,
+    proposal_factory,
+    comment_factory,
+):
+    phase, module, project, idea = setup_phase(
+        phase_factory, idea_factory, idea_phases.FeedbackPhase
+    )
+    phase1, module1, project1, proposal = setup_phase(
+        phase_factory, proposal_factory, budgeting_phases.CollectPhase
+    )
+    empty_module = module_factory(project=project)
+
+    # no items or comments
+    clear_query_cache()
+    with django_assert_num_queries(18):
+        count = get_num_entries(empty_module)
+        assert count == 0
+
+    # one comment, no subcomments
+    comment = comment_factory(content_object=idea)
+    clear_query_cache()
+    with django_assert_num_queries(18):
+        count = get_num_entries(module)
+        assert count == 2
+
+    # two comments, no subcomments
+    comment_1 = comment_factory(content_object=idea)
+    clear_query_cache()
+    with django_assert_num_queries(18):
+        count = get_num_entries(module)
+        assert count == 3
+
+    # two subcomments for comment
+    comment_factory(content_object=comment)
+    comment_factory(content_object=comment)
+    clear_query_cache()
+    with django_assert_num_queries(18):
+        count = get_num_entries(module)
+        assert count == 5
+
+    # two subcomments for comment_1
+    comment_factory(content_object=comment_1)
+    comment_factory(content_object=comment_1)
+    clear_query_cache()
+    with django_assert_num_queries(18):
+        count = get_num_entries(module)
+        assert count == 7
+
+    # add another comment
+    comment_factory(content_object=idea)
+    clear_query_cache()
+    with django_assert_num_queries(18):
+        count = get_num_entries(module)
+        assert count == 8
+
+    # proposal comments
+    proposal_comment = comment_factory(content_object=proposal)
+    comment_factory(content_object=proposal_comment)
+    comment_factory(content_object=proposal_comment)
+    # add subcomments
+    clear_query_cache()
+    with django_assert_num_queries(18):
+        count = get_num_entries(module1)
+        assert count == 4


### PR DESCRIPTION
**Describe your changes**
Change the template tag which calculates the number of contributions in a module to include the child comments

fixes #5220

Testing:
Add comments and child comments to an idea/proposal/... and check that the count is correct on the module tile (only is shown in a multimodule project)

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog