### PR TITLE
meinberlin/fixtures: add allow_unregistered_users to poll fixture

### DIFF
--- a/meinberlin/fixtures/polls.json
+++ b/meinberlin/fixtures/polls.json
@@ -2,6 +2,7 @@
   {
     "model": "a4polls.poll",
     "pk": 8,
+     "allow_unregistered_users": false,
     "fields": {}
   },
   {


### PR DESCRIPTION
**Describe your changes**
Add new and non-nullable field `allow_unregistered_users` to poll fixture to make them work with the new poll model in a4

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog