### PR TITLE
templates/account: refactor narrow wrapper

### DIFF
--- a/changelog/_8424.md
+++ b/changelog/_8424.md
@@ -1,0 +1,4 @@
+## Changed
+
+- renamed `/components_user_facing/_account.scss` to `/components_user_facing/_narrow-wrapper.scss`
+- adapted `templates/account/signup.html`, `templates/account/login.html` and `templates/account/password_change.html` respectively

--- a/meinberlin/assets/scss/components_user_facing/_button.scss
+++ b/meinberlin/assets/scss/components_user_facing/_button.scss
@@ -1,10 +1,16 @@
 .button {
+    color: $text-base!important;
+
     &:before {
         background-color: $primary;
-        color: inherit;
+        color: $text-base;
     }
 
     &:after {
-        color: inherit;
+        color: $text-base;
     }
+}
+
+.button--full-width {
+    width: 100%; // enforce full-width on all viewports (used on narrow containers on desktop e.g. login page)
 }

--- a/meinberlin/assets/scss/components_user_facing/_narrow-wrapper.scss
+++ b/meinberlin/assets/scss/components_user_facing/_narrow-wrapper.scss
@@ -1,23 +1,21 @@
-.account__wrapper {
+// narrow wrapper appears on login, signup, forgot password pages
+.narrow-wrapper {
     max-width: 30rem;
     margin: 0 auto;
 }
 
-.account__password-reminder {
+.narrow-wrapper__secondary-cta {
     padding: 1.5em 0 2em;
     text-align: center;
 
     @media (min-width: $breakpoint-tablet) {
         padding: 0.8em 0;
         text-align: right;
+        margin-left: 1em;
     }
 }
 
-.account__button {
-    width: 100%;
-}
-
-.account__footer {
+.narrow-wrapper__footer {
     padding: 1em 0 3em;
 
     &--decoration {

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -21,7 +21,6 @@
 @import "styles_user_facing/utility";
 
 @import "components_user_facing/accordion-list";
-@import "components_user_facing/account";
 @import "components_user_facing/alert";
 @import "components_user_facing/button";
 @import "components_user_facing/card";
@@ -35,6 +34,7 @@
 @import "components_user_facing/moderator_feedback";
 @import "components_user_facing/moderator_notes";
 @import "components_user_facing/moderator_status";
+@import "components_user_facing/narrow-wrapper";
 @import "components_user_facing/nextprev";
 @import "components_user_facing/phase_info";
 @import "components_user_facing/pill";

--- a/meinberlin/templates/account/login.html
+++ b/meinberlin/templates/account/login.html
@@ -6,7 +6,7 @@
 {% endblock head_title %}
 
 {% block content %}
-    <div class="account__wrapper">
+    <div class="narrow-wrapper">
         <h1>{% translate "Login" %}</h1>
 
         <form method="post" action="{% url 'account_login' %}" class="form--base">
@@ -27,17 +27,17 @@
                 <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
             {% endif %}
 
-            <div class="account__password-reminder">
+            <div class="narrow-wrapper__secondary-cta">
                 <a href="{% url 'account_reset_password' %}">{% translate "Forgot Password?" %}</a>
             </div>
 
-            <button class="button account__button" type="submit">{% translate "Login" %}</button>
+            <button class="button button--full-width" type="submit">{% translate "Login" %}</button>
         </form>
-      
-        <section class="account__footer">
-            <span class="account__footer--decoration" aria-hidden="true"></span>
+
+        <section class="narrow-wrapper__footer">
+            <span class="narrow-wrapper__footer--decoration" aria-hidden="true"></span>
             <h2>{% translate "Don't have an account yet?" %}</h2>
-            <a class="button button--light account__button" href="{{ signup_url }}">{% translate "Register" %}</a>
+            <a class="button button--light button--full-width" href="{{ signup_url }}">{% translate "Register" %}</a>
         </section>
     </div>
 {% endblock content %}

--- a/meinberlin/templates/account/password_reset.html
+++ b/meinberlin/templates/account/password_reset.html
@@ -1,29 +1,29 @@
 {% extends "account/base.html" %}
 {% load i18n account %}
 
-{% block head_title %}{% translate "Password Reset" %}{% endblock %}
+{% block head_title %}
+    {% translate "Password Reset" %}
+{% endblock head_title %}
 
 {% block content %}
-    <h1>{% translate "Password Reset" %}</h1>
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
+    <div class="narrow-wrapper">
+        <h1>{% translate "Password Reset" %}</h1>
 
-    <p>{% translate "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
+        <p>{% translate "Forgot password? Enter your email address and you will receive an email with which you can reset your password. Please contact us if you have any problems resetting your password." %}</p>
 
-    <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
-        {% if form.non_field_errors %}
-            <ul class="errorlist" aria-live="assertive" aria-atomic="true">
-            {% for error in form.non_field_errors %}
-                <li>{{ error|escape }}</li>
-            {% endfor %}
-            </ul>
-        {% endif %}
+        <form method="post" action="{% url 'account_reset_password' %}" class="password_reset">
+            {% if form.non_field_errors %}
+                <ul class="errorlist" aria-live="assertive" aria-atomic="true">
+                    {% for error in form.non_field_errors %}
+                        <li>{{ error|escape }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
 
-        {% csrf_token %}
-        {% include 'meinberlin_contrib/includes/form_field.html' with field=form.email %}
-        <input class="btn btn--primary" type="submit" value="{% translate 'Reset My Password' %}" />
-    </form>
-    <p>{% blocktranslate %}Please contact us if you have any trouble resetting your password.{% endblocktranslate %}</p>
-
-{% endblock %}
+            {% csrf_token %}
+            {% include 'meinberlin_contrib/includes/form_field.html' with field=form.email %}
+            
+            <button class="button button--full-width" type="submit">{% translate 'Reset Password' %}</button>            
+        </form>
+    </div>
+{% endblock content %}

--- a/meinberlin/templates/account/signup.html
+++ b/meinberlin/templates/account/signup.html
@@ -6,11 +6,10 @@
 {% endblock head_title %}
 
 {% block content %}
-    <div class="account__wrapper">
-
+    <div class="narrow-wrapper">
         <h1>{% translate "Register" %}</h1>
 
-         <form id="signup_form" method="post" action="{% url 'account_signup' %}" class="form--base">
+        <form id="signup_form" method="post" action="{% url 'account_signup' %}" class="form--base">
             {% if form.non_field_errors %}
                 <ul class="errorlist" aria-live="assertive" aria-atomic="true">
                     {% for error in form.non_field_errors %}
@@ -58,14 +57,14 @@
             {% endif %}
 
             <div class="u-spacer-top">
-                <button class="button account__button" type="submit">{% translate "Register" %}</button>
+                <button class="button button--full-width" type="submit">{% translate "Register" %}</button>
             </div>
         </form>
 
-        <section class="account__footer">
-            <span class="account__footer--decoration" aria-hidden="true"></span>
+        <section class="narrow-wrapper__footer">
+            <span class="narrow-wrapper__footer--decoration" aria-hidden="true"></span>
             <h2>{% translate "Already have an account?" %}</h2>
-            <a class="button button--light account__button" href="{{ login_url }}">{% translate "Login" %}</a>
+            <a class="button button--light button--full-width" href="{{ login_url }}">{% translate "Login" %}</a>
         </section>
     </div>
 {% endblock content %}


### PR DESCRIPTION
### Changes
- Renamed `_account.scss` to `_narrow-wrapper.scss` to reflect its use on only a handful of account pages that implement a custom narrow container. This container has a special treatment of the button, which is full width on all viewports. 
- Updated relevant templates (`signup.html`, `login.html`, and `password_change.html`) to use the renamed styles.  
- Regarding the `secondary-cta` class, I applied it as a nested class since it's a one-off style, although it does not strictly follow BEM conventions. Not quite sure about that, maybe it belongs on utility?

- should i rather create a separate cta-wrapper and then take the variation into account there? 

Let me know if this works or if you'd like any adjustments!

![Screenshot 2024-10-01 at 13-50-37 Passwort zurücksetzen — meinBerlin](https://github.com/user-attachments/assets/76126ee2-4c79-41a6-9eed-9ff5f0eb0dcc)
