### PR TITLE
[#8768] [#8790] [#8818] Search profile fixes

### DIFF
--- a/meinberlin/react/kiezradar/SearchProfile.jsx
+++ b/meinberlin/react/kiezradar/SearchProfile.jsx
@@ -9,6 +9,7 @@ const cancelText = django.gettext('Cancel')
 const saveText = django.gettext('Save')
 const savingText = django.gettext('Saving')
 const viewProjectsText = django.gettext('View projects')
+const plansText = django.gettext('Plans')
 const errorText = django.gettext('Error')
 const errorDeleteSearchProfilesText = django.gettext(
   'Failed to delete search profile'
@@ -78,7 +79,11 @@ export default function SearchProfile ({ apiUrl, planListUrl, profile: profile_,
   ]
     .map((filter) => filter.map(({ name }) => name))
 
-  const selection = [[profile.query_text], ...filters]
+  const selection = [
+    [profile.query_text],
+    ...filters,
+    [profile.plans_only ? plansText : null]
+  ]
     .map((names) => names.join(', '))
     .filter(Boolean)
 

--- a/meinberlin/react/kiezradar/use-create-search-profile.jest.js
+++ b/meinberlin/react/kiezradar/use-create-search-profile.jest.js
@@ -51,6 +51,7 @@ describe('useCreateSearchProfile', () => {
       topics: ['ANT'],
       participations: [0, 1, 2],
       projectState: ['active', 'past', 'future'],
+      plansOnly: false,
       search: ''
     }
 
@@ -59,7 +60,9 @@ describe('useCreateSearchProfile', () => {
       organisations: [1],
       topics: [1],
       project_types: [1, 2, 3],
-      status: [1, 2, 3]
+      status: [1, 2, 3],
+      plans_only: false,
+      notification: true
     }
 
     const { result } = renderHook(() =>
@@ -71,6 +74,7 @@ describe('useCreateSearchProfile', () => {
         topicChoices,
         participationChoices,
         projectStatus,
+        searchProfilesCount: 0,
         onSearchProfileCreate: () => {}
       })
     )
@@ -93,6 +97,7 @@ describe('useCreateSearchProfile', () => {
       topics: [],
       participations: [],
       projectState: [],
+      plansOnly: false,
       search: ''
     }
 
@@ -128,6 +133,7 @@ describe('useCreateSearchProfile', () => {
         topicChoices,
         participationChoices,
         projectStatus,
+        searchProfilesCount: 0,
         onSearchProfileCreate: mockOnSearchProfileCreate
       })
     )
@@ -137,5 +143,37 @@ describe('useCreateSearchProfile', () => {
     })
 
     expect(mockOnSearchProfileCreate).toHaveBeenCalledWith(mockedSearchProfile)
+  })
+
+  it('sets limitExceeded to true when searchProfilesCount is 10', async () => {
+    const appliedFilters = {
+      districts: [],
+      organisation: [],
+      topics: [],
+      participations: [],
+      projectState: [],
+      plansOnly: false,
+      search: ''
+    }
+
+    const { result } = renderHook(() =>
+      useCreateSearchProfile({
+        searchProfilesApiUrl,
+        appliedFilters,
+        districts,
+        organisations,
+        topicChoices,
+        participationChoices,
+        projectStatus,
+        searchProfilesCount: 10,
+        onSearchProfileCreate: () => {}
+      })
+    )
+
+    await act(async () => {
+      await result.current.createSearchProfile()
+    })
+
+    expect(result.current.limitExceeded).toBe(true)
   })
 })

--- a/meinberlin/react/kiezradar/use-create-search-profile.js
+++ b/meinberlin/react/kiezradar/use-create-search-profile.js
@@ -20,12 +20,19 @@ export function useCreateSearchProfile ({
   topicChoices,
   participationChoices,
   projectStatus,
+  searchProfilesCount,
   onSearchProfileCreate
 }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [limitExceeded, setLimitExceeded] = useState(false)
 
   const createSearchProfile = async () => {
+    if (searchProfilesCount === 10) {
+      setLimitExceeded(true)
+      return
+    }
+
     setLoading(true)
     setError(null)
 
@@ -51,7 +58,9 @@ export function useCreateSearchProfile ({
       organisations: organisationIds,
       topics: topicIds,
       project_types: participationIds,
-      status: projectStatusIds
+      status: projectStatusIds,
+      plans_only: appliedFilters.plansOnly,
+      notification: true
     }
 
     if (appliedFilters.search.length > 0) {
@@ -70,7 +79,7 @@ export function useCreateSearchProfile ({
     }
   }
 
-  return { loading, error, createSearchProfile }
+  return { loading, limitExceeded, error, createSearchProfile }
 }
 
 function getFilteredResults ({

--- a/meinberlin/react/plans/SaveSearchProfile.jsx
+++ b/meinberlin/react/plans/SaveSearchProfile.jsx
@@ -30,10 +30,6 @@ export default function SaveSearchProfile ({
     )
   }
 
-  if (searchProfilesCount > 10) {
-    return <span className="save-search-profile__action">{limitText}</span>
-  }
-
   if (searchProfile) {
     return (
       <a className="save-search-profile__action save-search-profile__action--link" href="/account/search-profiles">
@@ -42,7 +38,7 @@ export default function SaveSearchProfile ({
     )
   }
 
-  return <CreateSearchProfileButton {...props} />
+  return <CreateSearchProfileButton {...props} searchProfilesCount={searchProfilesCount} />
 }
 
 function CreateSearchProfileButton ({
@@ -53,9 +49,10 @@ function CreateSearchProfileButton ({
   projectStatus,
   searchProfilesApiUrl,
   appliedFilters,
+  searchProfilesCount,
   onSearchProfileCreate
 }) {
-  const { loading, error, createSearchProfile } = useCreateSearchProfile({
+  const { loading, limitExceeded, error, createSearchProfile } = useCreateSearchProfile({
     searchProfilesApiUrl,
     appliedFilters,
     districts,
@@ -63,8 +60,13 @@ function CreateSearchProfileButton ({
     topicChoices,
     participationChoices,
     projectStatus,
+    searchProfilesCount,
     onSearchProfileCreate
   })
+
+  if (limitExceeded) {
+    return <span className="save-search-profile__action">{limitText}</span>
+  }
 
   if (error) {
     return <span className="save-search-profile__error">{error}</span>

--- a/meinberlin/react/projects/getDefaultState.js
+++ b/meinberlin/react/projects/getDefaultState.js
@@ -18,7 +18,8 @@ export const getDefaultState = (searchProfile) => {
       districts: searchProfile.districts.map(d => d.name),
       organisation: searchProfile.organisations.map(o => o.name),
       participations: searchProfile.project_types.map(p => p.id),
-      topics: searchProfile.topics.map((t) => t.code)
+      topics: searchProfile.topics.map((t) => t.code),
+      plansOnly: searchProfile.plans_only
     }
   }
 


### PR DESCRIPTION
**Describe your changes**
This PR implements various search profile fixes based on these tickets:

- [#8768 Notifications should default to "on" when search profile is saved (Sev)](https://taiga.liqd.net/project/liqd-liquid-software/task/8768)
- [#8790 Send plans_only field to backend](https://taiga.liqd.net/project/liqd-liquid-software/task/8790)
- [#8818 fix issues](https://taiga.liqd.net/project/liqd-liquid-software/task/8818) (from [#8661 [mB] Kiezradar frontend: "save search" button on Project Overview page (sev)](https://taiga.liqd.net/project/liqd-liquid-software/us/8661?milestone=424))

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog