### PR TITLE
Fix styling for actions of comments on mobile

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_rating.scss
+++ b/meinberlin/assets/scss/components_user_facing/_rating.scss
@@ -1,6 +1,10 @@
 .rating {
-    display: inline-block;
-    white-space: nowrap;
+    display: flex;
+
+    @media screen and (min-width: $breakpoint-palm) {
+        display: inline-block;
+        white-space: nowrap;
+    }
 }
 
 .rating__label {
@@ -11,9 +15,16 @@
 .rating-button {
     color: $link-color;
     margin-right: 1em;
+    padding: 0;
 
     i {
         margin-right: 0.4em;
+        margin-bottom: 0.4em;
+        display: block;
+
+        @media screen and (min-width: $breakpoint-palm) {
+            display: inline;
+        }
     }
 
     .fa-chevron-up:before {

--- a/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-comments.scss
+++ b/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-comments.scss
@@ -166,6 +166,7 @@
     padding: $em-spacer 0 1.5em 0;
     overflow-x: scroll;
     scrollbar-width: none;
+    align-items: center;
 
     @media screen and (min-width: $breakpoint-palm) {
         display: flex;
@@ -177,15 +178,28 @@
 
 .a4-comments__action-bar {
     white-space: nowrap;
+    display: flex;
+    align-items: center;
 }
 
 .a4-comments__action-bar__btn {
     margin-right: $spacer;
+    padding: 0;
 
     .fa,
     .far,
     .fas {
         color: $link-color; // overwrite icons default color
+        display: block;
+        text-align: center;
+        margin-right: 0;
+        margin-bottom: .4em;
+
+        @media screen and (min-width: $breakpoint-palm) {
+            display: inline;
+            text-align: left;
+            margin-bottom: 0;
+        }
     }
 }
 


### PR DESCRIPTION
closes #5694 
the size of the last two icons bother me a bit still, because they seem so large in comparison to the others, but i left it as is for now.

![CleanShot 2024-10-16 at 18 38 06@2x](https://github.com/user-attachments/assets/6ee10aba-5ede-4211-b2c9-b859a959a440)

desktop:
![CleanShot 2024-10-16 at 18 44 29@2x](https://github.com/user-attachments/assets/0a84764c-552d-48e5-ac68-88ce16cd35fc)


cc @CarolingerSeilchenspringer 