### PR TITLE
[#8629] Moved `is_answered` update logic to QuestionModerator component

### DIFF
--- a/changelog/_8629.md
+++ b/changelog/_8629.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Moved `is_answered` update logic to `QuestionModerator` component

--- a/meinberlin/react/livequestions/QuestionBox.jsx
+++ b/meinberlin/react/livequestions/QuestionBox.jsx
@@ -140,14 +140,6 @@ export default class QuestionBox extends React.Component {
     return updateItem(data, url, 'PATCH')
   }
 
-  removeFromList (id, data) {
-    this.updateQuestion(data, id)
-      .then(response => this.setState(prevState => ({
-        filteredQuestions: prevState.filteredQuestions.filter(question => question.id !== id),
-        pollingPaused: false
-      })))
-  }
-
   handleLike (id, value) {
     const url = '/api/questions/' + id + '/likes/'
     const data = { value }
@@ -257,7 +249,6 @@ export default class QuestionBox extends React.Component {
               </div>
               <QuestionList
                 questions={this.state.filteredQuestions}
-                removeFromList={this.removeFromList.bind(this)}
                 updateQuestion={this.updateQuestion.bind(this)}
                 handleLike={this.handleLike.bind(this)}
                 isModerator={this.props.isModerator}

--- a/meinberlin/react/livequestions/QuestionList.jsx
+++ b/meinberlin/react/livequestions/QuestionList.jsx
@@ -15,7 +15,6 @@ const QuestionList = (props) => {
                 displayIsLive={!question.is_hidden}
                 displayIsHidden
                 displayIsAnswered={!question.is_hidden}
-                removeFromList={props.removeFromList.bind(this)}
                 updateQuestion={props.updateQuestion.bind(this)}
                 handleLike={props.handleLike.bind(this)}
                 isModerator={props.isModerator}

--- a/meinberlin/react/livequestions/QuestionModerator.jsx
+++ b/meinberlin/react/livequestions/QuestionModerator.jsx
@@ -25,7 +25,6 @@ const QuestionModerator = ({
   is_live: _isLive,
   is_on_shortlist: _isOnShortlist,
   likes,
-  removeFromList,
   togglePollingPaused,
   updateQuestion
 }) => {
@@ -87,7 +86,12 @@ const QuestionModerator = ({
     const value = !isAnswered
     const boolValue = value ? 1 : 0
     const data = { is_answered: boolValue }
-    removeFromList(id, data)
+    updateQuestion(data, id)
+      .then((response) => response.json())
+      .then(responseData => {
+        setIsAnswered(responseData.is_answered)
+      })
+      .then(() => togglePollingPaused())
   }
 
   const toggleIshidden = () => {

--- a/meinberlin/react/livequestions/StatisticsBox.jsx
+++ b/meinberlin/react/livequestions/StatisticsBox.jsx
@@ -20,12 +20,6 @@ function StatisticsBox (props) {
     return updateItem(data, url, 'PATCH')
   }
 
-  const removeFromList = (id, data) => {
-    updateQuestion(data, id)
-      .then(() => setAnsweredQuestions(prevQuestions => prevQuestions.filter(question => question.id !== id)
-      ))
-  }
-
   const countCategory = (category) => {
     let countPerCategory = 0
     let answeredQuestions = 0
@@ -94,7 +88,6 @@ function StatisticsBox (props) {
             displayIsLive={false}
             displayIsHidden={false}
             displayIsAnswered={question.is_answered}
-            removeFromList={removeFromList}
             key={question.id}
             id={question.id}
             is_answered={question.is_answered}


### PR DESCRIPTION
**Describe your changes**
This PR moves the `is_answered` update logic to the `QuestionModerator` component.

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [X] Changelog