### PR TITLE
caching: fix some cases in which the cache wasn't refreshed correctly

### DIFF
--- a/meinberlin/apps/projects/signals.py
+++ b/meinberlin/apps/projects/signals.py
@@ -11,8 +11,16 @@ from meinberlin.apps.projects.tasks import set_cache_for_projects
 @receiver(a4dashboard_signals.project_created)
 @receiver(a4dashboard_signals.project_published)
 @receiver(a4dashboard_signals.project_unpublished)
+@receiver(a4dashboard_signals.project_component_updated)
 def post_dashboard_signal_delete(sender, project, user, **kwargs):
     """Refresh project, plan and extproject cache on dashboard signal"""
+    set_cache_for_projects.delay_on_commit(get_next_projects=True)
+
+
+@receiver(a4dashboard_signals.module_published)
+@receiver(a4dashboard_signals.module_unpublished)
+def post_module_publish_unpublish(sender, module, **kwargs):
+    """Refresh project, plan and extproject cache on module (un)publish"""
     set_cache_for_projects.delay_on_commit(get_next_projects=True)
 
 
@@ -23,7 +31,6 @@ def post_phase_save_delete(sender, instance, **kwargs):
     set_cache_for_projects.delay_on_commit(get_next_projects=True)
 
 
-@receiver(post_save, sender=Project)
 @receiver(post_delete, sender=Project)
 def post_save_delete(sender, instance, *args, **kwargs):
     """


### PR DESCRIPTION
- add module publish and unpublish signals to refresh the cache
- add project_component_updated signal to refresh the cache

fixes #5684

while the phase signal I added reset the cache, it did it before the module was published in the project, so the project was not included in the active ones.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog