### PR TITLE
[#5620] users/adapters.py: show actual email address in unknown_account mail

### DIFF
--- a/meinberlin/apps/users/adapters.py
+++ b/meinberlin/apps/users/adapters.py
@@ -43,6 +43,7 @@ class AccountAdapter(DefaultAccountAdapter):
             return url
 
     def send_mail(self, template_prefix, email, context):
+        context.update({"email": email})
         return UserAccountEmail.send(email, template_name=template_prefix, **context)
 
     def get_email_confirmation_redirect_url(self, request):


### PR DESCRIPTION

fixes #5620
![CleanShot 2024-09-30 at 15 45 48@2x](https://github.com/user-attachments/assets/eb67269b-54aa-49ac-a753-9f28178e18b2)
