### PR TITLE
projects: disable iframes in result tab

### DIFF
--- a/changelog/_1111.md
+++ b/changelog/_1111.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- disable iframes in project result tab

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -217,7 +217,7 @@
         <section class="container">
             <div class="offset-lg-2 col-lg-8 ck-content">
                 {% if project.result %}
-                    {{ project.result | transform_collapsibles | richtext }}
+                    {{ project.result | transform_collapsibles | disable_iframes | richtext }}
                 {% else %}
                     {% translate 'No results yet.' %}
                 {% endif %}


### PR DESCRIPTION
**Describe your changes**
add the `disable_iframes` templatetag as it was missing here

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog