### PR TITLE
dependencies: update a4 tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@fortawesome/fontawesome-free": "6.5.1",
     "@maplibre/maplibre-gl-leaflet": "0.0.20",
     "acorn": "8.11.3",
-    "adhocracy4": "liqd/adhocracy4#71d27d2a822c64270aa73e4044cade4da88e142d",
+    "adhocracy4": "liqd/adhocracy4#mB-v2402.1",
     "autoprefixer": "10.4.17",
     "bootstrap": "5.2.3",
     "copy-webpack-plugin": "12.0.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@71d27d2a822c64270aa73e4044cade4da88e142d#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@mB-v2402.1#egg=adhocracy4
 
 # Additional requirements
 beautifulsoup4==4.11.2


### PR DESCRIPTION
Update a4 tag in dependencies, preparing for new release.
tag is pushed in a4.
@goapunk 

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog