### PR TITLE
[7899] add captcha to bplan statement form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ lint-html-fix:
 .PHONY: lint-html-files
 lint-html-files:
 	EXIT_STATUS=0; \
-	$(VIRTUAL_ENV)/bin/djlint $(ARGUMENTS) --profile=django --ignore=H030,H031 || EXIT_STATUS=$$?; \
+	$(VIRTUAL_ENV)/bin/djlint $(ARGUMENTS) --profile=django --ignore=H030,H031,T002 || EXIT_STATUS=$$?; \
 	exit $${EXIT_STATUS}
 
 .PHONY: lint-python-files

--- a/changelog/7899.md
+++ b/changelog/7899.md
@@ -1,0 +1,7 @@
+### Added
+
+- add captcha to bplan statement form
+
+### Changed
+
+- make the captcha js listen to both DOMContentLoaded and a4.embed.ready

--- a/meinberlin/apps/bplan/forms.py
+++ b/meinberlin/apps/bplan/forms.py
@@ -1,21 +1,37 @@
 from django import forms
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 from meinberlin.apps.extprojects.forms import ExternalProjectCreateForm
 from meinberlin.apps.extprojects.forms import ExternalProjectForm
 
+from ..captcha.fields import CaptcheckCaptchaField
 from . import models
 
 
 class StatementForm(forms.ModelForm):
+    captcha = CaptcheckCaptchaField(label=_("I am not a robot"))
+
     class Meta:
         model = models.Statement
         fields = ["name", "email", "statement", "street_number", "postal_code_city"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not (hasattr(settings, "CAPTCHA_URL") and settings.CAPTCHA_URL):
+            del self.fields["captcha"]
 
 
 class BplanProjectCreateForm(ExternalProjectCreateForm):
     class Meta:
         model = models.Bplan
-        fields = ["name", "description", "tile_image", "tile_image_alt_text", "tile_image_copyright"]
+        fields = [
+            "name",
+            "description",
+            "tile_image",
+            "tile_image_alt_text",
+            "tile_image_copyright",
+        ]
 
 
 class BplanProjectForm(ExternalProjectForm):

--- a/meinberlin/apps/bplan/templates/meinberlin_bplan/statement_create_form.html
+++ b/meinberlin/apps/bplan/templates/meinberlin_bplan/statement_create_form.html
@@ -1,35 +1,36 @@
 {% extends "base.html" %}
 {% load i18n %}
-
-{% block title %}{% translate 'Submit a development plan statement' %} &mdash; {{ block.super }}{% endblock %}
-
+{% block title %}
+    {% translate "Submit a development plan statement" %} — {{ block.super }}
+{% endblock title %}
 {% block content %}
-<div class="container">
-    <div class="offset-lg-2 col-lg-8">
-        <h2>{% translate 'Submit a development plan statement' %}</h2>
-
-        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-            {% csrf_token %}
-            {{ form.media }}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.name %}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.street_number %}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.postal_code_city %}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.email %}
-
-            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.statement %}
-
-            <p>
-                {% translate "The processing of personal data is carried out as part of the development plan procedure on the basis of § 3 Baugesetzbuch in conjunction with Art. 6 Buchst. e Datenschutz-Grundverordnung und Berliner Datenschutzgesetz. Detailed information on data processing rights and personal data can be found in the privacy policy at the bottom of the page." %}
-            </p>
-
-            <div class="u-spacer-bottom">
-                <input type="submit" class="btn btn--primary" value="{% translate 'Submit' %}" />
-            </div>
-        </form>
+    <div class="container">
+        <div class="offset-lg-2 col-lg-8">
+            <h2>{% translate "Submit a development plan statement" %}</h2>
+            <form enctype="multipart/form-data"
+                  action="{{ request.path }}"
+                  method="post">
+                {% csrf_token %}
+                {{ form.media }}
+                {% include "meinberlin_contrib/includes/form_field.html" with field=form.name %}
+                {% include "meinberlin_contrib/includes/form_field.html" with field=form.street_number %}
+                {% include "meinberlin_contrib/includes/form_field.html" with field=form.postal_code_city %}
+                {% include "meinberlin_contrib/includes/form_field.html" with field=form.email %}
+                {% include "meinberlin_contrib/includes/form_field.html" with field=form.statement %}
+                {% if form.captcha %}
+                    {% with tabindex="0" %}
+                        {% include "meinberlin_contrib/includes/form_field.html" with field=form.captcha %}
+                    {% endwith %}
+                {% endif %}
+                <p>
+                    {% translate "The processing of personal data is carried out as part of the development plan procedure on the basis of § 3 Baugesetzbuch in conjunction with Art. 6 Buchst. e Datenschutz-Grundverordnung und Berliner Datenschutzgesetz. Detailed information on data processing rights and personal data can be found in the privacy policy at the bottom of the page." %}
+                </p>
+                <div class="u-spacer-bottom">
+                    <input type="submit"
+                           class="btn btn--primary"
+                           value="{% translate 'Submit' %}" />
+                </div>
+            </form>
+        </div>
     </div>
-</div>
-{% endblock %}
+{% endblock content %}

--- a/meinberlin/apps/captcha/assets/captcheck.js
+++ b/meinberlin/apps/captcha/assets/captcheck.js
@@ -31,7 +31,7 @@ const ariaLabelText = django.gettext('Click for text-based question')
 const textImageMode = '&gt; ' + django.gettext('Image mode')
 const textTextMode = '&gt; ' + django.gettext('Text mode')
 
-window.onload = function () {
+function initializeCaptcha () {
   function chooseAnswer (idp, ans, session, combinedAnswerId) {
     const inputField = document.getElementById(combinedAnswerId)
     inputField.value = ans + ':' + session
@@ -169,3 +169,6 @@ window.onload = function () {
     xhr.send()
   })
 }
+
+document.addEventListener('DOMContentLoaded', initializeCaptcha, false)
+document.addEventListener('a4.embed.ready', initializeCaptcha, false)


### PR DESCRIPTION
**Describe your changes**
add captcha to bplan statement form and disable djlint rule which clashes sometimes with html quotes

testing: in the organisation dashboard, create a bplan / bebauungsplan. After creating it you can find the embed code at the bottom of the page ("Code zum Einbetten des Projekts"). Copy the url from the `src` attribute of the iframce and open it in a new tab (e.g. `http://127.0.0.1:8003/embed/projects/test/` if you called your bplan test)

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog