### PR TITLE
WIP: assets/js: add polyfill for Object.hasOwn() to make comments work

### DIFF
--- a/changelog/_1113.md
+++ b/changelog/_1113.md
@@ -1,0 +1,2 @@
+- added poyfill for Object.hasOwn() to make comments work on older browsers
+  (e.g. safari 14)

--- a/meinberlin/assets/js/app.js
+++ b/meinberlin/assets/js/app.js
@@ -4,6 +4,8 @@ import 'select2' // used to select projects in containers
 import 'shariff'
 import 'slick-carousel'
 
+import 'core-js/actual/object/has-own' // required polyfill for older browsers
+
 import '../../apps/actions/assets/timestamps.js'
 import '../../apps/moderatorremark/assets/idea_remarks.js'
 import '../../apps/newsletters/assets/dynamic_fields.js'

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@babel/preset-react": "7.24.7",
     "@testing-library/react": "14.3.1",
     "babel-loader": "9.1.3",
+    "core-js": "^3.38.1",
     "eslint": "8.57.0",
     "eslint-config-standard": "17.1.0",
     "eslint-config-standard-jsx": "11.0.0",


### PR DESCRIPTION
assets/js: add polyfill for Object.hasOwn() to make comments work on older browsers. 

**Describe your changes**
Brought over from a+ -> https://github.com/liqd/adhocracy-plus/pull/2742

Testing: Test on older browsers (e.g. safari 14) with any module which has comments

**Tasks**
- [ ] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog