### PR TITLE
[#8732] signup-form: change wording

### DIFF
--- a/meinberlin/apps/users/forms.py
+++ b/meinberlin/apps/users/forms.py
@@ -83,19 +83,20 @@ class TermsSignupForm(allauth_forms.SignupForm):
     get_newsletters = forms.BooleanField(
         label=_("Newsletter"),
         help_text=_(
-            "Yes, I would like to receive e-mail newsletters about "
-            "the projects I am following."
+            "Yes, I would like to receive e-mail newsletters about the projects "
+            "I am following. I can undo this at any time in my user "
+            "account settings."
         ),
         required=False,
     )
     get_notifications = forms.BooleanField(
         label=_("Notifications"),
         help_text=_(
-            "Yes, I would like to be notified by e-mail about the "
-            "start and end of participation opportunities. This "
-            "applies to all projects I follow. I also receive an "
-            "e-mail when someone comments on one of my "
-            "contributions."
+            "Yes, I would like to be notified by e-mail about the start and "
+            "end of participation opportunities. This applies to all projects "
+            "I follow. I also receive an e-mail when someone comments on one "
+            "of my contributions. I can adapt notification in my user account "
+            "settings. "
         ),
         required=False,
         initial=True,


### PR DESCRIPTION
**Describe your changes**
Change wording, now actually in the frontend too.

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog