### PR TITLE
[#8646] search-profile: add dummy kiezradar search profile page for further frontend development

### DIFF
--- a/meinberlin/apps/kiezradar/templates/meinberlin_kiezradar/search_profile_list.html
+++ b/meinberlin/apps/kiezradar/templates/meinberlin_kiezradar/search_profile_list.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% load static i18n react_kiezradar_search_profiles %}
+
+{% block title %}{% translate 'Search profiles' %} - {{ block.super }}{% endblock title %}
+
+{% block extra_js %}
+    <script type="text/javascript" src="{% static 'react_kiezradar_search_profiles.js' %}"></script>
+    {{ block.super }}
+{% endblock extra_js %}
+
+{% block breadcrumbs %}
+{#    <div id="content-header">#}
+{#        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">#}
+{#            <ol>#}
+{#                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>#}
+{#                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Project Overview' %}</a></li>#}
+{#                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>#}
+{#                {% if module.is_in_module_cluster %}#}
+{#                    <li><a href="{{ module.get_detail_url }}">{{ module.name|truncatechars:50 }}</a></li>#}
+{#                {% endif %}#}
+{#                <li><a href="{{ object.get_absolute_url }}">{% translate 'Proposal' %}</a></li>#}
+{#                <li class="active" aria-current="page">{% translate 'Edit proposal' %}</li>#}
+{#            </ol>#}
+{#        </nav>#}
+{#    </div>#}
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div id="layout-grid__area--maincontent">
+    {% react_kiezradar_search_profiles %}
+</div>
+{% endblock content %}

--- a/meinberlin/apps/kiezradar/templatetags/react_kiezradar_search_profiles.py
+++ b/meinberlin/apps/kiezradar/templatetags/react_kiezradar_search_profiles.py
@@ -1,0 +1,17 @@
+import json
+
+from django import template
+from django.utils.html import format_html
+
+register = template.Library()
+
+
+@register.simple_tag()
+def react_kiezradar_search_profiles():
+    attributes = {}
+
+    return format_html(
+        '<div data-mb-widget="kiezradar-search-profiles" '
+        'data-attributes="{attributes}"></div>',
+        attributes=json.dumps(attributes),
+    )

--- a/meinberlin/apps/kiezradar/urls.py
+++ b/meinberlin/apps/kiezradar/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path(
+        "search-profiles/",
+        views.SearchProfileListView.as_view(),
+        name="search_profiles",
+    ),
+]

--- a/meinberlin/apps/kiezradar/views.py
+++ b/meinberlin/apps/kiezradar/views.py
@@ -1,0 +1,5 @@
+from django.views import generic
+
+
+class SearchProfileListView(generic.TemplateView):
+    template_name = "meinberlin_kiezradar/search_profile_list.html"

--- a/meinberlin/config/urls.py
+++ b/meinberlin/config/urls.py
@@ -97,6 +97,7 @@ urlpatterns = [
     path("django-admin/", admin.site.urls),
     path("dashboard/", include("meinberlin.apps.dashboard.urls")),
     path("account/", include("meinberlin.apps.account.urls")),
+    path("account/", include("meinberlin.apps.kiezradar.urls")),
     path("embed/", include("meinberlin.apps.embed.urls")),
     path(
         "initiators/",

--- a/meinberlin/react/kiezradar/dummy.jsx
+++ b/meinberlin/react/kiezradar/dummy.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Dummy = () => (
+  <p>Put content here</p>
+)
+
+export default Dummy

--- a/meinberlin/react/kiezradar/react_kiezradar_search_profiles_init.jsx
+++ b/meinberlin/react/kiezradar/react_kiezradar_search_profiles_init.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { widget as ReactWidget } from 'adhocracy4'
+import Dummy from './dummy'
+
+function init () {
+  ReactWidget.initialise('mb', 'kiezradar-search-profiles',
+    function (el) {
+      // const props = JSON.parse(el.getAttribute('data-attributes'))
+      const root = createRoot(el)
+      root.render(
+        <React.StrictMode>
+          <Dummy />
+        </React.StrictMode>
+      )
+    }
+  )
+}
+
+document.addEventListener('DOMContentLoaded', init, false)

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -95,6 +95,9 @@ module.exports = {
     react_map_teaser: {
       import: './meinberlin/react/plans/react_map_teaser.jsx'
     },
+    react_kiezradar_search_profiles: {
+      import: './meinberlin/react/kiezradar/react_kiezradar_search_profiles_init.jsx'
+    },
     topics: {
       import: './meinberlin/react/topicprio/react_topics_init.jsx'
     },


### PR DESCRIPTION
**Describe your changes**
This basically just adds a mostly empty view under http://127.0.0.1:8003/account/search-profiles/ to allow further development for frontend.

cc @sevfurneaux 
