### PR TITLE
contrib/templates: create reusable form_submit_actions.html

### DIFF
--- a/changelog/_8422.md
+++ b/changelog/_8422.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Updated module page forms to feature a grey background container and buttons, aligning with the BO style guide (e.g., the proposal form now uses the "form--base panel--heavy" classes for consistency).
+- Relocated follow.scss to a4-follow.scss within the adhocracy folder, indicating that it overwrites styles for an A4 component.
+
+### Added
+- Introduced a reusable snippet `form_submit_actions.html` to enhance consistency and maintainability across forms.

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/includes/proposal_form.html
@@ -1,5 +1,6 @@
 {% load i18n widget_tweaks %}
-<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
+
+<form class="form--base panel--heavy" novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
     {{ form.media }}
 
@@ -47,8 +48,5 @@
         {% endif %}
     </div>
 
-    <div class="u-spacer-bottom">
-        <input type="submit" class="btn btn--primary" value="{% translate 'Save'%}" />
-        <a href="{{ cancel }}" class="btn btn--light">{% translate 'Cancel'%}</a>
-    </div>
+    {% include 'meinberlin_contrib/includes/form_submit_actions.html' %}
 </form>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_submit_actions.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_submit_actions.html
@@ -1,0 +1,10 @@
+{% load i18n widget_tweaks %}
+
+<div class="form-actions">
+    <div class="form-actions__left">
+        <a href="{{ cancel }}" class="link--back">{% translate 'Cancel' %}</a>
+    </div>
+    <div class="form-actions__right">
+        <button class="button" type="submit">{% translate 'Save' %}</button>
+    </div>
+</div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_submit_flex_end.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_submit_flex_end.html
@@ -1,0 +1,5 @@
+{% load i18n widget_tweaks %}
+
+<div class="u-flex-end">
+    <button class="button button--fullwidth-palm" type="submit">{% translate button_text %}</button>
+</div>

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/includes/idea_form.html
@@ -1,5 +1,6 @@
 {% load i18n %}
-<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
+
+<form class="form--base panel--heavy" novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
     {{ form.media }}
 
@@ -19,8 +20,5 @@
 
     {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=form.right_of_use %}
 
-    <div class="u-spacer-bottom">
-        <input type="submit" class="btn btn--primary" value="{% translate 'Save'%}" />
-        <a href="{{ cancel }}" class="btn btn--light">{% translate 'Cancel'%}</a>
-    </div>
+    {% include 'meinberlin_contrib/includes/form_submit_actions.html' %}
 </form>

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/includes/proposal_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/includes/proposal_form.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
+<form class="form--base panel--heavy" novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
     {{ form.media }}
 
@@ -26,9 +26,6 @@
     {% include 'meinberlin_contrib/includes/form_field.html' with field=form.point %}
 
     {% include 'meinberlin_contrib/includes/form_field.html' with field=form.point_label %}
-
-    <div class="u-spacer-bottom">
-        <input type="submit" class="btn btn--primary" value="{% translate 'Save'%}" />
-        <a href="{{ cancel }}" class="btn btn--light">{% translate 'Cancel'%}</a>
-    </div>
+ 
+    {% include 'meinberlin_contrib/includes/form_submit_actions.html' %}
 </form>

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/includes/mapidea_form.html
@@ -1,5 +1,6 @@
 {% load i18n %}
-<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
+
+<form class="form--base panel--heavy" novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
     {{ form.media }}
 
@@ -23,8 +24,5 @@
 
     {% include 'meinberlin_contrib/includes/form_field.html' with field=form.point_label %}
 
-    <div class="u-spacer-bottom">
-        <input type="submit" class="btn btn--primary" value="{% translate 'Save'%}" />
-        <a href="{{ cancel }}" class="btn btn--light">{% translate 'Cancel'%}</a>
-    </div>
+    {% include 'meinberlin_contrib/includes/form_submit_actions.html' %}
 </form>

--- a/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-follow.scss
+++ b/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-follow.scss
@@ -1,0 +1,29 @@
+.follow__container > span {
+    width: 100%;
+}
+
+// BO overwrites
+.a4-btn--follow,
+.a4-btn--following {
+    @extend .button;
+    @extend .button--fullwidth-palm;
+}
+
+.a4-btn--follow:after {
+    content: "\f067"; // plus sign
+}
+
+.a4-btn--following:after {
+    content: "\f00c"; // check mark
+}
+
+// we do not display alert in mB
+.a4-follow__notification {
+    display: none;
+}
+
+.follow__container {
+    display: flex;
+    align-items: end;
+    margin-bottom: 2 * $spacer;
+}


### PR DESCRIPTION
## Changes

- created reusable submit for form submit on module forms
- adapted module form styles with grey background.
- moved follow to a4 folder

![Screenshot 2024-10-01 at 18-22-23 Edit Eco-Hub Empowering Communities for Sustainable Living — meinBerlin](https://github.com/user-attachments/assets/ff4ee39b-580b-4a8e-952f-212b47d19c3a)
