### PR TITLE
[#8467] Remove card title hover styling and change button text

### DIFF
--- a/changelog/_8467.md
+++ b/changelog/_8467.md
@@ -8,3 +8,4 @@
 – Added `LikeCard` component to `QuestionModerator` and `QuestionUser` components
 - Style shortlist pill
 – Style moderator buttons
+– Change moderator buttons text

--- a/meinberlin/assets/scss/components_user_facing/_card.scss
+++ b/meinberlin/assets/scss/components_user_facing/_card.scss
@@ -27,6 +27,11 @@
     text-decoration: underline;
 }
 
+.card__header .title--no-underline:hover {
+    cursor: default;
+    text-decoration: none;
+}
+
 .card__link--hover {
     text-decoration: underline !important; // BO overide
 }

--- a/meinberlin/react/livequestions/LikeCard.jsx
+++ b/meinberlin/react/livequestions/LikeCard.jsx
@@ -7,7 +7,7 @@ const likedTag = django.gettext('Liked')
 const likesTag = django.gettext('Likes')
 const addLikeTag = django.gettext('add like')
 const undoLikeTag = django.gettext('undo like')
-const shortlistTag = django.gettext('on shortlist')
+const bookmarkedTag = django.gettext('bookmarked')
 
 export default function LikeCard ({
   title,
@@ -22,7 +22,7 @@ export default function LikeCard ({
   return (
     <article className="modul-card card">
       <header className="card__header">
-        <h3 className="title">{title}</h3>
+        <h3 className="title title--no-underline">{title}</h3>
         {(category || isOnShortlist) && (
           <div className="card__status status">
             {category && (
@@ -30,7 +30,7 @@ export default function LikeCard ({
             )}
             {isOnShortlist && (
               <Pill pillClass="card__pill pill pill--shortlist">
-                {shortlistTag}
+                {bookmarkedTag}
               </Pill>
             )}
           </div>

--- a/meinberlin/react/livequestions/QuestionModerator.jsx
+++ b/meinberlin/react/livequestions/QuestionModerator.jsx
@@ -101,8 +101,8 @@ export default class QuestionModerator extends React.Component {
     const doneText = django.gettext('mark as done')
     const addLiveText = django.gettext('added to live list')
     const removeLiveText = django.gettext('remove from live list')
-    const addShortlistText = django.gettext('added to shortlist')
-    const removeShortlistText = django.gettext('remove from shortlist')
+    const addBookmarkText = django.gettext('add bookmark')
+    const removeBookmarkText = django.gettext('remove bookmark')
 
     return (
       <>
@@ -124,8 +124,8 @@ export default class QuestionModerator extends React.Component {
                   this.state.is_hidden && 'card__button--active'
                 )}
                 onClick={this.toggleIshidden.bind(this)}
-                aria-label={this.props.is_hidden ? hiddenText : undoHiddenText}
-                title={this.props.is_hidden ? hiddenText : undoHiddenText}
+                aria-label={this.props.is_hidden ? undoHiddenText : hiddenText}
+                title={this.props.is_hidden ? undoHiddenText : hiddenText}
               >
                 <i
                   className={classNames(
@@ -145,10 +145,10 @@ export default class QuestionModerator extends React.Component {
                 )}
                 onClick={this.toggleIsOnShortList.bind(this)}
                 aria-label={
-                  this.state.is_on_shortlist ? addShortlistText : removeShortlistText
+                  this.state.is_on_shortlist ? removeBookmarkText : addBookmarkText
                 }
                 title={
-                  this.state.is_on_shortlist ? addShortlistText : removeShortlistText
+                  this.state.is_on_shortlist ? removeBookmarkText : addBookmarkText
                 }
               >
                 <i className="fas fa-bookmark" aria-hidden="true" />
@@ -176,8 +176,8 @@ export default class QuestionModerator extends React.Component {
                   this.state.is_live && 'card__button--active'
                 )}
                 onClick={this.toggleIslive.bind(this)}
-                aria-label={this.state.is_live ? addLiveText : removeLiveText}
-                title={this.state.is_live ? addLiveText : removeLiveText}
+                aria-label={this.state.is_live ? removeLiveText : addLiveText}
+                title={this.state.is_live ? removeLiveText : addLiveText}
               >
                 <i className="fas fa-tv" aria-hidden="true" />
               </button>


### PR DESCRIPTION
**Describe your changes**
This PR removes the card title hover styling and changes the moderator button text.

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [X] Changelog