### PR TITLE
apps/bplan: remove char limit on name and description

### DIFF
--- a/changelog/8543.md
+++ b/changelog/8543.md
@@ -16,3 +16,5 @@
   - update the bplan api documentation
   - add a `bplan_id` field which will replace the `identifier` field once the
   switch to diplan is done
+  - remove char limit for name and description field, instead truncate text if
+  too long

--- a/docs/bplan_api.md
+++ b/docs/bplan_api.md
@@ -76,7 +76,7 @@ The following fields need to be provided:
 
 - *name*: string
   - Name of the BPLAN (e.g. used as the title of the project tile)
-  - Maximum length of 120 chars
+  - Maximum length of 120 chars, however longer input is accepted and will be cut to 120
 - *(imperia only) identifier*: string
   - Identifier that clearly identifies the BPLAN, needs to be the same as in the FIS Broker (e.g. `VIII - 329`)
   - Maximum length of 120 chars
@@ -85,7 +85,7 @@ The following fields need to be provided:
   - Maximum length of 120 chars
 - *description*: string
   - Description of the BPLAN shown in the project tile
-  - Maximum length of 250 chars
+  - Maximum length of 250 chars, however longer input is accepted and will be cut to 250
 - *url*: string
   - URL of the external site the BPLAN is embedded on
 - *office_worker_email*: string


### PR DESCRIPTION
**Describe your changes**
apps/bplan: remove char limit on name and description and instead truncate the input if too long

This means we won't save  the full name or description if it exceeds the limits. Otherwise we'd have to make a new model or change the char limit for all projects, not just bplans we don't want to do

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [x] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog