### PR TITLE
react/livequestions: remove-bookmarked-from-answered-questions

### DIFF
--- a/meinberlin/react/livequestions/StatisticsBox.jsx
+++ b/meinberlin/react/livequestions/StatisticsBox.jsx
@@ -98,7 +98,7 @@ function StatisticsBox (props) {
             key={question.id}
             id={question.id}
             is_answered={question.is_answered}
-            is_on_shortlist={question.is_on_shortlist}
+            is_on_shortlist={false}
             is_live={question.is_live}
             is_hidden={question.is_hidden}
             category={question.category}
@@ -114,7 +114,7 @@ function StatisticsBox (props) {
             key={question.id}
             id={question.id}
             is_answered={question.is_answered}
-            is_on_shortlist={question.is_on_shortlist}
+            is_on_shortlist={false}
             is_live={question.is_live}
             is_hidden={question.is_hidden}
             category={question.category}


### PR DESCRIPTION
**Describe your changes**
This PR removes the **bookmarked** pill (`is_on_shortlist={false}`) when in the **Statistics** view, resolving the [#8546 [mB] interactive event: statistics (Sev) - 'bookmarked' pill appears on questions in the 'answered questions' list issue](https://github.com/liqd/a4-meinberlin/issues/5774).


**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog