### PR TITLE
[8039] redesign item detail

### DIFF
--- a/changelog/_8039.md
+++ b/changelog/_8039.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Cleaned up `meinberlin_contrib/item_detail.html` and `components/_item_detail.scss`
+- Separated dropdown into `item_detail_dropdown.html` for further refactoring.

--- a/changelog/_8039.md
+++ b/changelog/_8039.md
@@ -2,3 +2,8 @@
 
 - Cleaned up `meinberlin_contrib/item_detail.html` and `components/_item_detail.scss`
 - Separated dropdown into `item_detail_dropdown.html` for further refactoring.
+- Initialized `dropdown.scss` on style_user_facing and refactored old code.
+
+### Added
+
+- Created a new assets file `contrib/assets/dropdown.js` to handle generic dropdown functionality

--- a/meinberlin/apps/contrib/assets/dropdown.js
+++ b/meinberlin/apps/contrib/assets/dropdown.js
@@ -1,0 +1,41 @@
+const Dropdown = {
+  toggleDropdown (event) {
+    const dropdown = event.currentTarget.parentNode
+    const isOpen = dropdown.getAttribute('aria-expanded') === 'true'
+
+    dropdown.setAttribute('aria-expanded', !isOpen)
+
+    const menu = dropdown.querySelector('.dropdown__menu')
+    menu.classList.toggle('dropdown__menu--show', !isOpen)
+
+    if (!isOpen) {
+      const menu = dropdown.querySelector('.dropdown__menu')
+      menu.firstElementChild.focus()
+    }
+  },
+
+  closeDropdown (event) {
+    const dropdowns = document.querySelectorAll('.js-dropdown')
+    dropdowns.forEach(function (dropdown) {
+      const isOpen = dropdown.getAttribute('aria-expanded') === 'true'
+      if (isOpen && !dropdown.contains(event.target)) {
+        dropdown.setAttribute('aria-expanded', 'false')
+        const menu = dropdown.querySelector('.dropdown__menu')
+        menu.classList.remove('dropdown__menu--show')
+      }
+    })
+  },
+
+  init () {
+    const dropdowns = document.querySelectorAll('.js-dropdown')
+    if (dropdowns.length > 0) {
+      dropdowns.forEach(function (button) {
+        button.addEventListener('click', Dropdown.toggleDropdown)
+      })
+
+      document.addEventListener('click', Dropdown.closeDropdown)
+    }
+  }
+}
+
+export default Dropdown

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_dropdown.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_dropdown.html
@@ -1,0 +1,34 @@
+{% load i18n item_tags contrib_tags moderatorremark_tags react_reports %}
+
+<div class="dropdown js-dropdown">
+    <button title="{% translate 'Actions' %}" type="button" class="dropdown__toggle" aria-haspopup="true" aria-expanded="false" id="idea-{{ object.pk }}-actions">
+        <i class="fas fa-ellipsis-h" aria-label="{% translate 'Actions' %}"></i>
+    </button>
+    <nav class="dropdown__menu" aria-labelledby="idea-{{ object.pk }}-actions">
+        <ul class="list--clean">
+            {% if user_may_change %}
+                {% get_item_update_url object as change_url %}
+                <li class="dropdown__item">
+                    <a href="{{ change_url }}">{% translate 'Edit' %}</a>
+                </li>
+                {% get_item_delete_url object as delete_url %}
+                <li class="dropdown__item">
+                    <a href="{{ delete_url }}">{% translate 'Delete' %}</a>
+                </li>
+            {% endif %}
+            {% get_item_url object 'moderate' False as moderate_url %}
+            {% if is_moderator and moderate_url %}
+                <li class="dropdown__item">
+                    <a href="{{ moderate_url }}">{% translate 'Moderate' %}</a>
+                </li>
+            {% endif %}
+
+            {% block dropdown_items %}{% endblock dropdown_items %}
+
+            <li class="dropdown__item">
+                {% translate 'Report' as report_text %}
+                {% react_reports object text=report_text class='' %}
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_labels.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_labels.html
@@ -1,12 +1,20 @@
 {% load contrib_tags %}
 
-<div class="item-detail__labels">
-    {% for badge in object.item_badges_for_detail  %}
-        <span class="label label--big">
+<ul class="pill__list">
+    {% for badge in object.item_badges_for_detail %}
+        <li class="pill
+                        {% if badge.0 == 'category' %}
+                        pill--category
+                        {% endif %}
+                        {% if badge.0 == 'label' %}
+                        pill--label
+                        {% endif %}
+                        ">
             {% if badge.0 == 'point_label' %}
                 <i class="fas fa-map-marker-alt" aria-hidden="true"></i>
             {% endif %}
+            
             {{ badge.1 }}
-        </span>
+        </li>
     {% endfor %}
-</div>
+</ul>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -1,17 +1,29 @@
 {% extends "base.html" %}
-{% load i18n module_tags rules react_comments_async react_comments_async react_reports react_ratings wagtailcore_tags item_tags contrib_tags thumbnail moderatorremark_tags %}
+{% load i18n module_tags rules react_comments_async react_comments_async react_reports react_ratings wagtailcore_tags item_tags contrib_tags moderatorremark_tags %}
 
-{% block title %}{{ object.name }} — {{ block.super }}{% endblock title %}
+{% block title %}
+    {{ object.name }}
+    —
+    {{ block.super }}
+{% endblock title %}
 
 {% block breadcrumbs %}
     <div id="content-header">
         <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
             <ol>
-                <li><a href="/">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
+                <li>
+                    <a href="/">meinBerlin</a>
+                </li>
+                <li>
+                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a>
+                </li>
+                <li>
+                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
+                </li>
                 {% if module.is_in_module_cluster %}
-                <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
+                    <li>
+                        <a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a>
+                    </li>
                 {% endif %}
                 <li class="active" aria-current="page">{{ object.name }}</li>
             </ol>
@@ -20,102 +32,74 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
-<div id="layout-grid__area--maincontent">
-    <article >
-        <div class="item-detail">
-            <h1 class="item-detail__title">{{ object.name }}</h1>
-
-            {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
-
-            <div class="item-detail__content">
-                <div class="item-detail__basic-content ck-content">
-                    <img class="item-detail__hero-image" src="{% thumbnail object.image 'item_image' %}" alt="">
-                    <div class="ck-content">
-                        {{ object.description | richtext }}
+    <div id="layout-grid__area--maincontent">
+        <article class="item-detail">
+            <header>
+                {% if object.image %}
+                    <div class="image item-detail__image">
+                        <div class="image__image">
+                            <img src="{{ object.image.url }}" alt="{{ object.image.alt }}"/>
+                        </div>
                     </div>
+                {% endif %}
+
+                <div class="item-detail__actions">
+                    <h1 class="item-detail__title">
+                        {{ object.name }}
+                    </h1>
+
+                    {% get_item_change_permission object as change_perm %}
+                    {% has_perm change_perm request.user object as user_may_change %}
+                    {% get_item_permission object 'moderate' as moderate_perm %}
+                    {% has_perm moderate_perm request.user object as is_moderator %}
+
+                    {% if request.user.is_authenticated %}
+                        {% include "meinberlin_contrib/includes/item_detail_dropdown.html" with object=object %}
+                    {% endif %}
                 </div>
 
-                {% block additional_content %}{% endblock additional_content %}
-            </div>
-
-            <div class="item-detail__meta lr-bar">
-                <div class="lr-bar__left">
-                    <strong class="item-detail__creator">{{ object.creator.username }}</strong>
+                <div class="item-detail__user">
+                    <strong>{{ object.creator.username }}</strong>
                     {% if object.modified %}
                         {% translate 'updated on ' %}{% html_date object.modified class='list-item__date' %}
                     {% else %}
                         {% translate 'created on ' %}{% html_date object.created class='list-item__date' %}
                     {% endif %}
                 </div>
-                <div class="lr-bar__right item-detail__ref">
+
+                {% include "meinberlin_contrib/includes/item_detail_labels.html" with object=object %}
+            </header>
+
+            <section class="item-detail__content">
+                <div class="ck-content">
+                    {{ object.description | richtext }}
+                </div>
+                <div class="item-detail__reference">
                     <strong>{% translate 'Reference No.' %}:</strong>
                     {{ object.reference_number }}
                 </div>
-            </div>
+                {% block additional_content %}{% endblock additional_content %}
+            </section>
 
-            <div class="item-detail__actions lr-bar">
+            <section>
                 {% block ratings %}
                     {% if object|has_feature:"rate" %}
-                        <div class="lr-bar__left">
+                        <div>
                             {% react_ratings object %}
                         </div>
                     {% endif %}
                 {% endblock ratings %}
+            </section>
 
-                {% get_item_change_permission object as change_perm %}
-                {% has_perm change_perm request.user object as user_may_change %}
-                {% get_item_permission object 'moderate' as moderate_perm %}
-                {% has_perm moderate_perm request.user object as is_moderator %}
+            {% block vote_button %}{% endblock vote_button %}
 
-                <div class="lr-bar__right">
+            {% include "meinberlin_contrib/components/moderator_feedback.html" %}
 
-                {% if request.user.is_authenticated %}
-                    <div class="dropdown">
-                        <button
-                                title="{% translate 'Actions' %}"
-                                type="button"
-                                class="dropdown-toggle btn btn--light btn--small"
-                                data-bs-toggle="dropdown"
-                                data-flip="false"
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                id="idea-{{ object.pk }}-actions"
-                        >
-                            <i class="fa fa-ellipsis-h" aria-label="{% translate 'Actions' %}"></i>
-                        </button>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="idea-{{ object.pk }}-actions">
-                            {% if user_may_change %}
-                                {% get_item_update_url object as change_url %}
-                                <a class="dropdown-item" href="{{ change_url }}">{% translate 'edit' %}</a>
-                                {% get_item_delete_url object as delete_url %}
-                                <a class="dropdown-item" href="{{ delete_url }}">{% translate 'delete' %}</a>
-                            {% endif %}
-                            {% get_item_url object 'moderate' False as moderate_url %}
-                            {% if is_moderator and moderate_url %}
-                                <a class="dropdown-item" href="{{ moderate_url }}">{% translate 'moderate' %}</a>
-                            {% endif %}
+            {% include "meinberlin_contrib/components/moderator_notes.html" %}
 
-                            {% block dropdown_items %}{% endblock dropdown_items %}
-                            <li>
-                                {% translate 'report' as report_text %}
-                                {% react_reports object text=report_text class='dropdown-item' %}
-                            </li>
-                        </div>
-                    </div>
-                {% endif %}
-                </div>
-            </div>
-        </div>
-        {% block vote_button %}{% endblock vote_button %}
-
-    
-        {% include "meinberlin_contrib/components/moderator_feedback.html" %}
- 
-        {% include "meinberlin_contrib/components/moderator_notes.html" %}
-
-        <section>
-            {% react_comments_async object %}
-        </section>
-    </article>
-</div>
+            <section>
+                {% react_comments_async object %}
+            </section>
+        </article>
+    </div>
 {% endblock content %}

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -5,6 +5,7 @@ import 'select2' // used to select projects in containers
 import '../../apps/actions/assets/timestamps.js'
 import '../../apps/newsletters/assets/dynamic_fields.js'
 import '../../apps/users/assets/user_indicator.js'
+import Dropdown from '../../apps/contrib/assets/dropdown.js'
 
 // map search function
 import 'adhocracy4/adhocracy4/maps/static/a4maps/a4maps_address.js'
@@ -30,6 +31,8 @@ function init () {
       minimumResultsForSearch: -1
     })
   }
+
+  Dropdown.init()
 }
 
 document.addEventListener('DOMContentLoaded', init, false)

--- a/meinberlin/assets/scss/components/_item_detail.scss
+++ b/meinberlin/assets/scss/components/_item_detail.scss
@@ -1,81 +1,30 @@
-.item-detail {
-    margin-bottom: $em-spacer;
-}
-
 .item-detail__title {
-    font-size: $font-size-xl;
+    padding: $spacer 0;
+    margin: 0;
 }
 
-.item-detail__labels {
-    margin-bottom: 1em;
+.item-detail__image {
+    margin-top: -40px;
+    
+    img {
+        aspect-ratio: 2/1;
+    }
 }
 
-.item-detail__labels .label {
-    display: inline-block;
-    margin-bottom: 0.4em;
+.item-detail__user {
+    padding-bottom: $spacer;
 }
 
-.item-detail__meta {
-    padding-bottom: 0.5 * $padding;
-    font-size: $font-size-sm;
+.item-detail .pill__list {
+    margin-bottom: 0.8em;
 }
 
 .item-detail__actions {
-    padding-top: $padding;
-    border-top: 1px solid $border-color;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
-.item-detail__creator {
-    margin-right: 0.5em;
-}
-
-.item-detail__ref {
-    @media screen and (max-width: $breakpoint-xs-down) {
-        float: left !important; // overwrite the l-bar-right for mobile
-        margin-left: 0 !important;
-    }
-}
-
-.item-detail__content {
-    position: relative;
-    z-index: 0;
-    margin-bottom: 1em;
-}
-
-.item-detail__basic-content {
-    @include clearfix;
-    position: relative;
-    margin-bottom: 1.5em;
-
-    overflow-wrap: break-word;
-}
-
-.item-detail__hero-image {
-    width: 100%;
-
-    @media screen and (min-width: $breakpoint-xs) {
-        display: inline-block;
-        float: right;
-        margin-left: 0.5em;
-        width: auto;
-    }
-}
-
-.item-detail__background-image {
-    position: relative;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: center;
-    width: 100%;
-    padding-top: 60%; // this creates an aspect ratio in css, 100% = 1:1 ratio
-
-    @media screen and (min-width: $breakpoint-xs) {
-        margin: 3 * $spacer 0 2 * $spacer;
-    }
-}
-
-.item-detail__copyright {
-    position: absolute;
-    bottom: 0;
-    right: 0;
+.item-detail__reference {
+    margin-bottom: $spacer;
 }

--- a/meinberlin/assets/scss/components_user_facing/_dropdown.scss
+++ b/meinberlin/assets/scss/components_user_facing/_dropdown.scss
@@ -1,0 +1,46 @@
+.dropdown {
+    position: relative;
+}
+
+.dropdown__toggle {
+    i {
+        font-size: 1.25em;
+    }
+}
+
+.dropdown__menu {
+    position: absolute;
+    display: none;
+    right: 0;
+    white-space: nowrap;
+    border: 1px solid $text-color;
+    background-color: $white;
+    flex-direction: column;
+    justify-content: space-between;
+    box-shadow: 0 0 5px rgba(100, 100, 100, 0.5);
+
+    ul {
+        margin-bottom: 0;
+    }
+
+    @media print {
+        display: none;
+    }
+}
+
+.dropdown__item {
+    padding: 0.5 * $spacer $spacer;
+    margin-bottom: 0;
+
+    &:not(:last-child) {
+        border-bottom: 1px solid;
+    }
+
+    a {
+        margin-bottom: 0;
+    }
+}
+
+.dropdown__menu--show {
+    display: block;
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -59,6 +59,7 @@
 @import "components_user_facing/card";
 @import "components_user_facing/control-bar";
 @import "components_user_facing/a4-control-bar-search";
+@import "components_user_facing/dropdown";
 @import "components_user_facing/follow";
 @import "components_user_facing/herounit_image_with_aside";
 @import "components_user_facing/input";

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -24,6 +24,7 @@
 @import "components/dsgvo_video_embed";
 @import "components/embed_layout";
 @import "components/embed_status";
+@import "components/item_detail";
 @import "components/item_detail_2";
 @import "components/label";
 @import "components/map";


### PR DESCRIPTION
**Description**
Refactor and cleanup item detail section (except dropdown on a different pr)

Can be tested on [localhost:8003/budgeting/2024-00014/](http://localhost:8003/budgeting/2024-00014/)
- please make sure to add a photo to the item
- dropdown is tackled [in a different issue](https://github.com/liqd/a4-meinberlin/pull/5581), so it looks broken right now:
![Screenshot 2024-03-26 at 11-58-55 Eco-Hub Empowering Communities for Sustainable Living — meinBerlin](https://github.com/liqd/a4-meinberlin/assets/8156337/5f8c36f0-311a-48f7-b92d-86f6cb91b911)


**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [x] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog