### PR TITLE
[#8748] adapt container width on cta pages

### DIFF
--- a/meinberlin/apps/cms/templates/meinberlin_cms/email_form_page.html
+++ b/meinberlin/apps/cms/templates/meinberlin_cms/email_form_page.html
@@ -9,22 +9,24 @@
 
 {% block content %}
     <div class="layout-grid__area--maincontent">
-        <h1>{{ page.title }}</h1>
-        {{ page.intro|richtext }}
+        <div class="narrow-wrapper">
+            <h1>{{ page.title }}</h1>
+            {{ page.intro|richtext }}
 
-        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
-            {% csrf_token %}
-            {{ form.media }}
+            <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+                {% csrf_token %}
+                {{ form.media }}
 
-            {% for field in form %}
-                {% if field|field_type == 'booleanfield' %}
-                    {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=field %}
-                {% else %}
-                    {% include 'meinberlin_contrib/includes/form_field.html' with field=field %}
-                {% endif %}
-            {% endfor %}
+                {% for field in form %}
+                    {% if field|field_type == 'booleanfield' %}
+                        {% include 'meinberlin_contrib/includes/form_checkbox_field.html' with field=field %}
+                    {% else %}
+                        {% include 'meinberlin_contrib/includes/form_field.html' with field=field %}
+                    {% endif %}
+                {% endfor %}
 
-            {% include 'meinberlin_contrib/includes/form_submit_flex_end.html' with button_text='Send' %}
-        </form>
+                {% include 'meinberlin_contrib/includes/form_submit_flex_end.html' with button_text='Send' %}
+            </form>
+        </div>
     </div>
 {% endblock content %}

--- a/meinberlin/apps/cms/templates/meinberlin_cms/email_form_page_landing.html
+++ b/meinberlin/apps/cms/templates/meinberlin_cms/email_form_page_landing.html
@@ -1,17 +1,19 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
 
-{% block title %}{{ page.title }} &mdash; {{ block.super }}{% endblock %}
+{% block title %}{{ page.title }} — {{ block.super }}{% endblock title %}
 
 {% block breadcrumbs %}
     {% include 'meinberlin_cms/includes/cms_breadcrumb.html' %}
-{% endblock %}
+{% endblock breadcrumbs %}
 
 {% block content %}
+<div class="narrow-wrapper">
     <div class="container">
         <div class="offset-lg-3 col-lg-6">
             <h1>{{ page.title }}</h1>
             {{ page.thank_you|richtext }}
         </div>
     </div>
-{% endblock %}
+</div>
+{% endblock content %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_detail.html
@@ -3,6 +3,7 @@
 
 {% block title %}{% blocktranslate with project=moderatorinvite.project.name %}Invitation to {{ project }}{% endblocktranslate %}{% endblock %}
 {% block content %}
+<div class="narrow-wrapper">
     <div class="container">
         <div class="offset-lg-3 col-lg-6">
             <h1>{% blocktranslate with project=moderatorinvite.project.name %}Moderation invitation for {{ project }}{% endblocktranslate %}</h1>
@@ -22,4 +23,5 @@
             <a class="btn btn--light" href="{% url 'account_signup' %}">{% translate "Register" %}</a>
         </div>
     </div>
+</div>
 {% endblock %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_form.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/moderatorinvite_form.html
@@ -3,6 +3,7 @@
 
 {% block title %}{% blocktranslate with project=moderatorinvite.project.name %}Invitation to {{ project }}{% endblocktranslate %}{% endblock title %}
 {% block content %}
+<div class="narrow-wrapper">
     <h1>{% blocktranslate with project=moderatorinvite.project.name %}Moderation invitation for {{ project }}{% endblocktranslate %}</h1>
 
     {% if form.non_field_errors %}
@@ -20,4 +21,5 @@
         {% csrf_token %}
         {% include 'meinberlin_contrib/includes/form_submit_flex_end.html' with button_text='Accept' secondary_button_text='Decline' %}
     </form>
+</div>
 {% endblock content %}

--- a/meinberlin/templates/account/password_reset_done.html
+++ b/meinberlin/templates/account/password_reset_done.html
@@ -9,6 +9,7 @@
 {% endblock head_title %}
 
 {% block content %}
+<div class="narrow-wrapper">
     <h1>{% translate "Password Reset" %}</h1>
     {% if user.is_authenticated %}
         {% include "account/snippets/already_logged_in.html" %}
@@ -16,4 +17,5 @@
     <p>
         {% blocktranslate %}We have sent you an e-mail. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.{% endblocktranslate %}
     </p>
+</div>
 {% endblock content %}

--- a/meinberlin/templates/account/password_reset_from_key.html
+++ b/meinberlin/templates/account/password_reset_from_key.html
@@ -4,6 +4,7 @@
 {% block head_title %}{% translate "Change Password" %}{% endblock %}
 
 {% block content %}
+    <div class="narrow-wrapper">
     <h1>{% if token_fail %}{% translate "Bad Token" %}{% else %}{% translate "Change Password" %}{% endif %}</h1>
 
     {% if token_fail %}
@@ -24,10 +25,11 @@
                 {% for field in form %}
                     {% include 'meinberlin_contrib/includes/form_field.html' with field=field %}
                 {% endfor %}
-                <input class="btn btn--primary" type="submit" name="action" value="{% translate 'Change password' %}"/>
+                <button class="button button--full-width" type="submit">{% translate 'Change password' %}</button>       
             </form>
         {% else %}
             <p>{% translate 'Your password is now changed.' %}</p>
         {% endif %}
     {% endif %}
+    </div>
 {% endblock %}

--- a/meinberlin/templates/account/verification_sent.html
+++ b/meinberlin/templates/account/verification_sent.html
@@ -5,8 +5,10 @@
     {% translate "Verify Your E-mail Address" %}
 {% endblock head_title %}
 {% block content %}
+<div class="narrow-wrapper">
     <h1>{% translate "Verify Your E-mail Address" %}</h1>
     <p>
         {% blocktranslate %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. If you do not see the verification e-mail in your main inbox, check your spam folder. Please contact us if you do not receive the verification e-mail within a few minutes.{% endblocktranslate %}
     </p>
+</div>
 {% endblock content %}


### PR DESCRIPTION
**Description:**
I'm using `narrow-wrapper` class to address layout issues on pages with single or minimal form fields, ensuring the form fields no longer appear excessively wide. This is a temporary fix, and a follow-up plan includes creating a `base-narrow.html` or similar template to standardize the layout going forward [(see issue)](https://github.com/liqd/a4-meinberlin/issues/6034)

