### PR TITLE
[#8015] re-design moderation form

### DIFF
--- a/changelog/_8015.md
+++ b/changelog/_8015.md
@@ -1,0 +1,5 @@
+### Changed
+
+- adapt forms on `proposal_moderate_form.html` to BO redesign
+- add two new helper/utility classes `.mt-1` `.mb-2`
+- increase (overwrite) `.formgroup__help` font-size to 14px

--- a/changelog/_8015.md
+++ b/changelog/_8015.md
@@ -1,5 +1,5 @@
 ### Changed
 
-- adapt forms on `proposal_moderate_form.html` to BO redesign
+- create reusable `moderator_form.html` snippet and update moderator form templates
 - add two new helper/utility classes `.mt-1` `.mb-2`
 - increase (overwrite) `.formgroup__help` font-size to 14px

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
@@ -1,49 +1,68 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{% translate 'Moderate' %} {{ object.name }} &mdash; {{ block.super }}{% endblock %}
+{% block title %}
+    {% translate 'Moderate' %}
+    {{ object.name }}
+    —
+    {{ block.super }}
+{% endblock %}
 
 {% block breadcrumbs %}
     <div id="content-header">
         <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
             <ol>
-                <li><a href="/">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                {% if module.is_in_module_cluster  %}
-                <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
+                <li>
+                    <a href="/">meinBerlin</a>
+                </li>
+                <li>
+                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a>
+                </li>
+                <li>
+                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
+                </li>
+                {% if module.is_in_module_cluster %}
+                    <li>
+                        <a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a>
+                    </li>
                 {% endif %}
-                <li><a href="{{ object.get_absolute_url }}">{% translate 'Proposal' %}</a></li>
+                <li>
+                    <a href="{{ object.get_absolute_url }}">{% translate 'Proposal' %}</a>
+                </li>
                 <li class="active" aria-current="page">{% translate 'Moderate proposal' %}</li>
             </ol>
         </nav>
     </div>
-{% endblock %}
+{% endblock breadcrumbs %}
 
 {% block content %}
-<div id="layout-grid__area--maincontent">
-    <h1>{% translate 'Moderate proposal' %}</h1>
+    <div id="layout-grid__area--maincontent">
+        <h1>{% translate 'Moderate proposal' %}</h1>
 
-    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-        {% csrf_token %}
-        {% for form in forms.values %}
-            {{ form.media }}
-        {% endfor %}
+        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+            {% csrf_token %}
+            {% for form in forms.values %}
+                {{ form.media }}
+            {% endfor %}
 
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
-        {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=forms.moderateable.is_archived %}
-        {% if forms.moderateable.show_tasks %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.completed_tasks add_class='u-top-divider' %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark %}
-        {% else %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark add_class='u-top-divider' %}
-        {% endif %}
+            {% include 'meinberlin_contrib/includes/form_field_select.html' with field=forms.moderateable.moderator_status %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
+            {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=forms.moderateable.is_archived %}
+            {% if forms.moderateable.show_tasks %}
+                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.completed_tasks add_class='u-top-divider' %}
+                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark %}
+            {% else %}
+                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark add_class='u-top-divider' %}
+            {% endif %}
 
-        <div class="u-spacer-bottom">
-            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-        </div>
-    </form>
-</div>
-{% endblock %}
+            <div class="form-actions">
+                <div class="form-actions__left">
+                    <a href="{{ object.get_absolute_url }}" class="link--back">{% translate 'Cancel' %}</a>
+                </div>
+                <div class="form-actions__right">
+                    <button type="submit" class="button">{% translate 'Save' %}</button>
+                </div>
+            </div>
+        </form>
+    </div>
+{% endblock content %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
@@ -6,7 +6,7 @@
     {{ object.name }}
     —
     {{ block.super }}
-{% endblock %}
+{% endblock title %}
 
 {% block breadcrumbs %}
     <div id="content-header">
@@ -38,31 +38,6 @@
 {% block content %}
     <div id="layout-grid__area--maincontent">
         <h1>{% translate 'Moderate proposal' %}</h1>
-
-        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-            {% csrf_token %}
-            {% for form in forms.values %}
-                {{ form.media }}
-            {% endfor %}
-
-            {% include 'meinberlin_contrib/includes/form_field_select.html' with field=forms.moderateable.moderator_status %}
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
-            {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=forms.moderateable.is_archived %}
-            {% if forms.moderateable.show_tasks %}
-                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.completed_tasks add_class='u-top-divider' %}
-                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark %}
-            {% else %}
-                {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark add_class='u-top-divider' %}
-            {% endif %}
-
-            <div class="form-actions">
-                <div class="form-actions__left">
-                    <a href="{{ object.get_absolute_url }}" class="link--back">{% translate 'Cancel' %}</a>
-                </div>
-                <div class="form-actions__right">
-                    <button type="submit" class="button">{% translate 'Save' %}</button>
-                </div>
-            </div>
-        </form>
+        {% include "meinberlin_contrib/components/moderator_form.html" %}
     </div>
 {% endblock content %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/components/moderator_form.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/components/moderator_form.html
@@ -1,0 +1,27 @@
+{% load i18n item_tags contrib_tags moderatorremark_tags %}
+
+<form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+    {% csrf_token %}
+    {% for form in forms.values %}
+        {{ form.media }}
+    {% endfor %}
+
+    {% include 'meinberlin_contrib/includes/form_field_select.html' with field=forms.moderateable.moderator_status %}
+    {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
+    {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=forms.moderateable.is_archived %}
+    {% if forms.moderateable.show_tasks %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.completed_tasks add_class='u-top-divider' %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark %}
+    {% else %}
+        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.remark.remark add_class='u-top-divider' %}
+    {% endif %}
+
+    <div class="form-actions">
+        <div class="form-actions__left">
+            <a href="{{ object.get_absolute_url }}" class="link--back">{% translate 'Cancel' %}</a>
+        </div>
+        <div class="form-actions__right">
+            <button type="submit" class="button">{% translate 'Save' %}</button>
+        </div>
+    </div>
+</form>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_checkbox_field.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_checkbox_field.html
@@ -1,20 +1,22 @@
 {% load i18n widget_tweaks %}
 
-<div class="form-check">
-    <label class="form-check-label">
-        {{ field|add_error_attr:"aria-invalid:true" }}
-        {{ field.label }}
-        {% if field.help_text %}
-        <div class="form-hint">
-            {{ field.help_text }}
-        </div>
+<div class="form-group {% if add_class %}{{ add_class }}{% endif %} mb-2">
+    <div class="form-check">
+        <label class="form-check-label">
+            {{ field|add_error_attr:"aria-invalid:true" }}
+            {{ field.label }}
+            {% if field.help_text %}
+                <div class="formgroup__help mt-1">
+                    {{ field.help_text }}
+                </div>
+            {% endif %}
+        </label>
+        {% if field.errors %}
+            <ul class="errorlist" aria-live="assertive" aria-atomic="true">
+                {% for error in field.errors %}
+                    <li>{{ error|escape }}</li>
+                {% endfor %}
+            </ul>
         {% endif %}
-    </label>
-    {% if field.errors %}
-        <ul class="errorlist" aria-live="assertive" aria-atomic="true">
-        {% for error in field.errors %}
-            <li>{{ error|escape }}</li>
-        {% endfor %}
-        </ul>
-    {% endif %}
+    </div>
 </div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html
@@ -1,6 +1,6 @@
 {% load i18n widget_tweaks %}
 
-<div class="form-group {% if add_class %}{{ add_class }}{% endif %}">
+<div class="form-group {% if add_class %}{{ add_class }}{% endif %} mb-2">
     <label for="{{ field.id_for_label }}" {% if tabindex %} tabindex="{{ tabindex }}" {% endif %} class="form-label">
         {{ field.label }}
         {% if field.field.required %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field_select.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field_select.html
@@ -1,0 +1,14 @@
+{% extends "meinberlin_contrib/includes/form_field.html" %}
+{% load widget_tweaks %}
+
+{% block field %}
+    <div class="widget widget--{{ field|widget_type }} input-group">
+        {% if before %}
+            <span class="input-group__before">{{ before }}</span>
+        {% endif %}
+        {{ field|add_class:'form-control'|add_error_attr:"aria-invalid:true" }}
+        {% if after %}
+            <span class="input-group__after">{{ after }}</span>
+        {% endif %}
+    </div>
+{% endblock field %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_moderate_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_moderate_form.html
@@ -1,40 +1,42 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{{ object.name }} &mdash; {% translate 'Give feedback' %}{% endblock %}
+{% block title %}
+    {{ object.name }}
+    —
+    {% translate 'Give feedback' %}
+{% endblock title %}
+
 {% block breadcrumbs %}
     <div id="content-header">
         <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
             <ol>
-                <li><a href="/">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                {% if module.is_in_module_cluster  %}
-                    <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
+                <li>
+                    <a href="/">meinBerlin</a>
+                </li>
+                <li>
+                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a>
+                </li>
+                <li>
+                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
+                </li>
+                {% if module.is_in_module_cluster %}
+                    <li>
+                        <a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a>
+                    </li>
                 {% endif %}
-                <li><a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a></li>
+                <li>
+                    <a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a>
+                </li>
                 <li class="active" aria-current="page">{% translate 'Moderate idea' %}</li>
             </ol>
         </nav>
     </div>
-{% endblock %}
+{% endblock breadcrumbs %}
+
 {% block content %}
-<div id="layout-grid__area--maincontent">
-    <h1>{% translate 'Feedback on this idea' %}</h1>
-    <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
-        {% csrf_token %}
-        {% for form in forms.values %}
-            {{ form.media }}
-        {% endfor %}
-
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
-
-
-        <div class="u-spacer-bottom">
-            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-        </div>
-    </form>
-</div>
-{% endblock %}
+    <div id="layout-grid__area--maincontent">
+        <h1>{% translate 'Feedback on this idea' %}</h1>
+        {% include "meinberlin_contrib/components/moderator_form.html" %}
+    </div>
+{% endblock content %}

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_moderate_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_moderate_form.html
@@ -1,41 +1,41 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{% blocktranslate with name=object.name %}Moderate {{ name }}{% endblocktranslate %}{% endblock %}
+{% block title %}
+    {% blocktranslate with name=object.name %}
+        Moderate {{ name }}
+    {% endblocktranslate %}
+{% endblock title %}
+
 {% block breadcrumbs %}
     <div id="layout-grid__area--contentheader">
         <div id="content-header">
             <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
                 <ol>
-                    <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
-                    <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                    {% if module.is_in_module_cluster  %}
-                        <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
+                    <li>
+                        <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a>
+                    </li>
+                    <li>
+                        <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
+                    </li>
+                    {% if module.is_in_module_cluster %}
+                        <li>
+                            <a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a>
+                        </li>
                     {% endif %}
-                    <li><a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a></li>
+                    <li>
+                        <a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a>
+                    </li>
                     <li class="active" aria-current="page">{% translate 'Moderate proposal' %}</li>
                 </ol>
             </nav>
         </div>
     </div>
-{% endblock %}
+{% endblock breadcrumbs %}
+
 {% block content %}
-<div class="container">
-    <h1>{% translate 'Moderate proposal' %}</h1>
-    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-        {% csrf_token %}
-        {% for form in forms.values %}
-            {{ form.media }}
-        {% endfor %}
-
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
-
-
-        <div class="u-spacer-bottom">
-            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-        </div>
-    </form>
-</div>
-{% endblock %}
+    <div class="container">
+        <h1>{% translate 'Moderate proposal' %}</h1>
+        {% include "meinberlin_contrib/components/moderator_form.html" %}
+    </div>
+{% endblock content %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{% blocktranslate with name=object.name %}Moderate {{ name }}{% endblocktranslate %}{% endblock %}
+{% block title %}
+    {% blocktranslate with name=object.name %}
+        Moderate {{ name }}
+    {% endblocktranslate %}
+{% endblock title %}
+
 {% block breadcrumbs %}
     <div id="content-header">
         <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
@@ -9,32 +14,19 @@
                 <li><a href="/">meinBerlin</a></li>
                 <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>
                 <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                {% if module.is_in_module_cluster  %}
-                    <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
+                {% if module.is_in_module_cluster %}
+                <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>
                 {% endif %}
                 <li><a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a></li>
                 <li class="active" aria-current="page">{% translate 'Moderate idea' %}</li>
             </ol>
         </nav>
     </div>
-{% endblock %}
+{% endblock breadcrumbs %}
+
 {% block content %}
-<div id="layout-grid__area--maincontent">
-    <h1>{% translate 'Moderate idea' %}</h1>
-    <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
-        {% csrf_token %}
-        {% for form in forms.values %}
-            {{ form.media }}
-        {% endfor %}
-
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.moderateable.moderator_status %}
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=forms.feedback_text.feedback_text %}
-
-
-        <div class="u-spacer-bottom">
-            <input type="submit" class="btn btn--primary" value="{% translate 'Save' %}" />
-            <a href="{{ object.get_absolute_url }}" class="btn btn--light">{% translate 'Cancel' %}</a>
-        </div>
-    </form>
-</div>
-{% endblock %}
+    <div id="layout-grid__area--maincontent">
+        <h1>{% translate 'Moderate idea' %}</h1>
+        {% include "meinberlin_contrib/components/moderator_form.html" %}
+    </div>
+{% endblock content %}

--- a/meinberlin/assets/scss/components/_ckeditor.scss
+++ b/meinberlin/assets/scss/components/_ckeditor.scss
@@ -12,3 +12,16 @@
     width: 100%;
   }
 }
+
+.ck-word-count {
+  @extend .formgroup__help !optional;
+}
+
+.ck .ck-toolbar {
+  border: 2px solid black !important;
+  border-bottom: none !important;
+}
+
+.ck .ck-editor__editable {
+  border: 2px solid black !important;
+}

--- a/meinberlin/assets/scss/style_dashboard.scss
+++ b/meinberlin/assets/scss/style_dashboard.scss
@@ -40,7 +40,7 @@
 @import "components_dashboard/control-bar";
 
 // @import "components/copyright";
-@import "components/ck_embed_iframe";
+@import "components/ckeditor";
 @import "components_dashboard/dashboard_nav";
 @import "components_dashboard/datepicker";
 @import "components/detail_info";

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -15,7 +15,7 @@
 @import "components/alert";
 @import "components/blocks";
 @import "components/captcheck";
-@import "components/ck_embed_iframe";
+@import "components/ckeditor";
 @import "components/detail_info";
 @import "components/details";
 @import "components/dialogue_box";
@@ -50,6 +50,7 @@
 
 // extra scss / overwrites
 @import "../extra_css/swiper";
+@import "../extra_css/ckeditor";
 
 @import "styles_user_facing/form";
 @import "styles_user_facing/utility";

--- a/meinberlin/assets/scss/styles_user_facing/_form.scss
+++ b/meinberlin/assets/scss/styles_user_facing/_form.scss
@@ -13,4 +13,6 @@ button {
   padding-left: 0;
 }
 
-
+.formgroup__help {
+  font-size: 14px;
+}

--- a/meinberlin/assets/scss/styles_user_facing/_utility.scss
+++ b/meinberlin/assets/scss/styles_user_facing/_utility.scss
@@ -31,3 +31,12 @@
 .mt-0 {
     margin-top: 0 !important;
 }
+
+// BO mimic of my-0.5
+.mt-1 {
+    margin-top: 0.5em;
+}
+
+.mb-2 {
+    margin-bottom: 1em;
+}


### PR DESCRIPTION
update moderation form according to styleguide. 
created a reusable snippet called `moderator_form.html` and added to contrib

create a proposal on i.e [http://localhost:8003/projekte/module/participatory-budgeting-3-phase/](http://localhost:8003/projekte/module/participatory-budgeting-3-phase/)

![Screenshot 2024-04-15 at 16-11-38 Moderate Proposal 1 — meinBerlin](https://github.com/liqd/a4-meinberlin/assets/8156337/c29e2511-0f6e-431f-9699-824f615a70cb)
