### PR TITLE
fix some issues with ckeditor content not shown correctly

### DIFF
--- a/changelog/5925.md
+++ b/changelog/5925.md
@@ -1,0 +1,4 @@
+### Changed
+
+- add ckeditor text size css to make text sizing work
+- add <i> tag to `collapsible-image-editor` Bleach config to allow italic text

--- a/meinberlin/assets/extra_css/_ckeditor.scss
+++ b/meinberlin/assets/extra_css/_ckeditor.scss
@@ -225,3 +225,23 @@
 .ck-content .image-inline.image-style-align-right {
   margin-left: var(--ck-inline-image-style-spacing);
 }
+
+/* @ckeditor/ckeditor5-font/theme/fontsize.css */
+.ck-content .text-tiny {
+    font-size: .7em;
+}
+
+/* @ckeditor/ckeditor5-font/theme/fontsize.css */
+.ck-content .text-small {
+    font-size: .85em;
+}
+
+/* @ckeditor/ckeditor5-font/theme/fontsize.css */
+.ck-content .text-big {
+    font-size: 1.4em;
+}
+
+/* @ckeditor/ckeditor5-font/theme/fontsize.css */
+.ck-content .text-huge {
+    font-size: 1.8em;
+}

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -350,6 +350,7 @@ BLEACH_LIST = {
             "em",
             "figcaption",
             "figure",
+            "i",
             "iframe",
             "img",
             "li",


### PR DESCRIPTION

**Describe your changes**
fix some issues with ckeditor content not shown correctly
- add missing <i> tag to allow italic in Bleach config
- add missing css for text sizing via ckeditor

fixes #5925

testing: add italic or text with different font size in the project information field in the dashboard then check on the project page that it is rendered correctly.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog