### PR TITLE
assets/scss: reduce font-size for user indicator close button

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_user_indicator.scss
+++ b/meinberlin/assets/scss/components_user_facing/_user_indicator.scss
@@ -59,6 +59,6 @@
     min-height: auto;
 
     &:after {
-        font-size: 1em;
+        font-size: 0.6em;
     }
 }


### PR DESCRIPTION
**Describe your changes**
Fix the "x" close button in the user indicator, the size changed after the css update of the styleguide.

![Screenshot 2024-04-08 at 12-06-26 meinBerlin — meinBerlin](https://github.com/liqd/a4-meinberlin/assets/1710203/48457fc0-8a5d-43cf-be7d-eeddd001f176) ![Screenshot 2024-04-08 at 12-09-43 Homepage — meinBerlin](https://github.com/liqd/a4-meinberlin/assets/1710203/91d3cd87-d8a8-497e-9eb7-4ae0147084a4)




**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog