### PR TITLE
[#8546] Style statistics progress

### DIFF
--- a/changelog/_8546.md
+++ b/changelog/_8546.md
@@ -4,3 +4,4 @@
 ### Changed
 
 - Style `StatisticsBox`
+- Add $primary green color to statistics progress

--- a/meinberlin/assets/scss/components_user_facing/_live_questions.scss
+++ b/meinberlin/assets/scss/components_user_facing/_live_questions.scss
@@ -9,15 +9,20 @@
 }
 
 .live-question__progress {
+    background-color: $body-bg;
+    border-radius: 1.2rem;
     display: flex;
-    gap: 8px;
-    margin-bottom: 8px;
+    font-size: 1rem;
+    line-height: 1.3;
+    height: 1.2rem;
+    gap: 1rem;
+    margin-bottom: 0.8rem;
     position: relative;
 }
 
 .live-question__progress-bar {
-    background-color: $gray-lighter;
-    border-radius: 10px;
+    background-color: $primary;
+    border-radius: 1.2rem;
     height: 100%;
     position: absolute;
     z-index: 0;


### PR DESCRIPTION
**Describe your changes**
This PR styles the statistics progress based on the updated design.

<img width="1016" alt="Screenshot 2024-11-26 at 14 46 11" src="https://github.com/user-attachments/assets/b1ee5127-2646-48a7-a138-630fee642d20">

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog