### PR TITLE
settings,prod: set redis cache timeout to 24hrs

### DIFF
--- a/meinberlin/config/settings/production.py
+++ b/meinberlin/config/settings/production.py
@@ -8,7 +8,7 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": "redis://127.0.0.1:6379/1",  # defaut is 0 and is taken by celery for backend results
-        "TIMEOUT": 60,
+        "TIMEOUT": 86400,  # 24hrs
     }
 }
 


### PR DESCRIPTION
**Describe your changes**
Briefly explain what you did and provide context for a clearer understanding.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog