### PR TITLE
WIP projects: cache project queryset

### DIFF
--- a/meinberlin/config/settings/production.py
+++ b/meinberlin/config/settings/production.py
@@ -8,7 +8,7 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": "redis://127.0.0.1:6379/1",  # defaut is 0 and is taken by celery for backend results
-        "TIMEOUT": 60,
+        "TIMEOUT": None,
     }
 }
 

--- a/tests/projects/test_tasks_caching.py
+++ b/tests/projects/test_tasks_caching.py
@@ -40,7 +40,7 @@ def test_task_schedule_reset_cache_for_projects_becoming_active(
             end_date=next_week,
             module__project=proj,
         )
-        count += 2
+        count += 2  # give 2 mins lag between start dates
 
     # check function get_next_projects_start
     with django_assert_num_queries(1):
@@ -62,6 +62,10 @@ def test_task_schedule_reset_cache_for_projects_becoming_active(
 
         next_projects_start = cache.get("next_projects_start")
         assert next_projects_start is None
+
+        project_queryset = cache.get("project_queryset")
+        assert project_queryset is not None
+        assert project_queryset.count() == 6
 
 
 @pytest.mark.django_db
@@ -114,3 +118,7 @@ def test_task_schedule_reset_cache_for_projects_becoming_past(
 
         next_projects_end = cache.get("next_projects_end")
         assert next_projects_end is None
+
+        project_queryset = cache.get("project_queryset")
+        assert project_queryset is not None
+        assert project_queryset.count() == 6


### PR DESCRIPTION
@goapunk have a look, it's a first attempt to set the queryset in the cache when we call `reset_cache_for_projects`. Another option would be to set the queryset in the cache every 12hrs as a scheduled task. 
Also I added cache timeout as none, which means keep forever. Because we clear the cache everytime there are project updates, i thought might be ok that cache never expires. Otherwise i can set it as 24hrs.

Test are pending fixing. 

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog