### PR TITLE
[#8605] Style plan detail page 

### DIFF
--- a/changelog/_8605.md
+++ b/changelog/_8605.md
@@ -1,3 +1,8 @@
 ### Changed
 
 - Change plan detail page styling
+
+### Added
+
+- extra serializer field for plan's published_projects
+- extra test for plan views with topics and published_projects

--- a/changelog/_8605.md
+++ b/changelog/_8605.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Change plan detail page styling

--- a/meinberlin/apps/plans/serializers.py
+++ b/meinberlin/apps/plans/serializers.py
@@ -1,8 +1,10 @@
+from django.utils import timezone
 from easy_thumbnails.files import get_thumbnailer
 from rest_framework import serializers
 
 from adhocracy4.projects.enums import Access
 from meinberlin.apps.projects.serializers import CommonFields
+from meinberlin.apps.projects.serializers import ProjectSerializer
 
 from .models import Plan
 
@@ -15,6 +17,7 @@ class PlanSerializer(serializers.ModelSerializer, CommonFields):
     participation_string = serializers.SerializerMethodField()
     point = serializers.SerializerMethodField()
     published_projects_count = serializers.SerializerMethodField()
+    published_projects = serializers.SerializerMethodField()
     subtype = serializers.ReadOnlyField(default="plan")
     tile_image = serializers.SerializerMethodField()
     tile_image_alt_text = serializers.SerializerMethodField()
@@ -36,6 +39,7 @@ class PlanSerializer(serializers.ModelSerializer, CommonFields):
             "point",
             "point_label",
             "published_projects_count",
+            "published_projects",
             "status",
             "subtype",
             "tile_image",
@@ -52,6 +56,11 @@ class PlanSerializer(serializers.ModelSerializer, CommonFields):
 
     def get_url(self, instance: Plan) -> str:
         return instance.get_absolute_url()
+
+    def get_published_projects(self, instance: Plan) -> ProjectSerializer:
+        return ProjectSerializer(
+            instance.published_projects, many=True, now=timezone.now()
+        ).data
 
     def get_published_projects_count(self, instance: Plan) -> int:
         """

--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -42,27 +42,56 @@
 
 {% block content %}
 <div id="layout-grid__area--maincontent">
+    {% if object.image %}
+        <section class="herounit-image-with-aside fullwidth">
+            <div class="mainbar">
+                <div class="mainbar__left">
+                    <div class="image">
+                        <div class="image__image">
+                            <img src="{{ object.image | thumbnail_url:"heroimage" }}" alt="{% if object.image_alt_text %}{{ object.image_alt_text }}{% else %}{% translate "Here you can find a decorative picture." %}{% endif %}" width="100%" height="auto" loading="lazy"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="mainbar__right">
+                    <div class="panel--heavy panel--remove-inner-panels flex--stretch-inner __py-0__">
+                        <ul class="pill__list pill__list--inline herounit-image-with-aside__pills">
+                            {% for topic in object.topic_names %}
+                                <li class="pill pill--topic">{{ topic }}</li>
+                            {% endfor %}
+                        </ul>
+
+                        <h1 class="title herounit-image-with-aside__title">{{ object.title }}</h1>
+                        <div class="herounit-image-with-aside__description">
+                            <p>{{ object.point_label }}</p>
+                            
+                            <p class="herounit-image-with-aside__copyright">
+                                {% if object.image_copyright %}
+                                    {% translate "Image" %}: {{ object.image_copyright }}
+                                {% else %}
+                                    {% translate "Image: copyright missing" %}
+                                {% endif %}
+                            </p>   
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
     <article class="item-detail">
-        <h1 class="item-detail__title u-break-word">
-            {{ object.title }}
-        </h1>
+        {% has_perm 'meinberlin_plans.change_plan' request.user object as user_may_change %}
+        {% if user_may_change %}
+            <div class="item-detail__edit">
+                <a class="item-detail__edit-link" href="{% url 'a4dashboard:plan-update' organisation_slug=object.organisation.slug pk=object.pk %}">
+                    {% translate 'Edit' %}
+                </a>
+            </div>
+        {% endif %}
 
-        <div class="item-detail__labels">
-            <span class="label label--secondary">{{ object.get_status_display }}</span>
-        </div>
-
-        <section class="item-detail-2__factsheet">
-            <dl class="item-detail-2__factsheet-table" title="{% translate 'Plan details' %}">
+        <section class="item-detail__factsheet">
+            <dl class="item-detail__factsheet-table" title="{% translate 'Plan details' %}">
 
                 {% if object.point_label %}
                     <div><dt>{% translate 'Location' %}</dt><dd>{{ object.point_label|default:'no val' }}</dd></div>
-                {% endif %}
-
-                {% if object.topic_names %}
-                <div>
-                    <dt>{% translate 'Topic' %}</dt>
-                    <dd>{{ object.topic_names.0 }}{% if object.topic_names.1 %}, {{ object.topic_names.1 }}{% endif %}</dd>
-                </div>
                 {% endif %}
 
                 {% if object.duration %}
@@ -98,73 +127,40 @@
                     </dd>
                 </div>
             </dl>
-            {% if object.image %}
-                <div
-                    class="item-detail__background-image"
-                    style="background-image: url({% thumbnail object.image 'plan_image' %})"
-                    role="img"
-                    aria-label="{% if plan.image_alt_text %}{{ plan.image_alt_text }}{% else %}{% translate 'Here you can find a decorative picture.' %}{% endif %}"
-                >
-                    <p class="item-detail__copyright copyright">
-                        {% if object.image_copyright %}
-                            © {{ object.image_copyright }}
-                        {% else %}
-                            {% translate 'copyright missing' %}
-                        {% endif %}
-                    </p>
-                </div>
-            {% endif %}
         </section>
 
-        <div class="item-detail-2__content{% if object.participation_explanation != 'Bitte Begründung einfügen' %}--borderless{% endif %}">
-            <div class="item-detail__basic-content ck-content">
-                {% if object.description %}
-                    {{ object.description | transform_collapsibles | richtext }}
-                {% endif %}
-            </div>
-        </div>
-        {% if object.participation_explanation != "Bitte Begründung einfügen" %}
-        <div class="item-detail-2__info-box">
-            <h2 class="item-detail-2__smalltitle">{% translate 'Level of participation' %}: {{ object.get_participation_display }}</h2>
-
-            {% if object.participation_explanation|length > 300 %}
-                <div id="collapsibleExplanation" class="collapse show u-no-transition">
-                    {{ object.participation_explanation|truncatechars:160 }}
-                </div>
-                <div id="collapsibleExplanation" class="collapse u-no-transition">
-                    {{ object.participation_explanation }}
-                </div>
-                <button
-                    class="btn--link collapsible"
-                    type="button" data-bs-toggle="collapse"
-                    data-bs-target="#collapsibleExplanation"
-                    aria-expanded="false"
-                    aria-controls="collapseReadLink"
-                >
-                    <span class="link--more">
-                        <span class="visually-hidden">{% translate 'toggle to' %}</span>
-                        {% translate 'Read more...' %}
-                    </span>
-                    <span class="link--less">
-                        <span class="visually-hidden">{% translate 'toggle to' %}</span>
-                        {% translate 'Read less' %}
-                    </span>
-                </button>
-            {% else %}
-                {{ object.participation_explanation }}
+        <div class="item-detail__basic-content ck-content">
+            {% if object.description %}
+                {{ object.description | transform_collapsibles | richtext }}
             {% endif %}
         </div>
+        {% if object.participation_explanation != "Bitte Begründung einfügen" %}
+        <section class="item-detail__factsheet">
+            <dl class="item-detail__factsheet-table" title="Plan details">
+                <div>
+                    <dt>{% translate 'Level of participation' %}</dt>
+                    <dd>
+                        {{ object.get_participation_display }}
+                        {% if object.participation_explanation %}
+                            <p>{{ object.participation_explanation }}</p>
+                        {% endif %}
+                    </dd>
+                </div>
+            </dl>
+        </section>
         {% endif %}
 
         {% if object.point %}
-            {% map_display_point object.point polygon %}
+            <div class="item-detail__map">
+                {% map_display_point object.point polygon %}
+            </div>
         {% endif %}
 
         {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url or object.organisation.address or object.organisation.url %}
-            <div class="l-tiles-2 u-spacer-bottom">
+            <div class="item-detail__contacts">
             {% if object.contact_name or object.contact_address_text or object.contact_email or object.contact_phone or object.contact_url %}
                 <div>
-                    <h2 class="item-detail-2__smalltitle">{% translate 'Contact for questions' %}</h2>
+                    <h2 class="item-detail__contact-title">{% translate 'Contact for questions' %}</h2>
                     <address>
                         {% if object.contact_name %}
                         <p>{{ object.contact_name }}</p>
@@ -176,14 +172,18 @@
                             <p><strong>{% translate 'Telephone' %}: </strong>{{ object.contact_phone }}</p>
                         {% endif %}
                         {% if object.contact_email %}
-                            <a class="btn btn--secondary" href="mailto:{{ object.contact_email }}">
-                                {% translate 'Email' %}
-                            </a>
+                            <p>
+                                <a href="mailto:{{ object.contact_email }}">
+                                    {% translate 'Email' %}
+                                </a>
+                            </p>
                         {% endif %}
                         {% if object.contact_url %}
-                            <a class="btn btn--secondary" target="_blank" href="{{ object.contact_url }}">
-                                {% translate 'Website' %}
-                            </a>
+                            <p>
+                                <a target="_blank" href="{{ object.contact_url }}">
+                                    {% translate 'Website' %}
+                                </a>
+                            </p>
                         {% endif %}
                     </address>
                 </div>
@@ -191,71 +191,43 @@
 
             {% if object.organisation.address or object.organisation.url %}
                 <div>
-                    <h2 class="item-detail-2__smalltitle">{% translate 'Responsible body' %}</h2>
+                    <h2 class="item-detail__contact-title">{% translate 'Responsible body' %}</h2>
                     <address>
                         {% if object.organisation.address %}
                         <p>{{ object.organisation.name }}</p>
                         <p>{{ object.organisation.address|linebreaks }}</p>
                         {% endif %}
                         {% if object.organisation.url %}
-                            <a class="btn btn--secondary" target="_blank" href="{{ object.organisation.url }}">
-                                {% translate 'Website' %}
-                            </a>
+                            <p>
+                                <a target="_blank" href="{{ object.organisation.url }}">
+                                    {% translate 'Website' %}
+                                </a>
+                            </p>
                         {% endif %}
                     </address>
                 </div>
             {% endif %}
             </div>
         {% endif %}
-
-        {% has_perm 'meinberlin_plans.change_plan' request.user object as user_may_change %}
-        {% if user_may_change %}
-        <div class="item-detail__actions lr-bar">
-            <div class="lr-bar__right">
-                <div class="dropdown">
-                    <button
-                        title="{% translate 'Actions' %}"
-                        type="button"
-                        class="dropdown-toggle btn btn--light btn--small"
-                        data-bs-toggle="dropdown"
-                        data-flip="false"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                        id="idea-{{ object.pk }}-actions"
-                    >
-                        <i class="fa fa-ellipsis-h" aria-label="{% translate 'Actions' %}"></i>
-                    </button>
-                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="idea-{{ object.pk }}-actions">
-                        <li>
-                            <a
-                                href="{% url 'a4dashboard:plan-update' organisation_slug=object.organisation.slug pk=object.pk %}"
-                                class="dropdown-item"
-                                data-embed-target="external"
-                            >
-                                {% translate 'Edit' %}
-                            </a>
-                        </li>
-                    </div>
-                </div>
-            </div>
-        </div>
-        {% endif %}
     </article>
 
     {% if object.published_projects %}
-    <section class="item-detail-2__project-list">
+    <section>
         <div class="container">
-            <h3 class="item-detail-2__project-title" id="participation-plans">
+            <h3 class="item-detail__project-title" id="participation-plans">
                 {% translate "Participation projects" %}
             </h3>
-            <ul class="u-list-reset participation-tile__list">
-            {% for project in object.published_projects %}
-                {% include "meinberlin_projects/includes/project_tile.html" with project=project %}
-            {% endfor %}
-            </ul>
+            <div
+                data-projects-list
+                data-projects="{{ published_projects }}"
+            ></div>
         </div>
     </section>
     {% endif %}
 </div>
 
 {% endblock content %}
+
+{% block extra_js_deferred %}
+    <script src="{% static 'mb_projects_list.js' %}"></script>
+{% endblock extra_js_deferred %}

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -6,6 +6,7 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
@@ -26,6 +27,7 @@ from meinberlin.apps.organisations.models import Organisation
 from meinberlin.apps.plans import models
 from meinberlin.apps.plans.forms import PlanForm
 from meinberlin.apps.plans.models import Plan
+from meinberlin.apps.projects import serializers as project_serializers
 
 
 class FreeTextFilterWidget(filter_widgets.FreeTextFilterWidget):
@@ -50,6 +52,10 @@ class PlanDetailView(rules_mixins.PermissionRequiredMixin, CanonicalURLDetailVie
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["polygon"] = settings.BERLIN_POLYGON
+        serializer = project_serializers.ProjectSerializer(
+            self.object.published_projects, many=True, now=timezone.now()
+        )
+        context["published_projects"] = json.dumps(serializer.data)
         return context
 
 

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -27,7 +27,7 @@ from meinberlin.apps.organisations.models import Organisation
 from meinberlin.apps.plans import models
 from meinberlin.apps.plans.forms import PlanForm
 from meinberlin.apps.plans.models import Plan
-from meinberlin.apps.projects import serializers as project_serializers
+from meinberlin.apps.projects.serializers import ProjectSerializer
 
 
 class FreeTextFilterWidget(filter_widgets.FreeTextFilterWidget):
@@ -51,11 +51,11 @@ class PlanDetailView(rules_mixins.PermissionRequiredMixin, CanonicalURLDetailVie
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["polygon"] = settings.BERLIN_POLYGON
-        serializer = project_serializers.ProjectSerializer(
+        serializer = ProjectSerializer(
             self.object.published_projects, many=True, now=timezone.now()
         )
-        context["published_projects"] = json.dumps(serializer.data)
+        context["published_projects"] = serializer.data
+        context["polygon"] = settings.BERLIN_POLYGON
         return context
 
 

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -6,7 +6,6 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
@@ -27,7 +26,7 @@ from meinberlin.apps.organisations.models import Organisation
 from meinberlin.apps.plans import models
 from meinberlin.apps.plans.forms import PlanForm
 from meinberlin.apps.plans.models import Plan
-from meinberlin.apps.projects.serializers import ProjectSerializer
+from meinberlin.apps.plans.serializers import PlanSerializer
 
 
 class FreeTextFilterWidget(filter_widgets.FreeTextFilterWidget):
@@ -51,10 +50,10 @@ class PlanDetailView(rules_mixins.PermissionRequiredMixin, CanonicalURLDetailVie
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        serializer = ProjectSerializer(
-            self.object.published_projects, many=True, now=timezone.now()
+        serializer = PlanSerializer(self.object)
+        context["published_projects"] = json.dumps(
+            serializer.data.get("published_projects")
         )
-        context["published_projects"] = serializer.data
         context["polygon"] = settings.BERLIN_POLYGON
         return context
 

--- a/meinberlin/assets/scss/components_user_facing/_herounit_image_with_aside.scss
+++ b/meinberlin/assets/scss/components_user_facing/_herounit_image_with_aside.scss
@@ -28,3 +28,11 @@
   font-size: 0.8em;
   color: $text-light;
 }
+
+.herounit-image-with-aside__pills.pill__list {
+  margin-bottom: 0.5rem;
+
+  @media screen and (min-width: $breakpoint-tablet) {
+    margin-bottom: -0.5rem;
+  }
+}

--- a/meinberlin/assets/scss/components_user_facing/_item_detail.scss
+++ b/meinberlin/assets/scss/components_user_facing/_item_detail.scss
@@ -1,6 +1,32 @@
+.item-detail {
+    margin-bottom: 4rem;
+}
+
 .item-detail__title {
     padding: $spacer 0;
     margin: 0;
+}
+
+.item-detail__edit {
+    text-align: right;
+}
+
+.item-detail__edit-link {
+    width: auto;
+    font-size: $em-spacer;
+    line-height: 1.2;
+    display: inline-block;
+    text-align: center;
+    cursor: pointer;
+
+    &:before {
+        content: "\f303";
+        font-family: "Font Awesome 5 Free", "Font Awesome 5 Brands", sans-serif;
+        font-weight: 700;
+        margin-right: .5em;
+        display: inline-block;
+        vertical-align: baseline;
+    }
 }
 
 .item-detail__image {
@@ -38,4 +64,127 @@
     strong {
         color: $text-base;
     }
+}
+
+.item-detail__factsheet {
+    border-bottom: 1px solid $gray-lighter;
+    border-top: 1px solid $gray-lighter;
+    padding: 1.5rem 0;
+    margin-top: 1.6rem;
+    margin-bottom: 1.6rem;
+
+    @media screen and (min-width: $breakpoint-palm) {
+        margin-bottom: 2.5rem;
+    }
+}
+
+dl.item-detail__factsheet-table div {
+    margin-bottom: 1.1rem;
+
+    @media screen and (min-width: $breakpoint-palm) {
+        display: grid;
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+        column-gap: 2.25rem;
+        margin-bottom: 1rem;
+    }
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+dl.item-detail__factsheet-table,
+dl.item-detail__factsheet-table dd,
+dl.item-detail__factsheet-table dt,
+dl.item-detail__factsheet-table p {
+    margin: 0;
+}
+
+dl.item-detail__factsheet-table dt {
+    grid-column: span 3;
+}
+
+dl.item-detail__factsheet-table dd {
+    grid-column: span 9;
+}
+
+.item-detail__basic-content .text-huge,
+.item-detail__basic-content .text-big,
+.item-detail__basic-content .text-small {
+    display: block;
+}
+
+.item-detail__basic-content .text-huge {
+    font-size: 1.5rem;
+}
+
+.item-detail__basic-content .text-big,
+.item-detail__basic-content .text-small {
+    font-size: 1rem;
+}
+
+.item-detail__basic-content .image {
+    text-align: left;
+    margin-bottom: 1rem;
+}
+
+.item-detail__basic-content p + .image {
+    margin-top: 2rem;
+
+    @media screen and (min-width: $breakpoint-palm) {
+        margin-top: 3rem;
+    }
+}
+
+.item-detail__contacts address p {
+    margin-bottom: 0.75rem;
+}
+
+.item-detail__basic-content .image + p {
+    margin-top: 2rem;
+
+    @media screen and (min-width: $breakpoint-palm) {
+        margin-top: 3rem;
+    }
+}
+
+.item-detail__contacts address p:last-child {
+    margin-bottom: 0;
+}
+
+.item-detail__contacts address p a  {
+    text-decoration: none;
+}
+
+.item-detail__contacts address p a:hover {
+    text-decoration: underline;
+}
+
+.item-detail__basic-content .image > figcaption {
+    background-color: transparent;
+    font-size: 0.75rem;
+    padding: 0.3rem 0 0;
+}
+
+.item-detail__map {
+  margin-bottom: 3rem;
+}
+
+.item-detail__contacts {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.item-detail__contact-title {
+    font-size: 1.4rem;
+    margin: 0 0 0.75rem;
+}
+
+.item-detail__contacts address {
+    font-style: normal;
+}
+
+.item-detail__project-title {
+    font-size: 1.75rem;
+    margin: 0 0 1.5rem;
 }

--- a/meinberlin/react/plans/react_projects_list.jsx
+++ b/meinberlin/react/plans/react_projects_list.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import ProjectsList from '../projects/ProjectsList'
+
+function init () {
+  const projectsList = document.querySelectorAll('[data-projects-list')
+  projectsList.forEach(el => {
+    const root = createRoot(el)
+    const projects = JSON.parse(el.getAttribute('data-projects'))
+    root.render(
+      <React.StrictMode>
+        <ProjectsList projects={projects} />
+      </React.StrictMode>)
+  })
+}
+
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -150,6 +150,12 @@ module.exports = {
       ],
       dependOn: 'adhocracy4'
     },
+    mb_projects_list: {
+      import: [
+        './meinberlin/react/plans/react_projects_list.jsx'
+      ],
+      dependOn: 'adhocracy4'
+    },
     // to be kept until everything uses the new maps
     a4maps_display_point: {
       import: [


### PR DESCRIPTION
**Describe your changes**
This PR styles the plan detail page and adds the React `<ProjectsList />` component for projects.

<img width="1400" alt="Screenshot 2024-12-12 at 22 47 44" src="https://github.com/user-attachments/assets/74e69d9a-e0aa-485e-ab57-e2a721964c4c" />

<img width="819" alt="Screenshot 2024-12-12 at 22 47 54" src="https://github.com/user-attachments/assets/97995b47-976c-41cd-bb9c-6eb0846c43eb" />

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [X] Changelog