### PR TITLE
modules: redesign module tiles on project page and module detail page

### DIFF
--- a/changelog/8731.md
+++ b/changelog/8731.md
@@ -1,0 +1,3 @@
+### Changed
+- update module tiles to resemble the new design
+- refactor status bar to show a projects time status (or a module time status, its flexible!)

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html
@@ -1,45 +1,24 @@
 {% load i18n project_tags meinberlin_project_tags contrib_tags thumbnail static rules %}
 {% project_tile_image project as project_image %}
 {% project_tile_image_copyright project as project_image_copyright %}
-<li class="participation-tile__vertical">
-    <a href="{% url 'module-detail' module.slug %}">
-        <div class="participation-tile__type">
-            <div class="participation-tile__content">
-                <h3 class="participation-tile__title">{{ module.name }}</h3>
-                <span class="participation-tile__item-count">
-                    <i class="fas fa-comments" aria-hidden="true"></i>
-                    {% get_num_entries module as num_entries %}
-                    {% blocktranslate count num_entries=num_entries %}{{ num_entries }} Contribution{% plural %}{{ num_entries }} Contributions{% endblocktranslate %}
-                </span>
-                {% if module.module_running_time_left %}
-                <div class="status-item status__active">
-                    <div class="status-bar__active">
-                        <span class="status-bar__active-fill" style="width: {{ module.module_running_progress }}%"></span>
-                    </div>
-                    <span class="participation-tile__status">
-                        <i class="fas fa-clock" aria-hidden="true"></i>
-                    {% blocktranslate with time_left=module.module_running_time_left %}remaining {{ time_left }}{% endblocktranslate %}
-                    </span>
-                </div>
-                {% elif not module.module_has_started %}
-                <div class="status-item status__future">
-                    <span class="participation-tile__status"><i class="fas fa-clock"  aria-hidden="true"></i>{% html_date module.module_start 'd.m.Y' as start_date %}
-                    {% blocktranslate with date=start_date %}Participation: starts on {{ date }}{% endblocktranslate %}
-                    </span>
-                </div>
-                {% elif module.module_has_finished %}
-                <div class="status-item status-bar__past">
-                    <span class="participation-tile__status">{% blocktranslate %}Participation ended. Read result{% endblocktranslate %}</span>
-                </div>
-                {% endif %}
-                <div class="participation-tile__spacer"></div>
-                {% if module.module_running_time_left %}
-                <div class="participation-tile__btn">
-                    {% has_perm 'a4projects.participate_in_project' request.user project as user_may_participate_in_project %}
-                    <a class="btn btn--primary btn--full u-spacer-bottom btn--small" href="{% url 'module-detail' module.slug %}">{% if user_may_participate_in_project %}{% translate 'Join now' %}{% else %}{% translate 'Read now' %}{% endif %}</a>
-                </div>
-                {% endif %}
-            </div>
-        </div>
-    </a>
-</li>
+<a href="{% url 'module-detail' module.slug %}" class="module-tile">
+  <h3 class="module-tile__title">{{ module.name }}</h3>
+  <p class="module-tile__description">{{ module.description }}</p>
+
+  {% if module.module_running_time_left %}
+
+    {% include "meinberlin_projects/includes/status_bar.html" with progress=module.module_running_progress uniqueId="module-running-progress-{{ module.pk }}" time_left=module.module_running_time_left %}
+
+  {% elif not module.module_has_started %}
+
+    <span class="module-tile__future">
+      <i class="far fa-clock" aria-hidden="true"></i>{% html_date module.module_start 'd.m.Y' as start_date %}
+      {% blocktranslate with date=start_date %}Begins on the {{ date }}{% endblocktranslate %}
+    </span>
+
+  {% elif module.module_has_finished %}
+
+    {% translate 'Participation ended' %}
+
+  {% endif %}
+</a>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/includes/status_bar.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/includes/status_bar.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+<progress
+  value="{{ progress }}"
+  max="100"
+  aria-valuenow="{{ progress }}"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  id="{{ uniqueId }}"
+  class="status-bar"
+>
+  {{ progress }}%
+</progress>
+{% if not uniqueId %}
+  <p class="message--error">Please add a uniqueId to status_bar.html includes!</p>
+{% endif %}
+<label for="{{ uniqueId }}" class="status-bar__timespan">
+  <i class="far fa-clock" aria-hidden="true"></i>
+  {% blocktranslate %}remaining {{ time_left }}{% endblocktranslate %}
+</label>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -3,17 +3,17 @@
 
 {% block extra_js %}
   {{ block.super }}
-    <script type="text/javascript" src="{% static 'dsgvo_video_embed.js' %}"></script>
+  <script type="text/javascript" src="{% static 'dsgvo_video_embed.js' %}"></script>
 {% endblock extra_js %}
 
 {% block title %}{{ project.name }} — {{ block.super }}{% endblock title %}
 
 {% block extra_messages %}
-    {{ block.super }}
+  {{ block.super }}
 
-    {% if project.is_draft %}
-        {% include 'meinberlin_contrib/components/info-box.html' with info_message='This project has not yet been published.' %}
-    {% endif %}
+  {% if project.is_draft %}
+    {% include 'meinberlin_contrib/components/info-box.html' with info_message='This project has not yet been published.' %}
+  {% endif %}
 {% endblock extra_messages %}
 
 {% block breadcrumbs %}
@@ -29,208 +29,206 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
-<!-- FIXME according to the marketing verticle the herounit should be before the maincontent however the styling for this here is nested within maincontent
-assume this will may be updated at somepoint  -->
-<div id="layout-grid__area--maincontent">
+  <!-- FIXME according to the marketing verticle the herounit should be before the maincontent however the styling for this here is nested within maincontent
+  assume this will may be updated at somepoint  -->
+  <div id="layout-grid__area--maincontent">
     <section class="herounit-image-with-aside fullwidth">
-        <div class="mainbar">
-            <div class="mainbar__left">
-                <div class="image">
-                    <div class="image__image">
+      <div class="mainbar">
+        <div class="mainbar__left">
+          <div class="image">
+            <div class="image__image">
                         <img src="{{ project.image | thumbnail_url:"heroimage" }}" alt="{% if project.image_alt_text %}{{ project.image_alt_text }}{% else %}{% translate "Here you can find a decorative picture." %}{% endif %}" width="100%" height="auto" loading="lazy"/>
-                    </div>
-                </div>
             </div>
-            <div class="mainbar__right">
-                <div class="panel--heavy panel--remove-inner-panels flex--stretch-inner __py-0__">
-                    <h1 class="title herounit-image-with-aside__title">{{ project.name }}</h1>
-                    <div class="herounit-image-with-aside__description">
-                        <p>{{ project.description }}</p>
-                        {% if project.image_copyright %}
-                            <p class="herounit-image-with-aside__copyright">
-                                {% translate "Image" %}: {{ project.image_copyright }}
-                            </p>
-                        {% else %}
-                            <p class="herounit-image-with-aside__copyright">
-                                {% translate "Image: copyright missing" %}
-                            </p>
-                        {% endif %}
-                    </div>
-                    <!-- Follow btn -->
-                    <div class="follow__container">
-                        {% react_follows project %}
-                    </div>
-                </div>
-            </div>
+          </div>
         </div>
+        <div class="mainbar__right">
+          <div class="panel--heavy panel--remove-inner-panels flex--stretch-inner __py-0__">
+            <h1 class="title herounit-image-with-aside__title">{{ project.name }}</h1>
+            <div class="herounit-image-with-aside__description">
+              <p>{{ project.description }}</p>
+              {% if project.image_copyright %}
+                <p class="herounit-image-with-aside__copyright">
+                  {% translate "Image" %}: {{ project.image_copyright }}
+                </p>
+              {% else %}
+                <p class="herounit-image-with-aside__copyright">
+                  {% translate "Image: copyright missing" %}
+                </p>
+              {% endif %}
+            </div>
+            <!-- Follow btn -->
+            <div class="follow__container">
+              {% react_follows project %}
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
     <div class="tabnavigation js-tabs">
-        <div class="row row--reverse-palm">
-            {% has_perm 'a4projects.change_project' request.user view.project as user_may_change %}
-            {% if user_may_change %}
-            <div class="tabnavigation--right">
-                <a class="tabnavigation__link" href="{% url 'a4dashboard:project-edit' project_slug=project.slug %}">
-                    {% translate "Edit" %}
-                </a>
-            </div>
-            {% endif %}
-            <ul
-                class="tabnavigation--left"
-                role="tablist"
-                aria-label='{% translate "Project Details Navigation" %}'
-            >
-                <li>
-                    <button
-                        id="tab-project-{{ project.pk }}-information"
-                        class="tabnavigation__button"
-                        type="button"
-                        role="tab"
-                        aria-selected="false"
-                        aria-controls="tabpanel-project-{{ project.pk }}-information"
-                        tabindex="-1">
-                            {% translate "Information" %}
-                    </button>
-                </li>
+      <div class="row row--reverse-palm">
+        {% has_perm 'a4projects.change_project' request.user view.project as user_may_change %}
+        {% if user_may_change %}
+          <div class="tabnavigation--right">
+            <a class="tabnavigation__link" href="{% url 'a4dashboard:project-edit' project_slug=project.slug %}">
+              {% translate "Edit" %}
+            </a>
+          </div>
+        {% endif %}
+        <ul
+          class="tabnavigation--left"
+          role="tablist"
+          aria-label='{% translate "Project Details Navigation" %}'
+        >
+          <li>
+            <button
+              id="tab-project-{{ project.pk }}-information"
+              class="tabnavigation__button"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              aria-controls="tabpanel-project-{{ project.pk }}-information"
+              tabindex="-1">
+              {% translate "Information" %}
+            </button>
+          </li>
 
-                <li>
-                    <button
-                        id="tab-project-{{ project.pk }}-participation"
-                        class="tabnavigation__button"
-                        type="button"
-                        role="tab"
-                        aria-selected="true"
-                        aria-controls="tabpanel-project-{{ project.pk }}-participation">
-                            {% translate "Participation" %}
-                    </button>
-                </li>
-                <li>
-                    <button
-                        id="tab-project-{{ project.pk }}-result"
-                        class="tabnavigation__button"
-                        type="button"
-                        role="tab"
-                        aria-selected="false"
-                        aria-controls="tabpanel-project-{{ project.pk }}-result"
-                        tabindex="-1">
-                            {% translate "Results" %}
-                    </button>
-                </li>
-            </ul>
-        </div>
+          <li>
+            <button
+              id="tab-project-{{ project.pk }}-participation"
+              class="tabnavigation__button"
+              type="button"
+              role="tab"
+              aria-selected="true"
+              aria-controls="tabpanel-project-{{ project.pk }}-participation">
+              {% translate "Participation" %}
+            </button>
+          </li>
+          <li>
+            <button
+              id="tab-project-{{ project.pk }}-result"
+              class="tabnavigation__button"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              aria-controls="tabpanel-project-{{ project.pk }}-result"
+              tabindex="-1">
+              {% translate "Results" %}
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
     <section
-        id="tabpanel-project-{{ project.pk }}-information"
-        class="tabpanel"
-        role="tabpanel"
-        aria-expanded="false"
-        aria-hidden="true"
-        aria-labelledby="tab-project-{{ project.pk }}-information">
-        <h2 class="mt-0">{% translate "Information" %}</h2>
-        <div class="ck-content">
-            {{ project.information | transform_collapsibles | disable_iframes | richtext }}
-        </div>
-        {% if project.contact_name or project.contact_address_text or project.contact_email or project.contact_phone or project.contact_url or project.organisation.address or project.organisation.url %}
-            {% if project.contact_name or project.contact_address_text or project.contact_email or project.contact_phone or project.contact_url %}
-                <div>
-                    <h3>{% translate "Contact for questions" %}</h3>
-                    <address>
-                        {% if project.contact_name %}
-                        <p>{{ project.contact_name }}</p>
-                        {% endif %}
-                        {% if project.contact_address_text %}
-                        <p>{{ project.contact_address_text|linebreaks }}</p>
-                        {% endif %}
-                        {% if project.contact_phone %}
+      id="tabpanel-project-{{ project.pk }}-information"
+      class="tabpanel"
+      role="tabpanel"
+      aria-expanded="false"
+      aria-hidden="true"
+      aria-labelledby="tab-project-{{ project.pk }}-information">
+      <h2 class="mt-0">{% translate "Information" %}</h2>
+      <div class="ck-content">
+        {{ project.information | transform_collapsibles | disable_iframes | richtext }}
+      </div>
+      {% if project.contact_name or project.contact_address_text or project.contact_email or project.contact_phone or project.contact_url or project.organisation.address or project.organisation.url %}
+        {% if project.contact_name or project.contact_address_text or project.contact_email or project.contact_phone or project.contact_url %}
+          <div>
+            <h3>{% translate "Contact for questions" %}</h3>
+            <address>
+              {% if project.contact_name %}
+                <p>{{ project.contact_name }}</p>
+              {% endif %}
+              {% if project.contact_address_text %}
+                <p>{{ project.contact_address_text|linebreaks }}</p>
+              {% endif %}
+              {% if project.contact_phone %}
                         <p><strong>{% translate "Telephone" %}: </strong>{{ project.contact_phone }}</p>
-                        {% endif %}
-                        {% if project.contact_email %}
-                        <a class="btn btn--secondary" href="mailto:{{ project.contact_email }}">
-                            {% translate "Email" %}
-                        </a>
-                        {% endif %}
-                        {% if project.contact_url %}
-                        <a class="btn btn--secondary" target="_blank" href="{{ project.contact_url }}">
-                            {% translate "Website" %}
-                        </a>
-                        {% endif %}
-                    </address>
-                </div>
-            {% endif %}
+              {% endif %}
+              {% if project.contact_email %}
+                <a class="btn btn--secondary" href="mailto:{{ project.contact_email }}">
+                  {% translate "Email" %}
+                </a>
+              {% endif %}
+              {% if project.contact_url %}
+                <a class="btn btn--secondary" target="_blank" href="{{ project.contact_url }}">
+                  {% translate "Website" %}
+                </a>
+              {% endif %}
+            </address>
+          </div>
+        {% endif %}
 
-            {% if project.organisation.address or project.organisation.url %}
-                <div>
-                    <h3>{% translate "Responsible body" %}</h3>
-                    <address>
-                        {% if project.organisation.address %}
-                        <p>{{ project.organisation.name }}</p>
-                        <p>{{ project.organisation.address|linebreaks }}</p>
-                        {% endif %}
-                        {% if project.organisation.url %}
-                        <a class="btn btn--secondary" target="_blank" href="{{ project.organisation.url }}">
-                            {% translate "Website" %}
-                        </a>
-                        {% endif %}
-                    </address>
-                </div>
-            {% endif %}
+        {% if project.organisation.address or project.organisation.url %}
+          <div>
+            <h3>{% translate "Responsible body" %}</h3>
+            <address>
+              {% if project.organisation.address %}
+                <p>{{ project.organisation.name }}</p>
+                <p>{{ project.organisation.address|linebreaks }}</p>
+              {% endif %}
+              {% if project.organisation.url %}
+                <a class="btn btn--secondary" target="_blank" href="{{ project.organisation.url }}">
+                  {% translate "Website" %}
+                </a>
+              {% endif %}
+            </address>
+          </div>
         {% endif %}
+      {% endif %}
     </section>
     <section
-        id="tabpanel-project-{{ project.pk }}-participation"
-        class="tabpanel"
-        role="tabpanel"
-        aria-expanded="true"
-        aria-hidden="false"
-        aria-labelledby="tab-project-{{ project.pk }}-participation">
-        <h2 class="mt-0">{% translate "Participate" %}</h2>
-        {% if event %}
-            <article>
-                <h2>{{ event.name }}</h2>
-                <div class="phase-info__item__subtitle">
-                {% html_date event.date 'DATETIME_FORMAT' %}
-                </div>
-                <p>{{ event.description | safe | transform_collapsibles | richtext }}</p>
-            </article>
-        {% elif view.is_project_view %}
-            <div class="participation-tile__wrapper">
-                <div class="participation-tile__list-container">
-                    <ul class="u-list-reset participation-tile__list">
-                    {% for module in modules %}
-                        {% include "meinberlin_projects/includes/project_module_tile.html" with project=project module=module %}
-                    {% endfor %}
-                    </ul>
-                </div>
-            </div>
-        {% else %}
-            <!-- if just one module and no phase view to dispatch to -->
-            <div class="modul-servicepanel fullwidth panel--heavy phase-info">
-                <div class="servicepanel__main">
-                    {% include "a4modules/includes/module_detail_phase.html" %}
-                </div>
-                <!-- these blocks are only filled when in phase view -->
-                <div class="servicepanel__right phase-info__cta">
-                    {% block project_action %}{% endblock project_action %}
-                </div>
-            </div>
-        {% endif %}
-        {% block voting_token_field %}{% endblock voting_token_field %}
-        {% block phase_content %}{% endblock phase_content %}
+      id="tabpanel-project-{{ project.pk }}-participation"
+      class="tabpanel"
+      role="tabpanel"
+      aria-expanded="true"
+      aria-hidden="false"
+      aria-labelledby="tab-project-{{ project.pk }}-participation">
+      <h2 class="mt-0">{% translate "Participate" %}</h2>
+      {% if event %}
+        <article>
+          <h2>{{ event.name }}</h2>
+          <div class="phase-info__item__subtitle">
+            {% html_date event.date 'DATETIME_FORMAT' %}
+          </div>
+          <p>{{ event.description | safe | transform_collapsibles | richtext }}</p>
+        </article>
+      {% elif view.is_project_view %}
+        <ul class="list--clean">
+          {% for module in modules %}
+            <li>
+              {% include "meinberlin_projects/includes/project_module_tile.html" with project=project module=module %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <!-- if just one module and no phase view to dispatch to -->
+        <div class="modul-servicepanel fullwidth panel--heavy phase-info">
+          <div class="servicepanel__main">
+            {% include "a4modules/includes/module_detail_phase.html" %}
+          </div>
+          <!-- these blocks are only filled when in phase view -->
+          <div class="servicepanel__right phase-info__cta">
+            {% block project_action %}{% endblock project_action %}
+          </div>
+        </div>
+      {% endif %}
+      {% block voting_token_field %}{% endblock voting_token_field %}
+      {% block phase_content %}{% endblock phase_content %}
     </section>
     <section
-        id="tabpanel-project-{{ project.pk }}-result"
-        class="tabpanel"
-        role="tabpanel"
-        aria-expanded="false"
-        aria-hidden="true"
-        aria-labelledby="tab-project-{{ project.pk }}-result">
-        <h2 class="mt-0">{% translate "Result" %}</h2>
-            {% if project.result %}
-                <div class="ck-content">
-                    {{ project.result | transform_collapsibles | disable_iframes | richtext }}
-                </div>
-            {% else %}
-                <p>{% translate "No results yet." %}</p>
-            {% endif %}
+      id="tabpanel-project-{{ project.pk }}-result"
+      class="tabpanel"
+      role="tabpanel"
+      aria-expanded="false"
+      aria-hidden="true"
+      aria-labelledby="tab-project-{{ project.pk }}-result">
+      <h2 class="mt-0">{% translate "Result" %}</h2>
+      {% if project.result %}
+        <div class="ck-content">
+          {{ project.result | transform_collapsibles | disable_iframes | richtext }}
+        </div>
+      {% else %}
+        <p>{% translate "No results yet." %}</p>
+      {% endif %}
     </section>
-</div>
+  </div>
 {% endblock content %}

--- a/meinberlin/assets/scss/components_user_facing/_module_tile.scss
+++ b/meinberlin/assets/scss/components_user_facing/_module_tile.scss
@@ -1,0 +1,40 @@
+// `a` to override the bo base style `a:link` to keep a black text color
+a.module-tile {
+    padding: 1.5rem 1.625rem 1.25rem;
+    border: 1px solid $gray-lighter;
+    color: $text-base;
+    min-height: 20em;
+    display: flex;
+    flex-direction: column;
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
+
+    .status-bar__timespan {
+        margin-bottom: 0;
+    }
+}
+
+.module-tile__title {
+    margin-top: 0;
+
+    .module-tile:hover &,
+    .module-tile:focus &, {
+        text-decoration: underline;
+    }
+}
+
+.module-tile__description {
+    margin-bottom: auto;
+}
+
+.module-tile__future {
+    vertical-align: middle;
+}
+
+.module-tile__future i,
+.module-tile__future time {
+    display: inline-block;
+}

--- a/meinberlin/assets/scss/components_user_facing/_project-tile.scss
+++ b/meinberlin/assets/scss/components_user_facing/_project-tile.scss
@@ -106,31 +106,6 @@ a.project-tile {
     }
 }
 
-.project-tile__status__bar {
-    width: 100%;
-    height: .3em;
-    appearance: none;
-    background: $message-light-green;
-    border: none;
-
-    &::-moz-progress-bar {
-        background: $primary;
-
-    }
-
-    &::-webkit-progress-bar {
-        background: $message-light-green;
-    }
-
-    &::-webkit-progress-value {
-        background: $primary;
-    }
-}
-
-.project-tile__timespan {
-    font-weight: 400;
-}
-
 .project-tile__plan__count {
     margin-right: .25em;
 }

--- a/meinberlin/assets/scss/components_user_facing/_status-bar.scss
+++ b/meinberlin/assets/scss/components_user_facing/_status-bar.scss
@@ -1,33 +1,26 @@
-.status-item {
-    text-align: left;
+.status-bar {
     width: 100%;
-}
+    height: .3em;
+    appearance: none;
+    background: $message-light-green;
+    border: none;
+    margin-bottom: .4em;
 
-.status-item_spacer {
-    height: 3 * $spacer;
-}
+    &::-moz-progress-bar {
+        background: $primary;
 
-.status-bar__active {
-    height: 5px;
-    background-color: $message-light-green;
-    margin-bottom: 0.5 * $spacer;
-}
+    }
 
+    &::-webkit-progress-bar {
+        background: $message-light-green;
+    }
 
-.status-bar__active-fill {
-    background-color: $primary;
-    display: block;
-    height: 100%;
-    position: relative;
-    overflow: hidden;
-}
-
-.status-bar__status {
-    color: $text-base;
-
-    i {
-        padding-right: 0.5 * $padding;
-        color: $secondary;
+    &::-webkit-progress-value {
+        background: $primary;
     }
 }
 
+.status-bar__timespan {
+    font-weight: 400;
+    font-size: $font-size-sm;
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -58,6 +58,7 @@
 @import "components_user_facing/user_action_bar";
 @import "components_user_facing/user_indicator";
 @import "components_user_facing/icon_switch";
+@import "components_user_facing/module_tile";
 @import "components_user_facing/projects-list";
 @import "components_user_facing/projects_map";
 @import "components_user_facing/projects_map_search";

--- a/meinberlin/react/projects/ProjectTile.jsx
+++ b/meinberlin/react/projects/ProjectTile.jsx
@@ -85,11 +85,11 @@ const ProjectTile = forwardRef(function ProjectTile ({ project, isHorizontal, to
                 aria-valuemin="0"
                 aria-valuemax="100"
                 id={statusId}
-                className="project-tile__status__bar"
+                className="status-bar"
               >
                 {statusBarProgress}
               </progress>
-              <label htmlFor={statusId} className="project-tile__timespan">
+              <label htmlFor={statusId} className="status-bar__timespan">
                 <i className="far fa-clock" aria-hidden="true" />
                 {getTimespan(project)}
               </label>

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -83,7 +83,9 @@
             <ul class="u-list-reset participation-tile__list">
               {% for other_module in module.module_cluster %}
                 {% if not other_module == module %}
-                  {% include "meinberlin_projects/includes/project_module_tile.html" with project=project module=other_module %}
+                  <li>
+                    {% include "meinberlin_projects/includes/project_module_tile.html" with project=project module=other_module %}
+                  </li>
                 {% endif %}
               {% endfor %}
             </ul>


### PR DESCRIPTION
**Describe your changes**
adds new module tile, just the base style, grid and view all logic are coming in a later story. Also as per @MarleyMi  request we leave the grey subtitle out for now due to skzl feedback.

![CleanShot 2025-01-15 at 18 02 13](https://github.com/user-attachments/assets/3db2bcc8-06d4-4c4a-9260-ac1cc24e3014)

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog