### PR TITLE
meinberlin_contrib/components: create info-box

### DIFF
--- a/changelog/_8473.md
+++ b/changelog/_8473.md
@@ -1,0 +1,5 @@
+### Changed
+- Converted alert component to a static info box `contrib/templates/meinberlin_contrib/components/`
+- Removed dismissible functionality (close button)
+- Updated ARIA semantics from `role="alert"` to `role="status"`
+- Info box visibility now toggles based on project publication state

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/components/info-box.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/components/info-box.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<div 
+  class="info-box" 
+  role="status" 
+  tabindex="0"
+>
+  <p class="info-box__text">
+    {% translate info_message %}
+  </p>
+</div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -12,7 +12,7 @@
     {{ block.super }}
 
     {% if project.is_draft %}
-        {% include 'meinberlin_contrib/components/alert.html' with alert_message='This project has not yet been published.' alert_type='info' %}
+        {% include 'meinberlin_contrib/components/info-box.html' with info_message='This project has not yet been published.' %}
     {% endif %}
 {% endblock extra_messages %}
 

--- a/meinberlin/assets/scss/components_user_facing/_info-box.scss
+++ b/meinberlin/assets/scss/components_user_facing/_info-box.scss
@@ -1,0 +1,9 @@
+.info-box {
+    margin: $spacer 0;
+    padding: $spacer;
+    background-color: $message-light-blue;
+}
+
+.info-box__text {
+    margin: 0;
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -30,6 +30,7 @@
 @import "components_user_facing/dropdown";
 @import "components_user_facing/form-submit-flex-end";
 @import "components_user_facing/herounit_image_with_aside";
+@import "components_user_facing/info-box";
 @import "components_user_facing/infographic_footer";
 @import "components_user_facing/input";
 @import "components_user_facing/item_detail";

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -17,7 +17,7 @@
   {{ block.super }}
 
   {% if project.is_draft %}
-    {% include 'meinberlin_contrib/components/alert.html' with alert_message='This project has not yet been published.' alert_type='info' %}
+    {% include 'meinberlin_contrib/components/info-box.html' with info_message='This project has not yet been published.' %}
   {% endif %}
 {% endblock extra_messages %}
 


### PR DESCRIPTION
# Refactor Alert to Status Info Box for Project Publication State
While investigating overlapping alerts for unpublished projects, identified that the current alert component was semantically incorrect for its use case.

fixes https://github.com/liqd/a4-meinberlin/issues/5849

![info-box](https://github.com/user-attachments/assets/004ede2f-f6b9-486c-be4d-1045e4a80776)

## Changes
- Converted alert component to a static info box
- Removed dismissible functionality (close button)
- Updated ARIA semantics from `role="alert"` to `role="status"`
- Info box visibility now toggles based on project publication state

## Rationale
The element's primary purpose is to display the current publication state of a project, making it a status indicator rather than an alert. Alerts are typically used for important, time-sensitive messages that require user attention, while this component serves as a persistent status display.