### PR TITLE
captcheck: add missing scss for captcheck styling

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_captcheck.scss
+++ b/meinberlin/assets/scss/components_user_facing/_captcheck.scss
@@ -1,0 +1,67 @@
+.captcheck_box {
+    font-family: $font-family-base;
+    color: $text-base;
+    border: 1px solid $border-color;
+    display: inline-block;
+    padding: .8em;
+    margin: 5px 2px 5px 1px;
+    text-decoration: none;
+}
+
+.captcheck_label_message,
+.captcheck_label_message b {
+    color: $text-base;
+    font-family: $font-family-base;
+}
+
+.captcheck_answer_label {
+    border: 0;
+
+    > input {
+        visibility: hidden;
+        position: absolute;
+    }
+
+    > input + img {
+        cursor: pointer;
+        border: 2px solid transparent; // needed so no movement after selection
+        min-width: 2em;
+        width: 18%;
+        max-width: 4em;
+    }
+
+    > input:checked + img {
+        cursor: pointer;
+        border: 2px solid $gray-light;
+        border-radius: 3px;
+    }
+}
+
+.captcheck_error_message {
+    color: $danger;
+}
+
+.captcheck_question_image {
+    display: initial;
+}
+
+.captcheck_question_access {
+    display: none;
+}
+
+.captcheck_alt_question_button {
+    float: right;
+    font-size: 80%;
+    cursor: pointer;
+    color: inherit;
+    text-decoration: inherit;
+    border: 0;
+}
+
+.captcheck_answer_images {
+    display: initial;
+}
+
+.captcheck_answer_access {
+    display: none;
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -26,6 +26,7 @@
 @import "components_user_facing/alert";
 @import "components_user_facing/button";
 @import "components_user_facing/card";
+@import "components_user_facing/captcheck";
 @import "components_user_facing/control-bar";
 @import "components_user_facing/container";
 @import "components_user_facing/details";


### PR DESCRIPTION
**Describe your changes**
![CleanShot 2025-01-20 at 07 28 00@2x](https://github.com/user-attachments/assets/11e71428-003c-42d6-a73a-41b693e41ce1)

fixes #5711 

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog