### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-02-26 14:00+0100\n"
-"PO-Revision-Date: 2024-04-25 10:56+0000\n"
-"Last-Translator: Steffen Blindow <s.blindow@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main/de/>"
-"\n"
+"PO-Revision-Date: 2024-07-19 12:04+0000\n"
+"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
+"main-design-dev/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -306,7 +306,7 @@ msgstr "hier können Sie alle Kommentare exportieren"
 #: meinberlin/templates/a4maps/map_choose_point_widget.html:7
 #: meinberlin/templates/header.html:134 meinberlin/templates/header.html:143
 msgid "Search"
-msgstr "Suchen"
+msgstr "Suche"
 
 #: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
 #: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_field.html:8

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-04-08 11:27+0200\n"
-"PO-Revision-Date: 2024-04-25 10:56+0000\n"
-"Last-Translator: Steffen Blindow <s.blindow@liqd.net>\n"
+"PO-Revision-Date: 2024-07-19 12:04+0000\n"
+"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
 "js-design-dev/de/>\n"
 "Language: de_DE\n"
@@ -939,7 +939,7 @@ msgstr ""
 #: adhocracy4/static/control_bar/ControlBarSearch.jsx:5
 #: adhocracy4/static/control_bar/ControlBarSearch.jsx:5
 msgid "Search"
-msgstr "Suchen"
+msgstr "Suche"
 
 #: adhocracy4/static/control_bar/ControlBarSearch.jsx:6
 #: adhocracy4/static/control_bar/ControlBarSearch.jsx:6


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main-design-dev](https://weblate.liqd.net/projects/meinberlin/main-design-dev/).


It also includes following components:

* [meinBerlin/js-design-dev](https://weblate.liqd.net/projects/meinberlin/js-design-dev/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main-design-dev/horizontal-auto.svg)