### PR TITLE
update react-router to v7

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,9 @@ const config = {
   transformIgnorePatterns: [
   // transpile all node_modules, not great?
     '/node_modules/(?!(.*)/)'
+  ],
+  setupFiles: [
+    '<rootDir>/setupTests.js'
   ]
 }
 

--- a/meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx
+++ b/meinberlin/apps/budgeting/assets/BudgetingProposalList.jsx
@@ -5,7 +5,7 @@ import { EndSessionLink } from './EndSessionLink'
 import { Pagination } from './Pagination'
 import { CountDown } from '../../contrib/assets/CountDown'
 import { ControlBar } from './ControlBar'
-import { useLocation, useSearchParams } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router'
 
 export const BudgetingProposalList = (props) => {
   const [data, setData] = useState([])

--- a/meinberlin/apps/budgeting/assets/ControlBar.jsx
+++ b/meinberlin/apps/budgeting/assets/ControlBar.jsx
@@ -5,7 +5,7 @@ import { ControlBarSearch } from './ControlBarSearch'
 import { ControlBarSearchTerm } from './ControlBarSearchTerm'
 import { FilterToggle } from '../../contrib/assets/FilterToggle'
 import django from 'django'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 const translated = {
   showFilters: django.gettext('Show filters'),

--- a/meinberlin/apps/budgeting/assets/ControlBarListMapSwitch.jsx
+++ b/meinberlin/apps/budgeting/assets/ControlBarListMapSwitch.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import django from 'django'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 export const ControlBarListMapSwitch = () => {
   // FIXME: to be changed, once Map is in React

--- a/meinberlin/apps/budgeting/assets/EndSessionLink.jsx
+++ b/meinberlin/apps/budgeting/assets/EndSessionLink.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import django from 'django'
 import Modal from 'adhocracy4/adhocracy4/static/Modal'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 export const EndSessionLink = (props) => {
   const translations = {

--- a/meinberlin/apps/budgeting/assets/Pagination.jsx
+++ b/meinberlin/apps/budgeting/assets/Pagination.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import django from 'django'
 import { PaginationButton } from './PaginationButton'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 const pageNavigationStr = django.gettext('Page navigation')
 const pageNextStr = django.gettext('next page')

--- a/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalList.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/BudgetingProposalList.jest.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, act, screen } from '@testing-library/react'
 import { BudgetingProposalList } from '../BudgetingProposalList'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 
 // permissions for anonymous/logged-in user during collection phase of 1 and 2 phase (3 phase is dfferent see ListItem test)
 const permissions = {

--- a/meinberlin/apps/budgeting/assets/__tests__/ControlBar.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/ControlBar.jest.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { ControlBar } from '../ControlBar'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 
 const filters = {
   category: {

--- a/meinberlin/apps/budgeting/assets/__tests__/ControlBarListMapSwitch.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/ControlBarListMapSwitch.jest.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { ControlBarListMapSwitch } from '../ControlBarListMapSwitch'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 
 test('Buttonlink to map with href', () => {
   render(

--- a/meinberlin/apps/budgeting/assets/__tests__/EndSessionLink.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/EndSessionLink.jest.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { EndSessionLink } from '../EndSessionLink'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 
 test('End session - check: modal rendered', async () => {
   render(

--- a/meinberlin/apps/budgeting/assets/__tests__/Pagination.jest.jsx
+++ b/meinberlin/apps/budgeting/assets/__tests__/Pagination.jest.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent, screen } from '@testing-library/react'
 import { Pagination } from '../Pagination'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 
 test('clicking on page 2 sets button to active', () => {
   render(

--- a/meinberlin/apps/budgeting/assets/react_proposals_init.jsx
+++ b/meinberlin/apps/budgeting/assets/react_proposals_init.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { widget as ReactWidget } from 'adhocracy4'
 import { BudgetingProposalList } from './BudgetingProposalList.jsx'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 
 function init () {
   ReactWidget.initialise('mb', 'proposals',

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-flip-move": "3.0.5",
     "react-leaflet": "^4.2.1",
     "react-markdown": "9.0.1",
-    "react-router-dom": "6.28.0",
+    "react-router": "7.0.2",
     "react-slick": "0.30.2",
     "react-sticky-box": "2.0.5",
     "sass": "1.82.0",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,7 @@
+// fix missing TextEncoder / TextDecocer in jsdom
+// this can be removed once https://github.com/jsdom/jsdom/pull/3791 was merged
+if (!globalThis.TextEncoder || !globalThis.TextDecoder) {
+  const { TextDecoder, TextEncoder } = require('node:util')
+  globalThis.TextEncoder = TextEncoder
+  globalThis.TextDecoder = TextDecoder
+}


### PR DESCRIPTION
**Describe your changes**
Followed the migration guide and added a fix for the tests failing because jsdom doesn't provide TextEncoder.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog