### PR TITLE
[8163] extend caching task to external projects and plans

### DIFF
--- a/changelog/8163.md
+++ b/changelog/8163.md
@@ -1,4 +1,15 @@
 ### Added
 
-- Cache for public projects duplicating the view projects-list
-- Scheduled reseting cache for public projects every hour
+- Cache for public projects, external projects and plans duplicating the view projects-list
+- Scheduled resetting cache for public projects, external projects and plans every hour
+- add select_related to external project queryset to save a query per project
+- add select_related and prefetch_related to plans
+- add topics to prefetch_related for projects
+
+### Changed
+
+- update celery to 5.4.0
+- make post_save and post_delete signal for external projects, plans and
+  projects reset the cache instead of deleting it.
+- use delay_on_commit() to call celery tasks to prevent race conditions, adjust
+  tests

--- a/meinberlin/apps/extprojects/api.py
+++ b/meinberlin/apps/extprojects/api.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.db.models import QuerySet
 from django.utils import timezone
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -8,14 +9,26 @@ from meinberlin.apps.extprojects.models import ExternalProject
 from meinberlin.apps.extprojects.serializers import ExternalProjectSerializer
 
 
-class ExternalProjectListViewSet(viewsets.ReadOnlyModelViewSet):
-    def get_queryset(self):
-        return ExternalProject.objects.filter(
+def get_external_projects() -> QuerySet[ExternalProject]:
+    """
+    Helper function to query the db and retrieve all
+    external projects.
+    """
+    return (
+        ExternalProject.objects.filter(
             project_type="meinberlin_extprojects.ExternalProject",
             is_draft=False,
             access=Access.PUBLIC,
             is_archived=False,
         )
+        .select_related("organisation")
+        .prefetch_related("topics")
+    )
+
+
+class ExternalProjectListViewSet(viewsets.ReadOnlyModelViewSet):
+    def get_queryset(self):
+        return get_external_projects()
 
     def get_serializer(self, *args, **kwargs):
         now = timezone.now()

--- a/meinberlin/apps/extprojects/signals.py
+++ b/meinberlin/apps/extprojects/signals.py
@@ -1,12 +1,15 @@
-from django.core.cache import cache
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from .models import ExternalProject
+from meinberlin.apps.extprojects.models import ExternalProject
+from meinberlin.apps.projects.tasks import set_cache_for_projects
 
 
 @receiver(post_save, sender=ExternalProject)
 @receiver(post_delete, sender=ExternalProject)
 def reset_cache(sender, instance, *args, **kwargs):
-    cache.delete("extprojects")
+    """Refresh external projects cache on save or delete"""
+    set_cache_for_projects.delay_on_commit(
+        projects=False, get_next_projects=False, ext_projects=True, plans=False
+    )

--- a/meinberlin/apps/plans/api.py
+++ b/meinberlin/apps/plans/api.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.db.models import QuerySet
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -6,11 +7,23 @@ from meinberlin.apps.plans.models import Plan
 from meinberlin.apps.plans.serializers import PlanSerializer
 
 
+def get_plans() -> QuerySet[Plan]:
+    """
+    Helper function to query the db and retrieve all
+    plans.
+    """
+    return (
+        Plan.objects.filter(is_draft=False)
+        .select_related("organisation", "district")
+        .prefetch_related("projects", "topics")
+    )
+
+
 class PlansListViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PlanSerializer
 
     def get_queryset(self):
-        return Plan.objects.filter(is_draft=False).prefetch_related("projects")
+        return get_plans()
 
     def list(self, request, *args, **kwargs):
         data = cache.get("plans")

--- a/meinberlin/apps/plans/models.py
+++ b/meinberlin/apps/plans/models.py
@@ -175,7 +175,7 @@ class Plan(ProjectContactDetailMixin, UserGeneratedContentModel):
     def __str__(self):
         return self.title
 
-    def get_absolute_url(self):
+    def get_absolute_url(self) -> str:
         return reverse(
             "meinberlin_plans:plan-detail",
             kwargs=dict(pk="{:05d}".format(self.pk), year=self.created.year),

--- a/meinberlin/apps/plans/signals.py
+++ b/meinberlin/apps/plans/signals.py
@@ -1,12 +1,15 @@
-from django.core.cache import cache
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from .models import Plan
+from meinberlin.apps.plans.models import Plan
+from meinberlin.apps.projects.tasks import set_cache_for_projects
 
 
 @receiver(post_save, sender=Plan)
 @receiver(post_delete, sender=Plan)
 def reset_cache(sender, instance, *args, **kwargs):
-    cache.delete("plans")
+    """Refresh plan cache on save or delete"""
+    set_cache_for_projects.delay_on_commit(
+        projects=False, get_next_projects=False, ext_projects=False, plans=True
+    )

--- a/meinberlin/apps/projects/api.py
+++ b/meinberlin/apps/projects/api.py
@@ -35,6 +35,7 @@ def get_public_projects() -> QuerySet[Project]:
             "plans",
             "organisation__initiators",
             "module_set__phase_set",
+            "topics",
         )
     )
     return projects

--- a/meinberlin/apps/projects/signals.py
+++ b/meinberlin/apps/projects/signals.py
@@ -1,49 +1,35 @@
-from django.core.cache import cache
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from adhocracy4.dashboard import signals as a4dashboard_signals
+from adhocracy4.phases.models import Phase
 from adhocracy4.projects.models import Project
-from meinberlin.apps.projects.tasks import get_next_projects_end
-from meinberlin.apps.projects.tasks import get_next_projects_start
+from meinberlin.apps.projects.tasks import set_cache_for_projects
 
 
 @receiver(a4dashboard_signals.project_created)
 @receiver(a4dashboard_signals.project_published)
 @receiver(a4dashboard_signals.project_unpublished)
 def post_dashboard_signal_delete(sender, project, user, **kwargs):
-    cache.delete_many(
-        [
-            "projects_activeParticipation",
-            "projects_futureParticipation",
-            "projects_pastParticipation",
-            "private_projects",
-            "extprojects",
-        ]
-    )
+    """Refresh project, plan and extproject cache on dashboard signal"""
+    set_cache_for_projects.delay_on_commit(get_next_projects=True)
+
+
+@receiver(post_save, sender=Phase)
+@receiver(post_delete, sender=Phase)
+def post_phase_save_delete(sender, instance, **kwargs):
+    """Refresh project, plan and extproject cache on phase save or delete"""
+    set_cache_for_projects.delay_on_commit(get_next_projects=True)
 
 
 @receiver(post_save, sender=Project)
 @receiver(post_delete, sender=Project)
 def post_save_delete(sender, instance, *args, **kwargs):
     """
-    Delete cache for project list views.
+    Refresh cache for project list views.
     Capture any new phases that may got created/updated while saving a project.
     """
-
-    cache.delete_many(
-        [
-            "projects_activeParticipation",
-            "projects_futureParticipation",
-            "projects_pastParticipation",
-            "private_projects",
-            "extprojects",
-        ]
+    set_cache_for_projects.delay_on_commit(
+        projects=True, get_next_projects=True, ext_projects=False, plans=False
     )
-
-    # set cache for the next projects that will be published in the next 10min
-    get_next_projects_start()
-
-    # set cache for the next project that ends and should be unpublished
-    get_next_projects_end()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ whitenoise==6.6.0
 zeep==4.2.1
 
 # Inherited a4-core requirements
-celery==5.3.6
+celery==5.4.0
 django-allauth==0.61.1
 django-autoslug==1.9.9
 django-ckeditor==6.7.1

--- a/tests/plans/test_views_integration.py
+++ b/tests/plans/test_views_integration.py
@@ -1,5 +1,6 @@
 import pytest
 from dateutil.parser import parse
+from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -96,6 +97,8 @@ def test_list_view(
         end_date=yesterday,
         module__project=project_past,
     )
+    # clear cache as it's populated on project creation
+    cache.clear()
 
     with freeze_time(now):
         assert Project.objects.all().count() == 9

--- a/tests/projects/test_tasks_caching.py
+++ b/tests/projects/test_tasks_caching.py
@@ -4,17 +4,25 @@ from datetime import timezone
 
 import pytest
 from django.core.cache import cache
+from django.db.models import signals
+from factory.django import mute_signals
 from freezegun import freeze_time
 
+from adhocracy4.projects.enums import Access
 from meinberlin.apps.projects.tasks import get_next_projects_end
 from meinberlin.apps.projects.tasks import get_next_projects_start
 from meinberlin.apps.projects.tasks import schedule_reset_cache_for_projects
 from meinberlin.apps.projects.tasks import set_cache_for_projects
+from meinberlin.apps.projects.tasks import set_ext_projects_cache
+from meinberlin.apps.projects.tasks import set_plans_cache
+from meinberlin.apps.projects.tasks import set_public_projects_cache
+from meinberlin.test.factories.extprojects import ExternalProjectFactory
+from meinberlin.test.factories.plans import PlanFactory
 
 
 @pytest.mark.django_db
 def test_task_schedule_reset_cache_for_projects_becoming_active(
-    client, phase_factory, project_factory, django_assert_num_queries
+    phase_factory, project_factory, django_assert_num_queries
 ):
     n_objects = 6
     objects = project_factory.create_batch(size=n_objects)
@@ -43,6 +51,7 @@ def test_task_schedule_reset_cache_for_projects_becoming_active(
         )
         count += 2
 
+    cache.clear()
     # check function get_next_projects_start
     with django_assert_num_queries(1):
         future_projects_timestamps = get_next_projects_start()
@@ -57,6 +66,7 @@ def test_task_schedule_reset_cache_for_projects_becoming_active(
         result = schedule_reset_cache_for_projects()
         assert result is True
 
+    cache.clear()
     with freeze_time(now + timedelta(minutes=11)):
         result = schedule_reset_cache_for_projects()
         assert result is False
@@ -93,6 +103,8 @@ def test_task_schedule_reset_cache_for_projects_becoming_past(
         end_date=now + timedelta(minutes=5),
         module__project=become_past_project,
     )
+
+    cache.clear()
     # check function get_next_projects_start
     with django_assert_num_queries(1):
         project_timestamps = get_next_projects_end()
@@ -109,6 +121,7 @@ def test_task_schedule_reset_cache_for_projects_becoming_past(
         result = schedule_reset_cache_for_projects()
         assert result is True
 
+    cache.clear()
     with freeze_time(now + timedelta(minutes=11)):
         result = schedule_reset_cache_for_projects()
         assert result is False
@@ -118,8 +131,167 @@ def test_task_schedule_reset_cache_for_projects_becoming_past(
 
 
 @pytest.mark.django_db
+def test_task_queries_for_plans(django_assert_num_queries):
+    n_objects = 6
+    PlanFactory.create_batch(size=n_objects)
+    with django_assert_num_queries(3):
+        set_plans_cache()
+
+
+@pytest.mark.django_db
+def test_task_queries_for_extprojects(django_assert_num_queries):
+    n_objects = 6
+    ExternalProjectFactory.create_batch(
+        size=n_objects, access=Access.PUBLIC, is_draft=False, is_archived=False
+    )
+    now = datetime.now(tz=timezone.utc)
+    with django_assert_num_queries(62):
+        set_ext_projects_cache(now)
+
+
+@pytest.mark.django_db
+def test_task_queries_for_projects(
+    project_factory, phase_factory, django_assert_num_queries
+):
+    n_objects = 6
+    objects = project_factory.create_batch(size=n_objects)
+
+    # make dates to work with phase_factory
+    now = datetime.now(tz=timezone.utc)
+    last_week = now - timedelta(days=7)
+    next_week = now + timedelta(days=7)
+
+    # make active projects
+    active_projects = objects[:2]
+    for proj in active_projects:
+        phase_factory(
+            start_date=last_week,
+            end_date=next_week,
+            module__project=proj,
+        )
+
+    # make past project
+    past_project = objects[2]
+    phase_factory(
+        start_date=last_week,
+        end_date=now - timedelta(minutes=5),
+        module__project=past_project,
+    )
+
+    # make future project
+    future_project = objects[3]
+    phase_factory(
+        start_date=next_week,
+        end_date=next_week + timedelta(days=7),
+        module__project=future_project,
+    )
+
+    now = datetime.now(tz=timezone.utc)
+    with django_assert_num_queries(73):
+        set_public_projects_cache(now)
+
+
+@pytest.mark.django_db
+def test_plan_signals_only_change_plan_cache(
+    django_capture_on_commit_callbacks, project_factory
+):
+    n_objects = 6
+    with mute_signals(signals.post_save, signals.post_delete):
+        projects = project_factory.create_batch(size=n_objects)
+        plans = PlanFactory.create_batch(size=n_objects)
+        ext_projects = ExternalProjectFactory.create_batch(
+            size=n_objects, access=Access.PUBLIC, is_draft=False, is_archived=False
+        )
+        set_cache_for_projects()
+        projects[0].delete()
+        ext_projects[0].delete()
+    with django_capture_on_commit_callbacks(execute=True):
+        plans[0].delete()
+    assert len(cache.get("projects_")) == n_objects
+    assert len(cache.get("extprojects")) == n_objects
+    assert len(cache.get("plans")) == n_objects - 1
+
+
+@pytest.mark.django_db
+def test_ext_project_signals_only_change_ext_projects_and_projects_cache(
+    django_capture_on_commit_callbacks, project_factory
+):
+    n_objects = 6
+    with mute_signals(signals.post_save, signals.post_delete):
+        projects = project_factory.create_batch(size=n_objects)
+        plans = PlanFactory.create_batch(size=n_objects)
+        ext_projects = ExternalProjectFactory.create_batch(
+            size=n_objects, access=Access.PUBLIC, is_draft=False, is_archived=False
+        )
+        set_cache_for_projects()
+        projects[0].delete()
+        plans[0].delete()
+    with django_capture_on_commit_callbacks(execute=True):
+        ext_projects[0].delete()
+    assert len(cache.get("plans")) == n_objects
+    # as ExternalProject is a child class of Project, the post_delete signal for Project is also called
+    assert len(cache.get("projects_")) == n_objects - 1
+    assert len(cache.get("extprojects")) == n_objects - 1
+
+
+@pytest.mark.django_db
+def test_project_signals_only_change_projects_cache(
+    django_capture_on_commit_callbacks, project_factory
+):
+    n_objects = 6
+    with mute_signals(signals.post_save, signals.post_delete):
+        projects = project_factory.create_batch(size=n_objects)
+        plans = PlanFactory.create_batch(size=n_objects)
+        ext_projects = ExternalProjectFactory.create_batch(
+            size=n_objects, access=Access.PUBLIC, is_draft=False, is_archived=False
+        )
+        set_cache_for_projects()
+        ext_projects[0].delete()
+        plans[0].delete()
+    with django_capture_on_commit_callbacks(execute=True):
+        projects[0].delete()
+    assert len(cache.get("plans")) == n_objects
+    assert len(cache.get("extprojects")) == n_objects
+    assert len(cache.get("projects_")) == n_objects - 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "namespace,factory,factory_kwargs",
+    [
+        ("plans", PlanFactory, {}),
+        (
+            "extprojects",
+            ExternalProjectFactory,
+            {"access": Access.PUBLIC, "is_draft": False, "is_archived": False},
+        ),
+    ],
+)
+def test_task_reset_for_plans_and_exprojects(
+    namespace, factory, factory_kwargs, django_assert_num_queries
+):
+    n_objects = 6
+    cache_key = namespace
+
+    factory.create_batch(size=n_objects, **factory_kwargs)
+
+    now = datetime.now(tz=timezone.utc)
+
+    # check function set_cache_for_projects
+    set_cache_for_projects()
+
+    from freezegun import freeze_time
+
+    with freeze_time(now):
+        with django_assert_num_queries(0):
+            # 0 number of queries means the api results are cached
+            cache_projects = cache.get(cache_key)
+            assert len(cache_projects) == 6
+
+
+@pytest.mark.django_db
 def test_task_reset_cache_for_projects(
-    client, phase_factory, project_factory, django_assert_num_queries
+    phase_factory, project_factory, django_assert_num_queries
 ):
     n_objects = 6
     objects = project_factory.create_batch(size=n_objects)
@@ -158,12 +330,71 @@ def test_task_reset_cache_for_projects(
     set_cache_for_projects()
 
     with freeze_time(now):
-        active_projects = cache.get("projects_activeParticipation")
-        future_project = cache.get("projects_futureParticipation")
-        past_project = cache.get("projects_pastParticipation")
-        projects = cache.get("projects_")
-        assert len(active_projects) == 2
-        assert len(past_project) == 1
-        assert len(future_project) == 1
-        # 2 active, 1 past, 1 future, 2 unspecified
-        assert len(projects) == 6
+        with django_assert_num_queries(0):
+            active_projects = cache.get("projects_activeParticipation")
+            future_project = cache.get("projects_futureParticipation")
+            past_project = cache.get("projects_pastParticipation")
+            projects = cache.get("projects_")
+            assert len(active_projects) == 2
+            assert len(past_project) == 1
+            assert len(future_project) == 1
+            # 2 active, 1 past, 1 future, 2 unspecified
+            assert len(projects) == 6
+
+
+@pytest.mark.django_db
+def test_new_phase_resets_cache(
+    phase_factory,
+    project_factory,
+    django_assert_num_queries,
+    django_capture_on_commit_callbacks,
+):
+    n_objects = 3
+    objects = project_factory.create_batch(size=n_objects)
+
+    # make dates to work with phase_factory
+    now = datetime.now(tz=timezone.utc)
+    last_week = now - timedelta(days=7)
+    next_week = now + timedelta(days=7)
+
+    # make active projects
+    active_projects = objects[:2]
+    for proj in active_projects:
+        phase_factory(
+            start_date=last_week,
+            end_date=next_week,
+            module__project=proj,
+        )
+
+    # make future project
+    future_project = objects[2]
+    phase_factory(
+        start_date=next_week,
+        end_date=next_week + timedelta(days=7),
+        module__project=future_project,
+    )
+
+    # check function set_cache_for_projects
+    set_cache_for_projects()
+
+    with freeze_time(now):
+        with django_assert_num_queries(0):
+            active_projects = cache.get("projects_activeParticipation")
+            future_projects = cache.get("projects_futureParticipation")
+            assert len(active_projects) == 2
+            assert len(future_projects) == 1
+
+    # turn future project into active project
+    with django_capture_on_commit_callbacks(execute=True):
+        phase_factory(
+            start_date=last_week,
+            end_date=next_week,
+            module__project=future_project,
+        )
+
+    with freeze_time(now):
+        with django_assert_num_queries(0):
+            active_projects = cache.get("projects_activeParticipation")
+            future_projects = cache.get("projects_futureParticipation")
+            assert len(active_projects) == 3
+            assert len(future_projects) == 0


### PR DESCRIPTION
**Describe your changes**
add missing bits to include external projects and plans so the performance boost of the cache isn't lost

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [x] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog