### PR TITLE
assets/scss: fix the broken button colors after updating the BO css

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_button.scss
+++ b/meinberlin/assets/scss/components_user_facing/_button.scss
@@ -1,6 +1,10 @@
 .button {
-    &:after {
+    &:before {
         background-color: $primary;
+        color: inherit;
+    }
+
+    &:after {
         color: inherit;
     }
 }

--- a/meinberlin/assets/scss/components_user_facing/_follow.scss
+++ b/meinberlin/assets/scss/components_user_facing/_follow.scss
@@ -7,11 +7,6 @@
 .a4-btn--following {
     @extend .button;
     @extend .button--fullwidth-palm;
-
-    &:after {
-        background-color: $primary;
-        color: inherit;
-    }
 }
 
 .a4-btn--follow:after {

--- a/meinberlin/assets/scss/components_user_facing/_phase_info.scss
+++ b/meinberlin/assets/scss/components_user_facing/_phase_info.scss
@@ -11,11 +11,6 @@
 .phase-info__cta {
     // enforce button to stick to bottom of container
     margin-top: auto;
-
-    .button:after {
-        background-color: $primary;
-        color: inherit;
-    }
 }
 
 .phase-info .modul-servicepanel .fa, .modul-servicepanel .far, .modul-servicepanel .fas {


### PR DESCRIPTION
**Describe your changes**
Fix the button colors after updating the BO css. Apparently it's swapped now. Not sure if that fixed all buttons but I guess we have to keep an eye out for others

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog