### PR TITLE
[#8681] notifications-settings: add new notifications page

### DIFF
--- a/changelog/8681.md
+++ b/changelog/8681.md
@@ -1,0 +1,7 @@
+### Changed
+- added some more options to actionable list component
+- added prop to have the label of a toggleswitch on the right
+
+### Added
+- View for notifications
+- new components for setting notification

--- a/meinberlin/apps/account/templates/meinberlin_account/notifications.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/notifications.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% load i18n static %}
+
+{% block title %}{% translate 'Your user profile' %} — {{ block.super }}{% endblock title %}
+
+{% block content %}
+  <h1>{% translate "Notifications" %}</h1>
+  <div id="notifications-react" data-initial-notifications="{&quot;email_newsletter&quot;:{&quot;email&quot;:false,&quot;activity_feed&quot;:true},&quot;participation_start&quot;:{&quot;email&quot;:true,&quot;activity_feed&quot;:true},&quot;participation_end&quot;:{&quot;email&quot;:true,&quot;activity_feed&quot;:true},&quot;new_events&quot;:{&quot;email&quot;:true,&quot;activity_feed&quot;:true},&quot;reactions&quot;:{&quot;email&quot;:true,&quot;activity_feed&quot;:true},&quot;moderation_reactions&quot;:{&quot;email&quot;:true,&quot;activity_feed&quot;:true},&quot;new_project_in_organisation&quot;:{&quot;email&quot;:true,&quot;activity_feed&quot;:true},&quot;new_contribution_in_moderated_project&quot;:{&quot;email&quot;:true,&quot;activity_feed&quot;:true}}" data-show-restricted="{% if show_restricted %}true{% endif %}"></div>
+{% endblock content %}
+
+{% block extra_js_deferred %}
+  <script src="{% static 'mb_notifications.js' %}"></script>
+{% endblock extra_js_deferred %}

--- a/meinberlin/apps/account/urls.py
+++ b/meinberlin/apps/account/urls.py
@@ -6,6 +6,7 @@ from . import views
 urlpatterns = [
     path("", views.AccountView.as_view(), name="account"),
     path("profile/", views.ProfileUpdateView.as_view(), name="account_profile"),
+    path("notifications/", views.NotificationsView.as_view(), name="notifications"),
     path("actions/", views.ProfileActionsView.as_view(), name="account_actions"),
     path("end-session/", api.EndSessionView.as_view(), name="end_session"),
 ]

--- a/meinberlin/apps/account/views.py
+++ b/meinberlin/apps/account/views.py
@@ -43,3 +43,15 @@ class ProfileActionsView(LoginRequiredMixin, generic.ListView):
         qs = super().get_queryset()
         qs = qs.filter(project__follow__creator=user, project__follow__enabled=True)
         return qs.exclude_updates()
+
+
+class NotificationsView(LoginRequiredMixin, generic.TemplateView):
+    template_name = "meinberlin_account/notifications.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["show_restricted"] = (
+            self.request.user.project_moderator.exists()
+            or len(self.request.user.organisations) > 0
+        )
+        return context

--- a/meinberlin/assets/scss/components_user_facing/_actionable-list.scss
+++ b/meinberlin/assets/scss/components_user_facing/_actionable-list.scss
@@ -4,11 +4,30 @@
     margin: 0 0 2.5em;
 }
 
+.actionable-list__header {
+    margin-top: .25rem;
+    margin-bottom: .5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    h2 {
+        margin-top: 0;
+        margin-bottom: 0;
+        flex-shrink: 1;
+    }
+}
+
+.actionable-list__header__action {
+    flex: 0 0 auto;
+    margin-left: .25rem;
+}
+
 .actionable-list__item {
     padding: 1.5em 0;
     border-top: 1px solid $gray-lighter;
 
-    &:last-child {
+    &:not(.actionable-list__item--hide-last-line):last-child {
         border-bottom: 1px solid $gray-lighter;
     }
 }

--- a/meinberlin/assets/scss/components_user_facing/_toggle_switch.scss
+++ b/meinberlin/assets/scss/components_user_facing/_toggle_switch.scss
@@ -5,3 +5,8 @@
 .toggle-switch__label {
     margin-right: .4em;
 }
+
+.toggle-switch__label--right {
+    margin-left: .4em;
+    margin-right: 0;
+}

--- a/meinberlin/assets/scss/styles_user_facing/_utility.scss
+++ b/meinberlin/assets/scss/styles_user_facing/_utility.scss
@@ -54,6 +54,14 @@
     margin-right: 0.5em;
 }
 
+.ml-1 {
+    margin-left: 0.5em;
+}
+
+.ml-2 {
+    margin-left: 1em;
+}
+
 .u-flex-end {
     display: flex;
     justify-content: flex-end;

--- a/meinberlin/react/account/NotificationToggle.jsx
+++ b/meinberlin/react/account/NotificationToggle.jsx
@@ -1,0 +1,35 @@
+import django from 'django'
+import React from 'react'
+import { ToggleSwitch } from '../contrib/ToggleSwitch'
+
+const emailStr = django.gettext('E-Mail')
+const activityFeedStr = django.gettext('Activity Feed')
+
+const NotificationToggle = ({ notification, notificationState, id, onToggle }) => {
+  return (
+    <>
+      <h3>{notification.title}</h3>
+      <p>{notification.description}</p>
+      <div className="flexbox">
+        <ToggleSwitch
+          uniqueId={id}
+          onSwitchStr={emailStr}
+          labelLeft={false}
+          checked={notificationState.email}
+          toggleSwitch={() => onToggle('email')}
+        />
+        {notification.showInActivityFeed &&
+          <ToggleSwitch
+            className="ml-1"
+            uniqueId={id}
+            onSwitchStr={activityFeedStr}
+            labelLeft={false}
+            checked={notificationState.activityFeed}
+            toggleSwitch={() => onToggle('activityFeed')}
+          />}
+      </div>
+    </>
+  )
+}
+
+export default NotificationToggle

--- a/meinberlin/react/account/NotificationsList.jsx
+++ b/meinberlin/react/account/NotificationsList.jsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react'
+import django from 'django'
+import { ToggleSwitch } from '../contrib/ToggleSwitch'
+import NotificationToggle from './NotificationToggle'
+
+const notifications = [
+  {
+    header: django.gettext('Project-Related Notifications'),
+    notifications: {
+      email_newsletter: {
+        title: django.gettext('E-Mail Newsletter'),
+        description: django.gettext('Receive newsletters with updates and news about the projects you follow via e-mail.')
+      },
+      participation_start: {
+        title: django.gettext('Participation Start'),
+        description: django.gettext('Receive a notification when a participation begins in a project you follow.'),
+        showInActivityFeed: true
+      },
+      participation_end: {
+        title: django.gettext('Participation End'),
+        description: django.gettext('Receive a notification when a participation is near its end in a project you follow.'),
+        showInActivityFeed: true
+      },
+      new_events: {
+        title: django.gettext('Event'),
+        description: django.gettext('Receive notifications for upcoming events in projects you follow.'),
+        showInActivityFeed: true
+      }
+    }
+  },
+  {
+    header: django.gettext('Interactions with Other Users or Moderation'),
+    notifications: {
+      reactions: {
+        title: django.gettext('Reactions of other users'),
+        description: django.gettext('Receive a notification when someone reacts to your contribution with a comment.')
+      },
+      moderation_reactions: {
+        title: django.gettext('Reactions of moderation'),
+        description: django.gettext('Receive a notification for feedback and status changes of your idea from the moderation.')
+      }
+    }
+  },
+  {
+    header: django.gettext('Notifications for Initiators and Moderators'),
+    restricted: true,
+    notifications: {
+      new_project_in_organisation: {
+        title: django.gettext('New Project in Your Organization'),
+        description: django.gettext('Receive a notification when a new project is created in your organization.')
+      },
+      new_contribution_in_moderated_project: {
+        title: django.gettext('New Contribution in a Moderated Project'),
+        description: django.gettext('Receive a notification when a new contribution is added to a project you moderate.')
+      }
+    }
+  }
+]
+
+const NotificationsList = ({
+  initialNotifications,
+  showRestricted = false
+}) => {
+  const [notificationsState, setNotificationsState] = useState(notifications.reduce((acc, notification) => {
+    if (notification.restricted && !showRestricted) return acc
+
+    Object.keys(notification.notifications).forEach(key => {
+      acc[key] = {
+        email: initialNotifications[key]?.email,
+        activityFeed: initialNotifications[key]?.activity_feed
+      }
+    })
+
+    return acc
+  }, {}))
+  const masterToggles = notifications
+    .filter((n) => !n.restricted || (n.restricted && showRestricted))
+    .map((n, i) => Object.keys(n.notifications).some((key) => notificationsState[key].email))
+
+  const onToggle = (type, key, force = null) => {
+    const newState = { ...notificationsState }
+    if (force !== null) newState[key][type] = force
+    else newState[key][type] = !notificationsState[key][type]
+    setNotificationsState(newState)
+  }
+
+  return (
+    <ul className="list--clean">
+      {notifications.map((notification, index) => {
+        if (notification.restricted && !showRestricted) return null
+
+        return (
+          <li key={notification.header}>
+            <div className="actionable-list__header">
+              <h2>{notification.header}</h2>
+              <ToggleSwitch
+                className="actionable-list__header__action"
+                uniqueId={'masterToggle' + index}
+                checked={masterToggles[index]}
+                toggleSwitch={() => {
+                  Object.keys(notification.notifications).forEach(key => {
+                    onToggle('email', key, !masterToggles[index])
+                  })
+                }}
+              />
+            </div>
+            <ul className="actionable-list">
+              {Object.entries(notification.notifications).map(([key, value]) => (
+                <li key={key} className="actionable-list__item actionable-list__item--hide-last-line">
+                  <NotificationToggle
+                    id={key}
+                    notification={value}
+                    notificationState={notificationsState[key]}
+                    onToggle={(type) => onToggle(type, key)}
+                  />
+                </li>
+              ))}
+            </ul>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default NotificationsList

--- a/meinberlin/react/account/react_notifications.jsx
+++ b/meinberlin/react/account/react_notifications.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import NotificationsList from './NotificationsList'
+
+function init () {
+  const el = document.getElementById('notifications-react')
+  const root = createRoot(el)
+  const notifications = JSON.parse(el.getAttribute('data-initial-notifications'))
+  const showRestricted = JSON.parse(el.getAttribute('data-show-restricted'))
+  root.render(
+    <React.StrictMode>
+      <NotificationsList initialNotifications={notifications} showRestricted={showRestricted} />
+    </React.StrictMode>)
+}
+
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/meinberlin/react/contrib/ToggleSwitch.jsx
+++ b/meinberlin/react/contrib/ToggleSwitch.jsx
@@ -7,10 +7,11 @@ export const ToggleSwitch = ({
   toggleSwitch,
   defaultChecked,
   checked,
-  className
+  className,
+  labelLeft = true
 }) => (
   <div className={classNames('toggle-switch form-check', className)}>
-    <label className="toggle-switch__label" htmlFor={uniqueId}>{onSwitchStr}</label>
+    {labelLeft && <label className="toggle-switch__label" htmlFor={uniqueId}>{onSwitchStr}</label>}
     <input
       type="checkbox"
       name={uniqueId}
@@ -24,5 +25,6 @@ export const ToggleSwitch = ({
       <i className="bicon bicon-check toggle-switch__icon toggle-switch__icon--on" aria-hidden="true" />
       <i className="bicon bicon-times toggle-switch__icon toggle-switch__icon--off" aria-hidden="true" />
     </span>
+    {!labelLeft && <label className="toggle-switch__label toggle-switch__label--right" htmlFor={uniqueId}>{onSwitchStr}</label>}
   </div>
 )

--- a/tests/account/test_account_view.py
+++ b/tests/account/test_account_view.py
@@ -1,0 +1,39 @@
+import pytest
+from django.urls import reverse
+
+from adhocracy4.test.helpers import setup_users
+
+
+@pytest.mark.django_db
+def test_show_restricted_false_in_notifications_view(client, user):
+    notifications_url = reverse(
+        "notifications",
+    )
+    client.login(username=user.email, password="password")
+    resp = client.get(notifications_url)
+    assert resp.status_code == 200
+    assert not resp.context["show_restricted"]
+
+
+@pytest.mark.django_db
+def test_show_restricted_moderator_in_notifications_view(client, project):
+    notifications_url = reverse(
+        "notifications",
+    )
+    anonymous, moderator, initiator = setup_users(project)
+    client.login(username=moderator.email, password="password")
+    resp = client.get(notifications_url)
+    assert resp.status_code == 200
+    assert resp.context["show_restricted"]
+
+
+@pytest.mark.django_db
+def test_show_restricted_initiator_in_notifications_view(client, project):
+    notifications_url = reverse(
+        "notifications",
+    )
+    anonymous, moderator, initiator = setup_users(project)
+    client.login(username=initiator.email, password="password")
+    resp = client.get(notifications_url)
+    assert resp.status_code == 200
+    assert resp.context["show_restricted"]

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -156,6 +156,12 @@ module.exports = {
       ],
       dependOn: 'adhocracy4'
     },
+    mb_notifications: {
+      import: [
+        './meinberlin/react/account/react_notifications.jsx'
+      ],
+      dependOn: 'adhocracy4'
+    },
     // to be kept until everything uses the new maps
     a4maps_display_point: {
       import: [


### PR DESCRIPTION
**Describe your changes**
Implements a page for setting user notifications 
![CleanShot 2025-01-14 at 13 19 22](https://github.com/user-attachments/assets/c19fba8a-3f3f-418f-817f-f948c78d9306)


**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog

cc @goapunk @m4ra no need to create a view for it, I already did that. I also added an example of what the data structure looks like the frontend code currently works with in `notifications.html`