### PR TITLE
[#8872] Add modal and save filters on login redirect

### DIFF
--- a/changelog/_8872.md
+++ b/changelog/_8872.md
@@ -1,0 +1,3 @@
+## Added
+
+- Added `Modal` component for when logging in on project overview.

--- a/meinberlin/assets/scss/components_user_facing/_kiezradar.scss
+++ b/meinberlin/assets/scss/components_user_facing/_kiezradar.scss
@@ -192,58 +192,6 @@
   z-index: 1001;
 }
 
-.kiezradar__modal {
-  border: none;
-  max-width: 43rem;
-  padding: 2rem 1.125rem;
-  margin: auto 3px 0;
-
-  @media screen and (min-width: $breakpoint-palm) {
-    margin: auto;
-  }
-}
-
-.kiezradar__modal::backdrop {
-  background: rgba(0, 0, 0, 0.5);
-}
-
-.kiezradar__modal-title {
-  font-size: 1.375rem;
-  margin: 0;
-  margin-bottom: 0.625rem;
-}
-
-.kiezradar__modal-text {
-  margin-bottom: 2.5rem;
-}
-
-.kiezradar__modal-buttons {
-  display: flex;
-
-  @media screen and (min-width: $breakpoint-palm) {
-    justify-content: flex-end;
-    gap: 2rem;
-  }
-}
-
-.kiezradar__modal-button-open {
-  margin-left: auto;
-
-  @media screen and (min-width: $breakpoint-palm) {
-    margin-left: 0;
-  }
-}
-
-.kiezradar__modal-close {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  padding: 0.25rem;
-  border: 0;
-  color: inherit;
-  cursor: pointer;
-}
-
 .kiezradar__controls--tablet {
   display: none;
 

--- a/meinberlin/assets/scss/components_user_facing/_modal.scss
+++ b/meinberlin/assets/scss/components_user_facing/_modal.scss
@@ -1,0 +1,59 @@
+.modal {
+  border: none;
+  max-width: 43rem;
+  padding: 2rem 1.125rem;
+  margin: auto 3px 0;
+
+  @media screen and (min-width: $breakpoint-palm) {
+    margin: auto;
+  }
+}
+  
+.modal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.modal__title {
+  font-size: 1.375rem;
+  margin: 0;
+  margin-bottom: 0.625rem;
+}
+
+.modal__text {
+  margin-bottom: 2.5rem;
+}
+
+.modal__content {
+  margin-bottom: 40px;
+}
+
+.modal__content > div {
+  margin: 0;
+}
+
+.modal__buttons {
+  display: flex;
+
+  @media screen and (min-width: $breakpoint-palm) {
+    justify-content: flex-end;
+    gap: 2rem;
+  }
+}
+
+.modal__confirm-button {
+  margin-left: auto;
+
+  @media screen and (min-width: $breakpoint-palm) {
+    margin-left: 0;
+  }
+}
+
+.modal__close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+}

--- a/meinberlin/assets/scss/style_user_facing.scss
+++ b/meinberlin/assets/scss/style_user_facing.scss
@@ -68,6 +68,7 @@
 @import "components_user_facing/project-tile";
 @import "components_user_facing/status-bar";
 @import "components_user_facing/video-wall";
+@import "components_user_facing/modal";
 
 // a4 overwrites
 @import "components_user_facing/adhocracy4/a4-address-search";

--- a/meinberlin/react/contrib/Modal.jsx
+++ b/meinberlin/react/contrib/Modal.jsx
@@ -2,9 +2,8 @@ import React, { useEffect, useRef } from 'react'
 import django from 'django'
 
 const closeText = django.gettext('Close')
-const deleteText = django.gettext('Delete')
 
-export default function DeleteModal ({ title, message, onDelete, onClose }) {
+export default function Modal ({ title, message, buttonText, onConfirm, onClose, children }) {
   const dialogRef = useRef(null)
 
   const closeModal = () => {
@@ -22,24 +21,25 @@ export default function DeleteModal ({ title, message, onDelete, onClose }) {
 
   return (
     <dialog
-      className="kiezradar__modal"
+      className="modal"
       ref={dialogRef}
-      aria-labelledby="modal-title"
+      aria-labelledby="modal__title"
       onKeyDown={(event) => {
         if (event.key === 'Escape') closeModal()
       }}
     >
-      <button type="button" className="kiezradar__modal-close" aria-label={closeText} onClick={closeModal}>
+      <button type="button" className="modal__close" aria-label={closeText} onClick={closeModal}>
         <span className="fa fa-times" aria-hidden="true" />
       </button>
-      <h3 id="modal-title" className="kiezradar__modal-title">{title}</h3>
-      <p className="kiezradar__modal-text">{message}</p>
-      <div className="kiezradar__modal-buttons">
+      <h3 id="modal__title" className="modal__title">{title}</h3>
+      <p className="modal__text">{message}</p>
+      {children && <div className="modal__content">{children}</div>}
+      <div className="modal__buttons">
         <button className="link" onClick={closeModal}>
           {closeText}
         </button>
-        <button className="button kiezradar__modal-button-open" onClick={onDelete}>
-          {deleteText}
+        <button className="button modal__confirm-button" onClick={onConfirm}>
+          {buttonText}
         </button>
       </div>
     </dialog>

--- a/meinberlin/react/contrib/helpers.js
+++ b/meinberlin/react/contrib/helpers.js
@@ -45,3 +45,34 @@ export const arraysEqual = (a, b) => {
   }
   return true
 }
+
+/*
+ * converts an object to URLSearchParams
+ *
+ * This function takes an object and converts it into a URLSearchParams
+ * instance, which can be used for query string formatting in URLs.
+ * It handles arrays by appending each value to the parameter, and ignores
+ * any null or undefined values.
+ *
+ * Example:
+ * For the input:
+ *   { search: 'apple', category: 'fruit', tags: ['red', 'green'], page: null }
+ * The output will be:
+ *   "search=apple&category=fruit&tags=red&tags=green"
+ *
+ * @param {Object} params - The object to convert into URLSearchParams
+ * @returns {URLSearchParams} - The resulting URLSearchParams instance
+ */
+export const toSearchParams = (params) => {
+  return Object.entries(params).reduce((acc, [key, value]) => {
+    if (value == null || value === '') return acc
+
+    if (Array.isArray(value)) {
+      value.forEach(val => (val != null && val !== '') && acc.append(key, val))
+    } else {
+      acc.set(key, value)
+    }
+
+    return acc
+  }, new URLSearchParams())
+}

--- a/meinberlin/react/kiezradar/KiezradarList.jsx
+++ b/meinberlin/react/kiezradar/KiezradarList.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 import Loading from './Loading'
 import { alert as Alert } from 'adhocracy4'
 import { updateItem } from '../contrib/helpers'
-import DeleteModal from './DeleteModal'
+import Modal from '../contrib/Modal'
 
 const noSavedKiezradarsText = django.gettext('No saved Kiezes')
 const addKiezText = django.gettext('Add Kiez')
@@ -69,10 +69,11 @@ export default function KiezradarList ({
           : (
             <>
               {deleteModal?.kiezradar && (
-                <DeleteModal
+                <Modal
                   title={confirmDeletionText(deleteModal.kiezradar.name)}
                   message={confirmDeletionDescriptionText}
-                  onDelete={() => handleDelete(deleteModal.kiezradar)}
+                  buttonText={deleteText}
+                  onConfirm={() => handleDelete(deleteModal.kiezradar)}
                   onClose={() => setDeleteModal(null)}
                 />
               )}

--- a/meinberlin/react/kiezradar/SearchProfile.jsx
+++ b/meinberlin/react/kiezradar/SearchProfile.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 import django from 'django'
 import SearchProfileButtons from './SearchProfileButtons'
-import { updateItem } from '../contrib/helpers'
+import { toSearchParams, updateItem } from '../contrib/helpers'
 import PushNotificationToggle from './PushNotificationToggle'
 import { alert as Alert } from 'adhocracy4'
 import DeleteModal from './DeleteModal'
@@ -170,7 +170,7 @@ export default function SearchProfile ({ apiUrl, planListUrl, searchProfile, onS
             checked={searchProfile.notification}
             onError={(error) => setError(error)}
           />
-          <a href={planListUrl + '?search-profile=' + searchProfile.id} className="button button--light search-profile__view-projects">
+          <a href={planListUrl + '?' + toQueryString(searchProfile)} className="button button--light search-profile__view-projects">
             {viewProjectsText}
           </a>
           {!isEditing && (
@@ -186,4 +186,19 @@ export default function SearchProfile ({ apiUrl, planListUrl, searchProfile, onS
       </div>
     </>
   )
+}
+
+function toQueryString (searchProfile) {
+  const projectStateMapping = ['active', 'past', 'future']
+
+  return toSearchParams({
+    'search-profile': searchProfile.id,
+    search: searchProfile.query_text || undefined,
+    districts: searchProfile.districts.map(district => district.name),
+    organisation: searchProfile.organisations.map(organisation => organisation.name),
+    participations: searchProfile.project_types.map(participation => participation.id),
+    topics: searchProfile.topics.map((topic) => topic.code),
+    plansOnly: searchProfile.plans_only,
+    projectState: searchProfile.status.map(status => projectStateMapping[status.status])
+  }).toString()
 }

--- a/meinberlin/react/kiezradar/SearchProfile.jsx
+++ b/meinberlin/react/kiezradar/SearchProfile.jsx
@@ -4,12 +4,13 @@ import SearchProfileButtons from './SearchProfileButtons'
 import { toSearchParams, updateItem } from '../contrib/helpers'
 import PushNotificationToggle from './PushNotificationToggle'
 import { alert as Alert } from 'adhocracy4'
-import DeleteModal from './DeleteModal'
+import Modal from '../contrib/Modal'
 
 const renameSearchProfileText = django.gettext('Rename search profile')
 const cancelText = django.gettext('Cancel')
 const saveText = django.gettext('Save')
 const savingText = django.gettext('Saving')
+const deleteText = django.gettext('Delete')
 const viewProjectsText = django.gettext('View projects')
 const plansText = django.gettext('Plans')
 const errorText = django.gettext('Error')
@@ -103,10 +104,11 @@ export default function SearchProfile ({ apiUrl, planListUrl, searchProfile, onS
   return (
     <>
       {deleteModal?.searchProfile && (
-        <DeleteModal
+        <Modal
           title={confirmDeletionText(deleteModal.searchProfile.name)}
           message={confirmDeletionDescriptionText}
-          onDelete={() => handleDelete()}
+          buttonText={deleteText}
+          onConfirm={() => handleDelete()}
           onClose={() => setDeleteModal(null)}
         />
       )}

--- a/meinberlin/react/plans/SaveSearchProfile.jsx
+++ b/meinberlin/react/plans/SaveSearchProfile.jsx
@@ -1,8 +1,15 @@
-import React from 'react'
+import React, { useState } from 'react'
 import django from 'django'
 import { useCreateSearchProfile } from '../kiezradar/use-create-search-profile'
+import Modal from '../contrib/Modal'
+import { alert as Alert } from 'adhocracy4'
+import { useSearchParams } from 'react-router-dom'
 
-const loginText = django.gettext('Login to save search profiles')
+const modalTitleText = django.gettext('Login or register to save a search profile')
+const modalMessageText = django.gettext('To save your search profile and access it later, please log in or create an account.')
+const modalButtonText = django.gettext('Continue to login')
+const alertTitleText = django.gettext('Please note, your current selection won’t be saved automatically')
+const alertMessageText = django.gettext('After logging in, you can create and save a new search profile.')
 const viewText = django.gettext('View search profiles')
 const limitText = django.gettext('You can only create 10 search profiles.')
 const saveText = django.gettext('Save search profile')
@@ -14,21 +21,42 @@ export default function SaveSearchProfile ({
   searchProfilesCount,
   ...props
 }) {
+  const [searchParams] = useSearchParams()
+  const [modal, setModal] = useState(false)
+
   if (!isAuthenticated) {
     return (
-      <div className="save-search-profile">
-        <a
-          className="save-search-profile__action save-search-profile__action--link"
-          href={
-            '/accounts/login/?next=' +
-            window.location.pathname +
-            window.location.search
-          }
-        >
-          <Icon />
-          {loginText}
-        </a>
-      </div>
+      <>
+        {modal && (
+          <Modal
+            title={modalTitleText}
+            message={modalMessageText}
+            buttonText={modalButtonText}
+            onConfirm={() => {
+              const nextUrl = window.location.pathname + '?' + searchParams.toString()
+              const encodedNext = encodeURIComponent(nextUrl)
+              window.location = '/accounts/login/?next=' + encodedNext
+              setModal(false)
+            }}
+            onClose={() => setModal(false)}
+          >
+            <Alert
+              title={alertTitleText}
+              message={alertMessageText}
+            />
+          </Modal>
+        )}
+        <div className="save-search-profile">
+          <button
+            className="save-search-profile__action save-search-profile__action--button"
+            type="button"
+            onClick={() => setModal(!modal)}
+          >
+            <Icon />
+            {saveText}
+          </button>
+        </div>
+      </>
     )
   }
 

--- a/meinberlin/react/plans/react_plans_map.jsx
+++ b/meinberlin/react/plans/react_plans_map.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import ProjectsListMapBox from '../projects/ProjectsListMapBox'
+import { BrowserRouter } from 'react-router-dom'
 
 function init () {
   const plansMapBox = document.querySelectorAll('[data-map="plans"]')
@@ -30,30 +31,32 @@ function init () {
     const root = createRoot(el)
     root.render(
       <React.StrictMode>
-        <ProjectsListMapBox
-          selectedDistrict={selectedDistrict}
-          selectedTopic={selectedTopic}
-          projectApiUrl={projectApiUrl}
-          extprojectApiUrl={extprojectApiUrl}
-          privateprojectApiUrl={privateprojectApiUrl}
-          plansApiUrl={plansApiUrl}
-          attribution={attribution}
-          baseUrl={baseUrl}
-          mapboxToken={mapboxToken}
-          omtToken={omtToken}
-          useVectorMap={useVectorMap}
-          bounds={bounds}
-          organisations={organisations}
-          districts={districts}
-          topicChoices={topicChoices}
-          participationChoices={participationChoices}
-          searchProfile={searchProfile}
-          searchProfilesApiUrl={searchProfilesApiUrl}
-          searchProfilesUrl={searchProfilesUrl}
-          searchProfilesCount={searchProfilesCount}
-          isAuthenticated={isAuthenticated}
-          projectStatus={projectStatus}
-        />
+        <BrowserRouter>
+          <ProjectsListMapBox
+            selectedDistrict={selectedDistrict}
+            selectedTopic={selectedTopic}
+            projectApiUrl={projectApiUrl}
+            extprojectApiUrl={extprojectApiUrl}
+            privateprojectApiUrl={privateprojectApiUrl}
+            plansApiUrl={plansApiUrl}
+            attribution={attribution}
+            baseUrl={baseUrl}
+            mapboxToken={mapboxToken}
+            omtToken={omtToken}
+            useVectorMap={useVectorMap}
+            bounds={bounds}
+            organisations={organisations}
+            districts={districts}
+            topicChoices={topicChoices}
+            participationChoices={participationChoices}
+            searchProfile={searchProfile}
+            searchProfilesApiUrl={searchProfilesApiUrl}
+            searchProfilesUrl={searchProfilesUrl}
+            searchProfilesCount={searchProfilesCount}
+            isAuthenticated={isAuthenticated}
+            projectStatus={projectStatus}
+          />
+        </BrowserRouter>
       </React.StrictMode>)
   })
 }

--- a/meinberlin/react/projects/ProjectsListMapBox.jsx
+++ b/meinberlin/react/projects/ProjectsListMapBox.jsx
@@ -9,10 +9,8 @@ import ProjectsMap from './ProjectsMap'
 import Spinner from '../contrib/Spinner'
 import { ProjectsControlBar } from './ProjectsControlBar'
 import { filterProjects } from './filter-projects'
-import {
-  getDefaultProjectState,
-  getDefaultState
-} from './getDefaultState'
+import { getDefaultProjectState, getDefaultState } from './getDefaultState'
+import { useLocation } from 'react-router-dom'
 
 const pageHeader = django.gettext('Kiezradar')
 const showMapStr = django.gettext('Show map')
@@ -55,12 +53,14 @@ const ProjectsListMapBox = ({
   searchProfilesCount,
   isAuthenticated
 }) => {
+  const location = useLocation()
+  const searchParams = new URLSearchParams(location.search)
   const [showMap, setShowMap] = useState(true)
   const [loading, setLoading] = useState(true)
-  const [projectState, setProjectState] = useState(getDefaultProjectState(searchProfile))
+  const [projectState, setProjectState] = useState(getDefaultProjectState(searchParams))
   const [items, setItems] = useState([])
   const fetchCache = useRef({})
-  const [appliedFilters, setAppliedFilters] = useState(getDefaultState(searchProfile))
+  const [appliedFilters, setAppliedFilters] = useState(getDefaultState(searchParams, { districts, organisations, participationChoices, topicChoices }))
   const [alert, setAlert] = useState(null)
   const [error, setError] = useState(null)
 
@@ -148,7 +148,7 @@ const ProjectsListMapBox = ({
           setAppliedFilters(filters)
         }}
         onResetClick={() => {
-          setAppliedFilters(getDefaultState(searchProfile))
+          setAppliedFilters(getDefaultState(null, { districts, organisations, participationChoices, topicChoices }))
           setProjectState(['active', 'future'])
         }}
         onAlert={setAlert}

--- a/meinberlin/react/projects/getDefaultState.js
+++ b/meinberlin/react/projects/getDefaultState.js
@@ -9,17 +9,30 @@ const defaultState = {
   plansOnly: false
 }
 
-export const getDefaultState = (searchProfile) => {
+export const getDefaultState = (searchParams, {
+  districts,
+  organisations,
+  participationChoices,
+  topicChoices
+}) => {
   let mergeData = {}
 
-  if (searchProfile) {
+  if (searchParams) {
     mergeData = {
-      search: searchProfile.query_text ?? '',
-      districts: searchProfile.districts.map(d => d.name),
-      organisation: searchProfile.organisations.map(o => o.name),
-      participations: searchProfile.project_types.map(p => p.id),
-      topics: searchProfile.topics.map((t) => t.code),
-      plansOnly: searchProfile.plans_only
+      search: searchParams.get('search') ?? '',
+      districts: districts
+        .filter((district) => searchParams.getAll('districts').includes(district.name))
+        .map((district) => district.name),
+      organisation: organisations
+        .filter((organisation) => searchParams.getAll('organisation').includes(organisation.name))
+        .map((organisation) => organisation.name),
+      participations: participationChoices
+        .filter((participation) => searchParams.getAll('participations').includes(participation.id.toString()))
+        .map((participation) => participation.id),
+      topics: topicChoices
+        .filter((topic) => searchParams.getAll('topics').includes(topic.code))
+        .map((topic) => topic.code),
+      plansOnly: searchParams.get('plansOnly') === 'true'
     }
   }
 
@@ -29,11 +42,12 @@ export const getDefaultState = (searchProfile) => {
   }
 }
 
-export const getDefaultProjectState = (searchProfile) => {
-  const mapping = ['active', 'past', 'future']
-  if (searchProfile && searchProfile.status.length) {
-    return searchProfile.status.map(s => mapping[s.status])
-  }
+const defaultProjectState = ['active', 'future']
+const validProjectStates = [...defaultProjectState, 'past']
 
-  return ['active', 'future']
+export const getDefaultProjectState = (searchParams) => {
+  const projectState = searchParams.getAll('projectState')
+  const filteredStates = projectState.filter(state => validProjectStates.includes(state))
+
+  return filteredStates.length ? filteredStates : defaultProjectState
 }


### PR DESCRIPTION
**Describe your changes**
This PR adds a modal if user isn't logged in and saves the project overview filters on login redirect.

<img width="1182" alt="Screenshot 2025-02-18 at 07 16 53" src="https://github.com/user-attachments/assets/3523cc8e-58ba-4091-b3f5-2f0f1e090b9e" />

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog