### PR TITLE
[#8038] redesign moderator notes

### DIFF
--- a/changelog/_8038.md
+++ b/changelog/_8038.md
@@ -1,0 +1,7 @@
+## Added
+- Separated the moderator notes into its own template (templates/meinberlin_contrib/components/moderator_notes.html) for better organization.
+- Created a new stylesheet (scss/components_user_facing/_moderator_notes.scss) specifically for the moderator notes snippet for better maintainability.
+- Added extra variables for icon color on (scss/components_user_facing/_variables.scss) with `icon-` prefix
+
+## Changed
+- refactor (scss/components_user_facing/_details.scss) to update global element selector to class `.details`

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/components/moderator_notes.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/components/moderator_notes.html
@@ -1,0 +1,71 @@
+{% load i18n item_tags contrib_tags moderatorremark_tags %}
+
+{% if is_moderator and module.blueprint_type in 'PB3,PB2,PB' %}
+    <section class="moderator-notes">
+        <details class="details" open>
+            <summary>
+                <h2 class="moderator-notes__title">{% translate 'Moderation' %}</h2>
+                <span class="fas fa-chevron-down moderator-notes__summary-icon" aria-hidden="true"></span>
+            </summary>
+
+            {% if object.module.moderationtask_set or object.remark.remark %}
+                <section>
+                    <h3>{% translate 'Moderation tasks' %}</h3>
+                    {% if object.module.moderationtask_set.count > 0 %}
+                        <ul class="moderator-notes__list">
+                            {% for task in object.module.moderationtask_set.all %}
+                                <li class="moderator-notes__list-item">
+                                    {% if task in object.completed_tasks.all %}
+                                        <span class="fas fa-check-circle moderator-notes__list-item--done" aria-label="{% translate 'Done' %}"></span>
+                                        {{ task.name }}
+                                    {% else %}
+                                        <span class="far fa-check-circle moderator-notes__list-item--pending" aria-label="{% translate 'Pending' %}"></span>
+                                        {{ task.name }}
+                                    {% endif %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        <p>
+                            {% translate 'If you want to add moderation tasks here, you can do so in the module settings.' %}
+                        </p>
+                    {% endif %}
+                </section>
+
+                <section>
+                    <h3>{% translate 'Remark' %}</h3>
+                    {% if object.remark.remark %}
+                        <div class="moderator-notes__content">
+                            <p>
+                                {{ object.remark.remark }}
+                            </p>
+                        </div>
+
+                        <div class="moderator-notes__meta">
+                            {% if object.remark.modified %}
+                                {% translate 'updated on ' %}{% html_date object.remark.modified %}
+                            {% else %}
+                                {% translate 'created on ' %}{% html_date object.remark.created %}
+                            {% endif %}
+                        </div>
+                    {% else %}
+                        <div class="moderator-notes__content">
+                            <p>
+                                {% translate 'No moderation remark has been filled yet.' %}
+                            </p>
+                        </div>
+                    {% endif %}
+                </section>
+
+            {% endif %}
+
+            {% get_item_url object 'moderate' False as moderate_url %}
+            {% if moderate_url %}
+                <a href="{{ moderate_url }}" data-embed-target="external">
+                    {% translate 'Edit' %}
+                </a>
+            {% endif %}
+
+        </details>
+    </section>
+{% endif %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -111,64 +111,8 @@
     
         {% include "meinberlin_contrib/components/moderator_feedback.html" %}
  
+        {% include "meinberlin_contrib/components/moderator_notes.html" %}
 
-    {% block moderation_info %}
-        {% if is_moderator and module.blueprint_type in 'PB3,PB2,PB' %}
-            <section class="detail-info__accordion">
-                <details class="accordion" open>
-                    <summary class="detail-info__accordion-title">
-                        <h2 class="detail-info__title">{% translate 'Moderation' %}</h2>
-                        {% get_item_url object 'moderate' False as moderate_url %}
-                        {% if moderate_url %}
-                        <div class="detail-info__edit-btn">
-                            <a
-                                href="{{ moderate_url }}"
-                                class="btn btn--small detail-info__btn"
-                                data-embed-target="external">
-                                    <i class="fas fa-pencil" aria-hidden="true"></i>
-                                    {% translate 'Edit' %}
-                            </a>
-                        </div>
-                        {% endif %}
-                        <i class="fa fa-chevron-down detail-info__collapse-btn" aria-hidden="true"></i>
-                    </summary>
-                    {% if object.module.moderationtask_set or object.remark.remark %}
-                    <div class="detail-info__accordion-body">
-                        <h3 class="detail-info__section-title">{% translate 'Moderation tasks' %}</h3>
-                        {% if object.module.moderationtask_set.count > 0 %}
-                            <ul class="u-list-reset">
-                            {% for task in object.module.moderationtask_set.all %}
-                                <li class="detail-info__list-item">
-                                {% if task in object.completed_tasks.all %}
-                                    <i class="fas fa-circle-check u-success" aria-role="img" aria-label="{% translate 'Done' %}"></i>
-                                    {{ task.name }}
-                                {% else %}
-                                    <span class="u-muted">{{ task.name }}</span>
-                                {% endif %}
-                                </li>
-                            {% endfor %}
-                            </ul>
-                        {% else %}
-                            <p class="u-muted">
-                                {% translate 'If you want to add moderation tasks here, you can do so in the module settings.' %}
-                            </p>
-                        {% endif %}
-                        <h3 class="detail-info__section-title">{% translate 'Remark' %}</h3>
-                        {% if object.remark.remark %}
-                            <p>
-                                {{ object.remark.remark }}
-                            </p>
-                        {% else %}
-                            <p class="u-muted">
-                                {% translate 'No moderation remark has been filled yet.' %}
-                            </p>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-                </details>
-            </section>
-        {% endif %}
-    {% endblock moderation_info %}
         <section>
             {% react_comments_async object %}
         </section>

--- a/meinberlin/assets/scss/components/_details.scss
+++ b/meinberlin/assets/scss/components/_details.scss
@@ -1,20 +1,34 @@
-details summary {
+.details summary {
     cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+}
+
+.details summary::marker {
+    display: none;
+    content: "";
 }
 
 // Hides the default arrow on safari
-details summary::-webkit-details-marker {
+.details summary::-webkit-details-marker {
     display: none;
 }
 
-details summary > * {
-    display: inline;
-}
-
-details summary > i {
+.details summary > span {
     transition: transform 0.3s;
+    display: flex;
 }
 
-details[open] summary > i {
+.details summary > span:before {
+    font-size: 22px;
+    align-self: center;
+}
+
+.details[open] summary > span {
     transform: rotate(180deg);
 }
+
+
+
+
+

--- a/meinberlin/assets/scss/components_user_facing/_moderator_notes.scss
+++ b/meinberlin/assets/scss/components_user_facing/_moderator_notes.scss
@@ -1,0 +1,49 @@
+.moderator-notes {
+    background-color: $bg-secondary;
+    padding: $spacer;
+}
+
+.moderator-notes__title {
+    font-size: 1.375em;
+    line-height: 1.5em;
+    margin: 0;
+}
+
+.moderator-notes__content {
+    p {
+        margin-bottom: 0.7em;
+    }
+}
+
+.moderator-notes__meta {
+    font-size: 14px;
+    color: $gray;
+    margin-bottom: 0.7em;
+}
+
+.moderator-notes__list {
+    margin-left: 0;
+    padding-left: 0;
+    list-style-type: none;
+}
+
+.moderator-notes__list-item {
+    &::marker {
+        display: none;
+        content: "";
+    }
+
+    span {
+        font-size: 18px;
+    }
+
+    &--done {
+        color: $icon-green;
+    }
+
+    &--pending {
+        color: $icon-light-grey;
+        background-color: $white;
+        border-radius: 50%;
+    }
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -61,6 +61,7 @@
 @import "components_user_facing/herounit_image_with_aside";
 @import "components_user_facing/input";
 @import "components_user_facing/moderator_feedback";
+@import "components_user_facing/moderator_notes";
 @import "components_user_facing/moderator_status";
 @import "components_user_facing/phase_info";
 @import "components_user_facing/pill";

--- a/meinberlin/assets/scss/styles_user_facing/_variables.scss
+++ b/meinberlin/assets/scss/styles_user_facing/_variables.scss
@@ -35,10 +35,6 @@ $link-hover-color-btn: darken($link-color-btn, 15%) !default;
 $border-color: #ccc !default;
 $input-border-color: $border-color !default;
 
-$feedback-color-accepted: #00A982 !default;
-$feedback-color-rejected: #E40622 !default;
-$feedback-color-consideration: #FFE60C !default;
-
 $em-spacer: 1em !default;
 $spacer: 1rem !default;
 $padding: 1rem !default;
@@ -112,3 +108,10 @@ $message-light-blue: #ebf1f7;
 $message-light-green: #e2f1eb;
 $message-light-red: #fdecee;
 $message-light-yellow: #f9f4e4;
+
+$feedback-color-accepted: #00A982 !default;
+$feedback-color-rejected: #E40622 !default;
+$feedback-color-consideration: #FFE60C !default;
+
+$icon-green: #00765b !default;
+$icon-light-grey: #dddddd !default;


### PR DESCRIPTION
**Description**
Redesign the moderator notes element on the item detail page:
![Screenshot 2024-03-18 at 16-51-01 Proposal 1 — meinBerlin](https://github.com/liqd/a4-meinberlin/assets/8156337/ce2cf95d-6b20-426a-82b7-684a7285d8b6)


The moderator notes can be tested on [/budgeting/2024-00014/](http://localhost:8003/budgeting/2024-00014/)

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [x] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog