### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-23 14:41+0100\n"
-"PO-Revision-Date: 2025-02-25 09:03+0000\n"
-"Last-Translator: MarleyMi <m.mittmann@liqd.net>\n"
+"PO-Revision-Date: 2025-02-25 10:28+0000\n"
+"Last-Translator: Julian Dehm <j.dehm@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
 "main-design-dev/de/>\n"
 "Language: de_DE\n"
@@ -4384,7 +4384,7 @@ msgstr[1] "%(num_entries)s Beiträge"
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html:21
 #, python-format
 msgid "remaining %(time_left)s"
-msgstr "noch %(time_left)"
+msgstr "noch %(time_left)s"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html:27
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:77
@@ -4408,7 +4408,7 @@ msgstr "jetzt lesen"
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:68
 #, python-format
 msgid "%(time_left)s remaining "
-msgstr "noch %(time_left) "
+msgstr "noch %(time_left)s "
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_timeline-carousel.html:12
 msgid "Timeline item"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main-design-dev](https://weblate.liqd.net/projects/meinberlin/main-design-dev/).


It also includes following components:

* [meinBerlin/js-design-dev](https://weblate.liqd.net/projects/meinberlin/js-design-dev/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main-design-dev/horizontal-auto.svg)