### PR TITLE
[#8890] Add Kiezradar map Berlin polygon boundary

### DIFF
--- a/changelog/_8890.md
+++ b/changelog/_8890.md
@@ -1,0 +1,3 @@
+## Added
+
+- Added Berlin polygon boundary to `KiezradarMap`.

--- a/meinberlin/apps/kiezradar/templatetags/react_kiezradar.py
+++ b/meinberlin/apps/kiezradar/templatetags/react_kiezradar.py
@@ -33,6 +33,7 @@ def react_kiezradar():
         "baseUrl": settings.A4_MAP_BASEURL,
         "mapboxToken": mapbox_token,
         "omtToken": omt_token,
+        "polygon": settings.BERLIN_POLYGON,
     }
 
     return format_html(


### PR DESCRIPTION
**Describe your changes**
This PR adds the Berlin polygon boundary to the Kiezradar map.

Also closes this issue: [#8750 [mB] Kiezradar Frontend: Creating a Kiez (radius) - selec. neighborhood outside allowed geographical area](https://github.com/liqd/a4-meinberlin/issues/6045)

![2025-02-11 13 19 17](https://github.com/user-attachments/assets/433d067a-d868-43a5-be27-2547c6dbcfaf)

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [X] Changelog