### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-04 12:03+0100\n"
-"PO-Revision-Date: 2025-01-31 11:15+0000\n"
+"PO-Revision-Date: 2025-02-25 10:27+0000\n"
 "Last-Translator: MarleyMi <m.mittmann@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main/de/>"
 "\n"
@@ -4368,7 +4368,7 @@ msgstr[1] "%(num_entries)s Beiträge"
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html:21
 #, python-format
 msgid "remaining %(time_left)s"
-msgstr "noch %(time_left)s"
+msgstr "noch %(time_left)"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html:27
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:77
@@ -4392,7 +4392,7 @@ msgstr "jetzt lesen"
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:68
 #, python-format
 msgid "%(time_left)s remaining "
-msgstr "noch %(time_left)s"
+msgstr "noch %(time_left) "
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_timeline-carousel.html:12
 msgid "Timeline item"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-04 12:03+0100\n"
-"PO-Revision-Date: 2025-01-31 11:15+0000\n"
+"PO-Revision-Date: 2025-02-25 10:27+0000\n"
 "Last-Translator: MarleyMi <m.mittmann@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
@@ -818,12 +818,12 @@ msgstr "Ihre Wahl"
 #: adhocracy4/ratings/static/ratings/RatingBox.jsx:9
 #: adhocracy4/ratings/static/ratings/RatingBox.jsx:9
 msgid "Likes"
-msgstr "gefällt mir"
+msgstr "Gefällt"
 
 #: adhocracy4/ratings/static/ratings/RatingBox.jsx:10
 #: adhocracy4/ratings/static/ratings/RatingBox.jsx:10
 msgid "Dislikes"
-msgstr "gefällt mir nicht"
+msgstr "gefällt nicht"
 
 #: adhocracy4/ratings/static/ratings/RatingButton.jsx:5
 #: adhocracy4/ratings/static/ratings/RatingButton.jsx:5


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main](https://weblate.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://weblate.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main/horizontal-auto.svg)