### PR TITLE
a4-modal: adapt styles to component refactor

### DIFF
--- a/changelog/_8984.md
+++ b/changelog/_8984.md
@@ -1,0 +1,5 @@
+### Changed
+- Update styles to reflect the Modal.jsx refactor in adhocracy4
+
+### Added
+- New CSS classes following `a4-modal` prefix convention

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_dropdown.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_dropdown.html
@@ -27,7 +27,7 @@
 
             <li class="dropdown__item">
                 {% translate 'Report' as report_text %}
-                {% react_reports object text=report_text class='' %}
+                {% react_reports object text=report_text class='a4-modal__toggle-wrapper--no-icon' %}
             </li>
         </ul>
     </nav>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n module_tags rules react_comments_async react_comments_async react_reports react_ratings wagtailcore_tags item_tags contrib_tags moderatorremark_tags %}
+{% load i18n module_tags rules react_comments_async react_comments_async react_ratings wagtailcore_tags item_tags contrib_tags moderatorremark_tags %}
 
 {% block title %}
     {{ object.name }}

--- a/meinberlin/assets/scss/components_user_facing/_form-submit-flex-end.scss
+++ b/meinberlin/assets/scss/components_user_facing/_form-submit-flex-end.scss
@@ -9,8 +9,7 @@
 }
 
 .form-submit-flex-end__link {
-    margin: 0 auto!important;
-    padding: $spacer!important;
+    padding-bottom: $spacer!important;
 
     @media (min-width: $breakpoint-tablet) {
         margin-right: $spacer * 1.5!important;

--- a/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-comments.scss
+++ b/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-comments.scss
@@ -184,12 +184,14 @@
     white-space: nowrap;
     display: flex;
     align-items: center;
+
+    button {
+        margin-right: $spacer;
+        padding: 0;
+    }
 }
 
 .a4-comments__action-bar__btn {
-    margin-right: $spacer;
-    padding: 0;
-
     .fa,
     .far,
     .fas {

--- a/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-modal.scss
+++ b/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-modal.scss
@@ -1,1 +1,123 @@
-@import "~bootstrap/scss/modal"; // needed for a4-comments
+.a4-modal {
+    border: none;
+    box-shadow: 0 0.5em 1em rgba(0, 0, 0, 0.15);
+    padding: 2em 1.125em;
+
+    &::backdrop {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+
+    @media (max-width: $breakpoint-palm) {
+        width: 100%;
+        max-width: 100%;
+        max-height: 85vh;
+        position: fixed;
+        inset: auto 0 0;
+        margin: 0;
+        border-radius: 1em 1em 0 0;
+        padding-top: 0.75em;
+        transform: translateY(100%);
+        animation: slide-out 200ms ease-out forwards;
+        overflow-y: auto;
+
+        &[open] {
+            animation: slide-in 300ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+        }
+    }
+
+    @media (min-width: $breakpoint-palm) {
+        min-width: 500px;
+        max-width: 685px;
+    }
+}
+
+.a4-modal__toggle {
+    white-space: normal;
+
+    @media (max-width: $breakpoint-palm) {
+        text-align: center!important;
+    }
+}
+
+.a4-modal__close {
+    position: absolute;
+    right: 1em;
+    top: 1em;
+    padding: 0;
+}
+
+.a4-modal__title {
+    margin: unset;
+    line-height: 1.5;
+}
+
+.a4-modal__description {
+    margin-bottom: 1em;
+}
+
+.a4-modal__footer {
+    padding-top: 1em;
+    display: flex;
+    justify-content: end;
+}
+
+.a4-modal__cancel {
+    margin-right: 1.5em !important;
+}
+
+@keyframes slide-in {
+    from {
+        transform: translateY(100%);
+    }
+
+    to {
+        transform: translateY(0);
+    }
+}
+
+@keyframes slide-out {
+    from {
+        transform: translateY(0);
+    }
+
+    to {
+        transform: translateY(100%);
+    }
+}
+
+// Edge cases
+
+// hack to remove the report icon when used in a dropdown 
+// (edge-case here: meinberlin/apps/contrib/templates/meinberlin_contrib/includes/item_detail_dropdown.html)
+.a4-modal__toggle-wrapper--no-icon {
+    i {
+        display: none;
+    }
+}
+
+// class used in a4 static/modals/UrlModal.jsx
+.a4-url-modal__body {
+    padding-top: 1em;
+
+    @media (max-width: $breakpoint-palm) {
+        .form-control {
+            border-bottom: none;
+        }
+    }
+
+    @media (min-width: $breakpoint-palm) {
+        display: flex;
+
+        .form-control {
+            border-right: none;
+        }
+    }
+}
+
+.a4-url-modal__button {
+    @extend .button; 
+    @extend .button--light;  
+    @extend .button--fulltone;
+    @extend .button--fullwidth-palm;
+    color: $text-inverted!important;
+}


### PR DESCRIPTION
Migrate from Bootstrap to custom CSS classes
dependency of https://github.com/liqd/adhocracy4/pull/1758

