### PR TITLE
[8606] newsletter: remove apostrophes in subject

### DIFF
--- a/changelog/5767.md
+++ b/changelog/5767.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- newsletter subject unicode error by removing apostrophes

--- a/meinberlin/apps/newsletters/models.py
+++ b/meinberlin/apps/newsletters/models.py
@@ -75,6 +75,7 @@ class Newsletter(UserGeneratedContentModel):
 
     def save(self, update_fields=None, *args, **kwargs):
         self.body = transforms.clean_html_field(self.body, "image-editor")
+        self.subject = self.subject.replace("'", "")  # remove any apostrophes
         if update_fields:
-            update_fields = {"body"}.union(update_fields)
+            update_fields = {"body", "subject"}.union(update_fields)
         super().save(update_fields=update_fields, *args, **kwargs)

--- a/tests/newsletters/test_newsletter_views.py
+++ b/tests/newsletters/test_newsletter_views.py
@@ -30,7 +30,7 @@ def test_send_organisation(
     data = {
         "sender_name": "Tester",
         "sender": "test@test.de",
-        "subject": "Testsubject",
+        "subject": "It's a testsubject",
         "body": "Testbody",
         "receivers": newsletter_models.ORGANISATION,
         "organisation": organisation.pk,
@@ -47,7 +47,7 @@ def test_send_organisation(
     assert newsletter_models.Newsletter.objects.count() == 1
     assert len(mail.outbox) == 1
     assert mail.outbox[0].to == [user1.email]
-    assert mail.outbox[0].subject == "Testsubject"
+    assert mail.outbox[0].subject == "Its a testsubject"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Describe your changes**
Apostrophes in email subject return Unicode Error, they are now removed. Escaping them, didn't work well, as the subject gets sent with weird encoding.

fixes #5767 

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog