### PR TITLE
add management command to create fake comments

### DIFF
--- a/changelog/_0001.md
+++ b/changelog/_0001.md
@@ -1,0 +1,3 @@
+### Added
+
+- added management command to create fake comments for testing

--- a/meinberlin/apps/dev/management/commands/create_comments.py
+++ b/meinberlin/apps/dev/management/commands/create_comments.py
@@ -1,0 +1,78 @@
+from argparse import RawTextHelpFormatter
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from faker import Faker
+
+from adhocracy4.comments.models import Comment
+from meinberlin.apps.ideas.models import Idea
+
+
+class Command(BaseCommand):
+    help = """
+    Creates fake comments for testing.
+    The command creates <count> comments as <user> on the specified <idea>.
+    To generate comments with the fixed text "Fake Comment" specify "--fixed".
+    Usage:
+
+        $ ./manage.py create_comments --user <pk> --idea <pk> --count <int>
+    """
+
+    def create_parser(self, *args, **kwargs):
+        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser.formatter_class = RawTextHelpFormatter
+        return parser
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user",
+            default=0,
+            type=int,
+            required=True,
+            help="primary key of user used to create the comments",
+        )
+        parser.add_argument(
+            "--idea",
+            default=-1,
+            type=int,
+            required=True,
+            help="primary key of the idea to add the comments to",
+        )
+        parser.add_argument(
+            "--count",
+            default=1,
+            type=int,
+            required=True,
+            help="number of comments to create",
+        )
+        parser.add_argument(
+            "--fixed",
+            action="store_true",
+            help="use fixed comment text",
+        )
+
+    def handle(self, *args, **options):
+        user_pk = options["user"]
+        idea_pk = options["idea"]
+        count = options["count"]
+        fixed = options["fixed"]
+
+        user_model = get_user_model()
+        user = user_model.objects.get(pk=user_pk)
+        idea = Idea.objects.get(pk=idea_pk)
+
+        fake = Faker("en_US")
+
+        comments = []
+        for i in range(count):
+            comments.append(
+                Comment(
+                    content_object=idea,
+                    creator=user,
+                    project=idea.project,
+                    comment=(
+                        fake.text(max_nb_chars=200) if not fixed else "Fake Comment"
+                    ),
+                )
+            )
+        Comment.objects.bulk_create(comments)


### PR DESCRIPTION
**Describe your changes**
Add a management command to create fake comments on an idea

testing: create an idea collection module, add an idea, get the id/pk from the django admin (i.e. http://127.0.0.1:8003/django-admin/meinberlin_ideas/idea/). To create one comment as the admin user run `python manage.py create_comments --user 1 --idea <the id of the idea you just looked up> --count 1`

**Tasks**
- [ ] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [x] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog