### PR TITLE
apps/bplan: add tile_image field to serializer which accepts a base64…

### DIFF
--- a/docs/bplan_api.md
+++ b/docs/bplan_api.md
@@ -105,13 +105,22 @@ The following fields need to be provided:
   - string containing coordinates separated by a comma, e.g. "1492195.544958444,6895923.461738203"
   - Location of the bplan
   - Projection: WGS84 / EPSG:3857
-- *image_url*: string
+- *(diplan only) tile_image*: string
+  - Base64 encoded image
+  - Minimal resolution 500x300 px (width x height)
+  - Maximum file size 10MB
+  - Allowed formats: png, jpeg, gif
+- *(imperia only) image_url*: string
   - URL of the image that is used in the project tile
   - Minimal resolution 500x300 px (width x height)
   - Maximum file size 10MB
+  - Allowed formats: png, jpeg, gif
 - *image_copyright*: string
   - Copyright shown for the image
   - Maximum length of 120 chars
+- *image_alt_text*: string
+  - Alt text for the tile image
+  - Maximum length of 80 chars
 
 #### Data example
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,8 +1,11 @@
+import base64
 import re
+from io import BytesIO
 
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 from django.core import mail
+from PIL import Image
 
 
 class pytest_regex:
@@ -35,3 +38,11 @@ def get_emails_for_address_and_subject(email_address, subject):
         )
     )
     return emails
+
+
+def get_base64_image(width, height):
+    """Returns a base64 encoded jpeg image with the given width and height"""
+    image = Image.new("RGB", size=(width, height), color=(256, 0, 0))
+    buffered = BytesIO()
+    image.save(buffered, format="JPEG")
+    return base64.b64encode(buffered.getvalue())


### PR DESCRIPTION
… encoded image as required by diplan

**Describe your changes**
Briefly explain what you did and provide context for a clearer understanding.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [x] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog