### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,15 +8,16 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-04-08 11:27+0200\n"
-"PO-Revision-Date: 2024-02-08 08:57+0000\n"
-"Last-Translator: Steffen Blindow <s.blindow@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js/de/>\n"
+"PO-Revision-Date: 2024-04-17 15:37+0000\n"
+"Last-Translator: Julian Dehm <j.dehm@liqd.net>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
+"js-design-dev/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.18.2\n"
+"X-Generator: Weblate 5.4.2\n"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:22
 #: adhocracy4/comments/static/comments/Comment.jsx:22
@@ -1163,8 +1164,8 @@ msgstr[1] ""
 msgctxt "card"
 msgid "Comment"
 msgid_plural "Comments"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Kommentar"
+msgstr[1] "Kommentare"
 
 #: meinberlin/react/contrib/card/CardStats.jsx:11
 #: meinberlin/react/contrib/map/ItemPopup.jsx:10


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main-design-dev](https://weblate.liqd.net/projects/meinberlin/main-design-dev/).


It also includes following components:

* [meinBerlin/js-design-dev](https://weblate.liqd.net/projects/meinberlin/js-design-dev/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main-design-dev/horizontal-auto.svg)