### PR TITLE
bplan/serializer: add binary=True to point JSONField 

### DIFF
--- a/docs/bplan_api.md
+++ b/docs/bplan_api.md
@@ -101,7 +101,7 @@ The following fields need to be provided:
   - End date of the participation in
   - [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601)
     (if no time zone is defined, german time zones UTC+01 and UTC+02 are used)
-- *point*: geojson
+- *point*: string containing valid geojson
   - Location of the bplan
   - Projection: WGS84 / EPSG:4326
 - *(diplan only) tile_image*: string
@@ -203,7 +203,7 @@ curl \
    "office_worker_email": "test@example.com",
    "start_date": "2019-01-01T00:00",
    "end_date": "2022-01-01T00:00",
-   "point": {"type": "Feature","geometry": {"type": "Point", "coordinates":[13.411924777644563,52.499598134440944]}}
+   "point": "{\"type\": \"Feature\",\"geometry\": {\"type\": \"Point\", \"coordinates\":[13.411924777644563,52.499598134440944]}}"
  }
 '
 ```
@@ -224,7 +224,7 @@ curl  -X POST http://127.0.0.1:8003/api/organisations/1/bplan/ \
    "office_worker_email": "test@example.com",
    "start_date": "2019-01-01T00:00",
    "end_date": "2022-01-01T00:00",
-   "point": {"type": "Feature","geometry": {"type": "Point", "coordinates":[13.411924777644563,52.499598134440944]}}
+   "point": "{\"type\": \"Feature\",\"geometry\": {\"type\": \"Point\", \"coordinates\":[13.411924777644563,52.499598134440944]}}"
  }
 '
 ```

--- a/meinberlin/apps/bplan/serializers.py
+++ b/meinberlin/apps/bplan/serializers.py
@@ -83,7 +83,7 @@ class BplanSerializer(serializers.ModelSerializer):
     )
     # overwrite the point model field so it's expecting json, the original field is validated as a string and therefore
     # doesn't pass validation when not receiving a string
-    point = serializers.JSONField(required=False, write_only=True)
+    point = serializers.JSONField(required=False, write_only=True, binary=True)
 
     class Meta:
         model = Bplan

--- a/tests/bplan/test_bplan_api.py
+++ b/tests/bplan/test_bplan_api.py
@@ -348,7 +348,7 @@ def test_bplan_api_diplan_adds_district_from_bplan_id(
         "office_worker_email": "test@liqd.de",
         "start_date": "2013-01-01 18:00",
         "bplan_id": "1-234",
-        "point": "0,0",
+        "point": '{"type":"Feature", "geometry":{"type":"Point","coordinates":[13.397788148643649,52.52958586909979]}}',
         "end_date": "2021-01-01 18:00",
     }
     user = organisation.initiators.first()
@@ -464,7 +464,7 @@ def test_bplan_api_location_task_not_called_if_point_included(
         "end_date": "2021-01-01 18:00",
         "identifier": "1-234",
         "is_published": True,
-        "point": "[0,0]",
+        "point": '{"type":"Feature", "geometry":{"type":"Point","coordinates":[13.397788148643649,52.52958586909979]}}',
     }
     user = organisation.initiators.first()
     apiclient.force_authenticate(user=user)
@@ -474,7 +474,13 @@ def test_bplan_api_location_task_not_called_if_point_included(
         bplan = bplan_models.Bplan.objects.first()
         assert bplan.is_draft is False
         assert bplan.is_diplan is True
-        assert bplan.point == "[0,0]"
+        assert bplan.point == {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [13.397788148643649, 52.52958586909979],
+            },
+        }
         mock.assert_not_called()
 
 
@@ -491,13 +497,7 @@ def test_bplan_api_accepts_valid_geojson(
         "end_date": "2021-01-01 18:00",
         "identifier": "1-234",
         "is_published": True,
-        "point": {
-            "type": "Feature",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [13.411924777644563, 52.499598134440944],
-            },
-        },
+        "point": '{"type":"Feature", "geometry":{"type":"Point","coordinates":[13.397788148643649,52.52958586909979]}}',
     }
     user = organisation.initiators.first()
     apiclient.force_authenticate(user=user)
@@ -511,7 +511,7 @@ def test_bplan_api_accepts_valid_geojson(
             "type": "Feature",
             "geometry": {
                 "type": "Point",
-                "coordinates": [13.411924777644563, 52.499598134440944],
+                "coordinates": [13.397788148643649, 52.52958586909979],
             },
         }
 
@@ -530,7 +530,7 @@ def test_bplan_api_accepts_valid_base64_image(
         "end_date": "2021-01-01 18:00",
         "identifier": "1-234",
         "is_published": True,
-        "point": "1492195.544958444,6895923.461738203",
+        "point": '{"type":"Feature", "geometry":{"type":"Point","coordinates":[13.397788148643649,52.52958586909979]}}',
         "tile_image": image,
     }
 


### PR DESCRIPTION
bplan/serializer: add binary=True to point JSONField as we receive a string containing (geo)json, not actual json. This came up during testing.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [x] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog