### PR TITLE
settings/base: add ckeditor link decorator to allow opening links in …

### DIFF
--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -553,7 +553,16 @@ CKEDITOR_5_CONFIGS = {
                 "reversed": "true",
             }
         },
-        "link": {"defaultProtocol": "https://"},
+        "link": {
+            "defaultProtocol": "https://",
+            "decorators": {
+                "openInNewTab": {
+                    "mode": "manual",
+                    "label": "Open in a new tab",
+                    "attributes": {"target": "_blank"},
+                }
+            },
+        },
     },
     "image-editor": {
         "language": "de",
@@ -590,7 +599,16 @@ CKEDITOR_5_CONFIGS = {
                 "reversed": "true",
             }
         },
-        "link": {"defaultProtocol": "https://"},
+        "link": {
+            "defaultProtocol": "https://",
+            "decorators": {
+                "openInNewTab": {
+                    "mode": "manual",
+                    "label": "Open in a new tab",
+                    "attributes": {"target": "_blank"},
+                }
+            },
+        },
     },
     "collapsible-image-editor": {
         "language": "de",
@@ -627,7 +645,16 @@ CKEDITOR_5_CONFIGS = {
                 "reversed": "true",
             }
         },
-        "link": {"defaultProtocol": "https://"},
+        "link": {
+            "defaultProtocol": "https://",
+            "decorators": {
+                "openInNewTab": {
+                    "mode": "manual",
+                    "label": "Open in a new tab",
+                    "attributes": {"target": "_blank"},
+                }
+            },
+        },
         "mediaEmbed": {
             "removeProviders": [
                 "dailymotion",


### PR DESCRIPTION
…new tab

**Describe your changes**
We want this to achieve the same behavior as with the old ckeditor. When inserting a link you can now choose to open it in a new tab

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog