### PR TITLE
[#8828] account_dashboard: style tab navigation

### DIFF
--- a/changelog/8828.md
+++ b/changelog/8828.md
@@ -1,0 +1,2 @@
+### Changed
+- styled navigation on account dashboard to look like tab navigation

--- a/meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html
@@ -28,38 +28,51 @@
       {% translate "Manage your username, your password and your e-mail addresses." %}
     </p>
 
-    <nav class="dashboard-nav" aria-label="{% translate 'User Dashboard navigation' %}">
+    <nav class="tabnavigation" aria-label="{% translate 'User Dashboard navigation' %}">
       {% with request.resolver_match.url_name as url_name %}
-        <ul class="dashboard-nav__pages">
-          <li class="dashboard-nav__page">
-            <a href="{% url 'account_profile' %}" class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == " account_profile" %}is-active{% endif %}">
-              {% translate 'Profile' %}
-            </a>
-          </li>
-          <li class="dashboard-nav__page">
-            <a href="{% url 'account_actions' %}" class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == " account_actions" %}is-active{% endif %}">
-              {% translate 'Activities' %}
-            </a>
-          </li>
-          <li class="dashboard-nav__page">
-            <a href="{% url 'account_change_password' %}" class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == " account_change_password" %}is-active{% endif %}">
-              {% translate 'Change password' %}
-            </a>
-          </li>
-          <li class="dashboard-nav__page">
-            <a href="{% url 'account_email' %}" class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == " account_email" %}is-active{% endif %}">
-              {% translate 'Email addresses' %}
-            </a>
-          </li>
-          {% get_providers as socialaccount_providers %}
-          {% if socialaccount_providers %}
-            <li class="dashboard-nav__page">
-              <a href="{% url 'socialaccount_connections' %}" class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == " socialaccount_connections" %}is-active{% endif %}">
-                {% translate 'Account Connections' %}
+        <div class="row">
+          <ul class="tabnavigation--left">
+            <li>
+              <a
+                href="{% url 'account_profile' %}"
+                class="tabnavigation__button"
+                {% if request.resolver_match.url_name == "account_profile" %}aria-selected="true"{% endif %}
+              >
+                {% translate 'Profile' %}
               </a>
             </li>
-          {% endif %}
-        </ul>
+            <li>
+              <a
+                href="{% url 'account_change_password' %}"
+                class="tabnavigation__button"
+                {% if request.resolver_match.url_name == "account_change_password" %}aria-selected="true"{% endif %}
+              >
+                {% translate 'Change password' %}
+              </a>
+            </li>
+            <li>
+              <a
+                href="{% url 'account_email' %}"
+                class="tabnavigation__button"
+                {% if request.resolver_match.url_name == "account_email" %}aria-selected="true"{% endif %}
+              >
+                {% translate 'Email addresses' %}
+              </a>
+            </li>
+            {% get_providers as socialaccount_providers %}
+            {% if socialaccount_providers %}
+              <li>
+                <a
+                  href="{% url 'socialaccount_connections' %}"
+                  class="tabnavigation__button"
+                  {% if request.resolver_match.url_name == "socialaccount_connections" %}aria-selected="true"{% endif %}
+                >
+                  {% translate 'Account Connections' %}
+                </a>
+              </li>
+            {% endif %}
+          </ul>
+        </div>
       {% endwith %}
     </nav>
 

--- a/meinberlin/assets/scss/components_user_facing/_tabnavigation.scss
+++ b/meinberlin/assets/scss/components_user_facing/_tabnavigation.scss
@@ -1,14 +1,21 @@
 // Styling taken from BO button element styling with some small adjustments
 .tabnavigation__button {
-    min-height: 43px;
+    min-height: 40px;
     width: auto;
-    padding: 10px 6px;
     font-size: $em-spacer;
     line-height: 1.2;
-    display: inline-block;
     text-align: center;
     cursor: pointer;
     overflow: visible;
+    padding: 4px;
+    display: inline-block;
+    color: var(--color-grey-darkest);
+}
+
+a.tabnavigation__button {
+    // this component looks different on links, this adapts the styling to
+    // make it look the same
+    min-height: 35px;
 }
 
 .tabnavigation__link {
@@ -67,12 +74,6 @@
     margin-right: 0
 }
 
-.tabnavigation--left li button {
-    padding: 4px;
-    display: inline-block;
-    color: var(--color-grey-darkest);
-}
-
 @media (width <= 37.5rem) {
     .tabnavigation--left li {
         flex-grow: 1;
@@ -80,7 +81,7 @@
     }
 }
 
-.tabnavigation--left li button[aria-selected="true"] {
+.tabnavigation__button[aria-selected="true"] {
     border-bottom: 4px solid $primary;
     font-weight: bold;
     color: var(--color-black);


### PR DESCRIPTION
**Describe your changes**
Styles account dashboard navigation to look like tab navigation

![CleanShot 2025-01-29 at 17 41 00](https://github.com/user-attachments/assets/1eb12c6b-67e5-48bc-b52d-8eca8abd4309)


**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog