### PR TITLE
a11y issue fix: pill text color not accessible

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_pill.scss
+++ b/meinberlin/assets/scss/components_user_facing/_pill.scss
@@ -1,8 +1,8 @@
 .pill {
     margin-right: 0.5 * $spacer;
+    color: $text-base;
 
     &--category {
-        color: $text-base;
         background-color: $purple;
     }
 


### PR DESCRIPTION
apply base text-color to all pill elements

 | Before      | After |
| ----------- | ----------- |
| ![pill-before](https://github.com/user-attachments/assets/d1f5c0c4-a9e1-4bd2-a006-ea3205667eac)      | ![pill-after](https://github.com/user-attachments/assets/0dc31a48-25aa-4a0c-94f8-eca2cda36a21)      |

issue:
![pill-color](https://github.com/user-attachments/assets/500f8f72-aa4d-46bc-96d6-ef3473175eb4)
