### PR TITLE
apps/bplan: Replace imghdr with python-magic

### DIFF
--- a/changelog/_0002.md
+++ b/changelog/_0002.md
@@ -1,0 +1,7 @@
+### Changed
+
+- `imghdr` support was deprecated in python, so now we use `python-magic` and built-in `mime` to check the filetype of images files for bplans created using the API.
+
+### Fixed 
+
+- Bug where tile_image was being used instead of image_url.

--- a/meinberlin/apps/bplan/serializers.py
+++ b/meinberlin/apps/bplan/serializers.py
@@ -155,7 +155,6 @@ class BplanSerializer(serializers.ModelSerializer):
 
         tile_image = validated_data.pop("tile_image", None)
         if tile_image:
-            print(tile_image)
             validated_data["tile_image"] = self._create_image_from_base64(tile_image)
 
         image_url = validated_data.pop("image_url", None)
@@ -329,6 +328,7 @@ class BplanSerializer(serializers.ModelSerializer):
 
         root_path, extension = posixpath.splitext(url_path)
         if file:
+            file.seek(0)
             file_mime = magic.from_buffer(file.read(), mime=True)
             extension = mimetypes.guess_extension(file_mime) or "jpeg"
 


### PR DESCRIPTION
`imghdr` support was deprecated in python, so this uses `python-magic` and built-in `mime` to check the filetype of images files for bplans created using the API.

Also reorders some conditionals to fix a bug where bug tile_image was being used instead of image_url.

Test with curl like so:
```
curl  -X POST http://127.0.0.1:8003/api/organisations/1/bplan/ \
 --user 'admin@liqd.net':'password' \
 -H "Content-Type: application/json" \
 -d \
 '
 {
   "name":"Luisenblock Ost - Bebauungsplan 1-70",
   "bplan_id": "VI - 96a",
   "description": "Test",
   "url": "https://mein.berlin.de",
   "office_worker_email": "test@example.com",
   "start_date": "2019-01-01T00:00",
   "end_date": "2022-01-01T00:00",
   "image_url": "https://cdn.britannica.com/39/226539-050-D21D7721/Portrait-of-a-cat-with-whiskers-visible.jpg"
 }
'
```

The new bplan should be at [http://127.0.0.1:8003/dashboard/organisations/liqd/bplans/](http://127.0.0.1:8003/dashboard/organisations/liqd/bplans/)

**Tasks**
- [ ] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog

