### PR TITLE
[#8530] css/support: fix styling for support button/box

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_button.scss
+++ b/meinberlin/assets/scss/components_user_facing/_button.scss
@@ -21,8 +21,7 @@
     color: $text-inverted;
     transition: background-color 0.2s ease-in-out;
 
-    &:not(:disabled):hover,
-    &:not(:disabled):focus {
+    &:not(:disabled):hover {
         background-color: $primary-600;
     }
 
@@ -33,6 +32,16 @@
 
     &--selected {
         background-color: $primary;
+
+        // for some reason the :focus state gets a default color equal to primary-600
+        // if nothing is set, so we explicitly set the color
+        &:not(:disabled):focus {
+            background-color: $primary;
+        }
+
+        &:not(:disabled):hover {
+            background-color: $primary-600;
+        }
     }
 
     &--read-only {

--- a/meinberlin/assets/scss/components_user_facing/_service-panel.scss
+++ b/meinberlin/assets/scss/components_user_facing/_service-panel.scss
@@ -1,14 +1,24 @@
 .servicepanel--centered {
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
     align-items: center;
 
-    .servicepanel__main {
-        grid-column: 2;
+    @media screen and (min-width: $breakpoint-palm) {
+        grid-template-columns: 1fr auto 1fr;
+        grid-template-rows: 1fr;
+
+        .servicepanel__main {
+            grid-column: 2;
+        }
+
+        .servicepanel__right {
+            grid-column: 3;
+            margin-left: auto;
+
+        }
     }
 
-    .servicepanel__right {
-        grid-column: 3;
-        margin-left: auto;
-    }
+
+
 }


### PR DESCRIPTION
**Describe your changes**
Makes the Support button behave correctly after clicking with a lingering focus and the support box wrap the button correctly into a new line on mobile

fixes #5881, #5892 

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog