### PR TITLE
[#8012] redesign moderator feedback

### DIFF
--- a/changelog/_8012.md
+++ b/changelog/_8012.md
@@ -1,0 +1,8 @@
+## Changed
+
+- Refactored the label class in ModeratorStatus.jsx for improved clarity and modularity.
+- Cleaned up templates/meinberlin_contrib/item_detail.html
+
+## Added
+- Separated the moderator feedback into its own template (templates/meinberlin_contrib/components/moderator_feedback.html) for better organization.
+- Created a new stylesheet (scss/components_user_facing/_moderator_feedback.scss) specifically for the moderator feedback for improved maintainability.

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/components/moderator_feedback.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/components/moderator_feedback.html
@@ -1,0 +1,58 @@
+{% load i18n item_tags contrib_tags moderatorremark_tags %}
+
+{% with feedback_classification=object.moderator_status|classify|lower %}
+    <section class="moderator-feedback
+                            moderator-feedback__bg
+                            {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
+                            moderator-feedback__bg--{{ feedback_classification }}
+                            {% endif %}
+                            ">
+        <h2 class="moderator-feedback__title">{% translate 'Feedback' %}</h2>
+
+        {% if object.moderator_status %}
+            <!-- This div could be replaced by ModeratorStatus.jsx since it's exactly the same thing: -->
+            <div class="moderator-status" aria-label="Status Indicator">
+                <span class="moderator-status__color-indicator moderator-status__label--{{ feedback_classification }}" aria-hidden="true"/></span>
+                <span>
+                    <strong>
+                        {% translate 'Status: ' %}
+                    </strong>
+                    {{ object.get_moderator_status_display }}
+                </span>
+             </div>
+        {% endif %}
+
+        {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
+            <div class="ck-content moderator-feedback__content">
+                {{ object.moderator_feedback_text.feedback_text | safe }}
+            </div>
+        {% else %}
+            <div class="ck-content moderator-feedback__content">
+                {% translate 'To add a feedback, please click edit.' %}
+            </div>
+        {% endif %}
+
+        {% if object.moderator_feedback_text.feedback_text %}
+            <div class="moderator-feedback__meta">
+                {{ object.module.project.organisation.name }}
+
+                {% if object.moderator_feedback_text.modified %}
+                    {% translate 'updated on ' %}{% html_date object.moderator_feedback_text.modified %}
+                {% else %}
+                    {% translate 'created on ' %}{% html_date object.moderator_feedback_text.created %}
+                {% endif %}
+            </div>
+        {% endif %}
+
+        {% if is_moderator %}
+            {% get_item_url object 'moderate' False as moderate_url %}
+            {% if moderate_url %}
+                <div>
+                    <a href="{{ moderate_url }}" data-embed-target="external">
+                        {% translate 'Edit' %}
+                    </a>
+                </div>
+            {% endif %}
+        {% endif %}
+    </section>
+{% endwith %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% load i18n module_tags rules react_comments_async react_ratings react_reports wagtailcore_tags item_tags contrib_tags thumbnail moderatorremark_tags %}
+{% load i18n module_tags rules react_comments_async react_comments_async react_reports react_ratings wagtailcore_tags item_tags contrib_tags thumbnail moderatorremark_tags %}
 
-{% block title %}{{object.name}} &mdash; {{ block.super }}{% endblock %}
+{% block title %}{{ object.name }} — {{ block.super }}{% endblock title %}
 
 {% block breadcrumbs %}
     <div id="content-header">
@@ -10,39 +10,17 @@
                 <li><a href="/">meinBerlin</a></li>
                 <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
                 <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                {% if module.is_in_module_cluster  %}
+                {% if module.is_in_module_cluster %}
                 <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
                 {% endif %}
                 <li class="active" aria-current="page">{{ object.name }}</li>
             </ol>
         </nav>
     </div>
-{% endblock %}
+{% endblock breadcrumbs %}
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
-    <!-- FIXME left in as the back template tag maybe useful but not sure yet, to be removed before release if not used -->
-    <!-- <nav class="breadcrumbs" aria-label="{% translate 'breadcrumbs' %}">
-        <ul>
-            <li>
-                {% if back %}
-                <a href="{{ back }}">
-                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                    {% if back_string %}
-                        {{ back_string }}
-                    {% else %}
-                        {% translate 'map' %}
-                    {% endif %}
-                </a>
-                {% else %}
-                <a href="{{ module.get_detail_url }}">
-                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
-                    {% translate 'back' %}
-                </a>
-                {% endif %}
-            </li>
-        </ul>
-    </nav> -->
     <article >
         <div class="item-detail">
             <h1 class="item-detail__title">{{ object.name }}</h1>
@@ -55,7 +33,7 @@
                     {{ object.description | richtext }}
                 </div>
 
-                {% block additional_content %}{% endblock %}
+                {% block additional_content %}{% endblock additional_content %}
             </div>
 
             <div class="item-detail__meta lr-bar">
@@ -80,13 +58,12 @@
                             {% react_ratings object %}
                         </div>
                     {% endif %}
-                {% endblock %}
+                {% endblock ratings %}
 
                 {% get_item_change_permission object as change_perm %}
                 {% has_perm change_perm request.user object as user_may_change %}
                 {% get_item_permission object 'moderate' as moderate_perm %}
                 {% has_perm moderate_perm request.user object as is_moderator %}
-
 
                 <div class="lr-bar__right">
 
@@ -116,7 +93,7 @@
                                 <a class="dropdown-item" href="{{ moderate_url }}">{% translate 'moderate' %}</a>
                             {% endif %}
 
-                            {% block dropdown_items %}{% endblock %}
+                            {% block dropdown_items %}{% endblock dropdown_items %}
                             <li>
                                 {% translate 'report' as report_text %}
                                 {% react_reports object text=report_text class='dropdown-item' %}
@@ -127,73 +104,11 @@
                 </div>
             </div>
         </div>
-        {% block vote_button %}{% endblock %}
+        {% block vote_button %}{% endblock vote_button %}
 
-        {% block moderator_feedback %}
-        {% if object.moderator_feedback_text.feedback_text or object.moderator_status or is_moderator  %}
-                <section class="detail-info__accordion">
-                    <details class="accordion" open>
-                        <summary class="detail-info__accordion-title">
-                            <h2 class="detail-info__title">{% translate 'Feedback' %}</h2>
-                                {% if is_moderator %}
-                                    {% get_item_url object 'moderate' False as moderate_url %}
-                                    {% if moderate_url %}
-                                    <div class="detail-info__edit-btn">
-                                        <a
-                                            href="{{ moderate_url }}"
-                                            class="btn btn--small detail-info__btn"
-                                            data-embed-target="external">
-                                                <i class="fas fa-pencil" aria-hidden="true"></i>
-                                                {% translate 'Edit' %}
-                                        </a>
-                                    </div>
-                                    {% endif %}
-                                {% endif %}
-                            {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
-                                <i class="fa fa-chevron-down detail-info__collapse-btn" aria-hidden="true"></i>
-                            {% endif %}
-                        </summary>
-                        {% if object.moderator_feedback_text.feedback_text or object.moderator_status %}
-                        <div class="detail-info__accordion-body">
-                            {% if object.moderator_status %}
-                                {% with feedback_classification=object.moderator_status|classify|lower %}
-                                    <h3 class="detail-info__section-title">{% translate 'Status' %}</h3>
-                                    <div class="detail-info__status-line--{{ feedback_classification }}"></div>
-                                    <div class="detail-info__status-icon--{{ feedback_classification }}">
-                                        {% if feedback_classification == 'consideration' or feedback_classification == 'qualified' %}
-                                            <i class="fa-solid fa-circle-half-stroke fa-rotate-270"></i>
-                                        {% elif feedback_classification == 'rejected' %}
-                                            <i class="fa-solid fa-circle-xmark"></i>
-                                        {% elif feedback_classification == 'accepted' %}
-                                            <i class="fas fa-check-circle"></i>
-                                        {% endif%}
-                                        <span class="detail-info__status-label">
-                                            {{ object.get_moderator_status_display }}
-                                        </span>
-                                    </div>
-                                {% endwith %}
-                            {% endif %}
-                            {% if object.moderator_feedback_text.feedback_text %}
-                            <div class="detail-info__section--no-border">
-                                <strong class="u-spacer-right">
-                                    {{ object.module.project.organisation.name }}
-                                </strong>
-                                {% if object.moderator_feedback_text.modified %}
-                                {% translate 'updated on ' %}{% html_date object.moderator_feedback_text.modified %}
-                                {% else %}
-                                {% translate 'created on ' %}{% html_date object.moderator_feedback_text.created %}
-                                {% endif %}
-                            </div>
-                            {% endif %}
-                            <p class="u-spacer-top-half ck-content">
-                                {{ object.moderator_feedback_text.feedback_text | safe }}
-                            </p>
-                        </div>
-                        {% endif %}
-                    </details>
-                </section>
-        {% endif %}
-    {% endblock %}
+    
+        {% include "meinberlin_contrib/components/moderator_feedback.html" %}
+ 
 
     {% block moderation_info %}
         {% if is_moderator and module.blueprint_type in 'PB3,PB2,PB' %}
@@ -251,11 +166,11 @@
                 </details>
             </section>
         {% endif %}
-    {% endblock %}
+    {% endblock moderation_info %}
         <section>
             <h2 class="visually-hidden">{% translate 'Comments' %}</h2>
             {% react_comments_async object %}
         </section>
     </article>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/meinberlin/assets/scss/components_user_facing/_moderator_feedback.scss
+++ b/meinberlin/assets/scss/components_user_facing/_moderator_feedback.scss
@@ -1,0 +1,43 @@
+.moderator-feedback {
+    padding: $spacer;
+    margin: 1.2em 0;
+    background-color: $bg-secondary;
+    color: $text-color;
+}
+
+.moderator-feedback__title {
+    font-size: 18px;
+    padding: 0;
+    margin: 0.3em 0;
+}
+
+.moderator-feedback__content { 
+    p {
+        margin-bottom: 0.7em;
+    }
+}
+
+.moderator-feedback__bg {
+    &--consideration,
+    &--qualified {
+        background-color: $message-light-yellow;
+    }
+
+    &--rejected {
+        background-color: $message-light-red;
+    }
+
+    &--accepted {
+        background-color: $message-light-green;
+    }
+
+    &--none {
+        background-color: $message-light-blue;
+    }
+}
+
+.moderator-feedback__meta {
+    font-size: 14px;
+    color: $gray;
+    margin-bottom: 0.7em;
+}

--- a/meinberlin/assets/scss/components_user_facing/_moderator_status.scss
+++ b/meinberlin/assets/scss/components_user_facing/_moderator_status.scss
@@ -13,3 +13,19 @@
     height: 0.8em;
     border-radius: 50%;
 }
+
+.moderator-status__label {
+        &--consideration,
+        &--qualified {
+            background-color: $feedback-color-consideration;
+            
+        }
+    
+        &--rejected {
+            background-color: $feedback-color-rejected;
+        }
+    
+        &--accepted {
+            background-color: $feedback-color-accepted;
+        }
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -61,6 +61,7 @@
 @import "components_user_facing/follow";
 @import "components_user_facing/herounit_image_with_aside";
 @import "components_user_facing/input";
+@import "components_user_facing/moderator_feedback";
 @import "components_user_facing/moderator_status";
 @import "components_user_facing/phase_info";
 @import "components_user_facing/pill";

--- a/meinberlin/assets/scss/styles_user_facing/_variables.scss
+++ b/meinberlin/assets/scss/styles_user_facing/_variables.scss
@@ -100,3 +100,8 @@ $enable-dark-mode: false !default;
 $purple: #9185be !default;
 $pink: #f6b4cc !default;
 $blue-dark: #022756 !default;
+
+$message-light-blue: #ebf1f7;
+$message-light-green: #e2f1eb;
+$message-light-red: #fdecee;
+$message-light-yellow: #f9f4e4;

--- a/meinberlin/react/contrib/ModeratorStatus.jsx
+++ b/meinberlin/react/contrib/ModeratorStatus.jsx
@@ -11,7 +11,7 @@ export const ModeratorStatus = ({ modStatus, modStatusDisplay }) => {
     return null // Don't render the component if either prop is missing
   }
 
-  const modTypeClass = 'label--' + modStatus.toLowerCase()
+  const modTypeClass = 'moderator-status__label--' + modStatus.toLowerCase()
 
   return (
     <div className="moderator-status" aria-label={translated.ariaLabel}>


### PR DESCRIPTION
**Description:**
Redesign the _moderator feedback_ element on the item detail page:

![Screenshot 2024-03-07 at 15-00-29 Proposal 1 — meinBerlin](https://github.com/liqd/a4-meinberlin/assets/8156337/a4b02125-9937-4690-bc9b-0e2c5b4d9bd9)

![Screenshot 2024-03-07 at 15-01-13 Proposal 1 — meinBerlin](https://github.com/liqd/a4-meinberlin/assets/8156337/d4536b13-1bc3-43f3-a748-58367b571b09)

The moderator feedback can be tested on [/budgeting/2024-00014/](http://localhost:8003/budgeting/2024-00014/)

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog