### PR TITLE
[#6061] a4dashboard: fix blueprints modal

### DIFF
--- a/changelog/_6061.md
+++ b/changelog/_6061.md
@@ -1,0 +1,8 @@
+### Changed
+- Renamed blueprint-picker.js to blueprint-dialog.js, completely removing Bootstrap and jQuery dependencies in favor of vanilla JavaScript with the native HTML dialog element
+- Fixed issue with body element being modified by Bootstrap modal code
+- Added proper AJAX request handling with `X-Requested-With: XMLHttpRequest` header to ensure only dialog content is loaded
+- Refactored modal in `nav_modules.html` to use native HTML `<dialog>` element for better performance and accessibility
+
+### Added
+- `/components_dashboard/_blueprint-dialog.scss` for styling the native dialog component

--- a/meinberlin/assets/js/blueprint-dialog.js
+++ b/meinberlin/assets/js/blueprint-dialog.js
@@ -1,0 +1,67 @@
+document.addEventListener('DOMContentLoaded', function () {
+  initModuleDialog()
+})
+
+function initModuleDialog () {
+  const button = document.getElementById('module-blueprint-btn')
+  const dialog = document.getElementById('module-blueprint-list')
+
+  if (!button || !dialog) return
+
+  // Move dialog to <body> for proper behavior
+  document.body.appendChild(dialog)
+
+  button.addEventListener('click', function (e) {
+    e.preventDefault()
+    const url = button.getAttribute('href')
+
+    fetch(url, {
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+      }
+    })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Network response was not ok')
+        }
+        return response.text()
+      })
+      .then(html => {
+        // Check if the response is a full HTML page
+        if (html.includes('<html') && html.includes('<head')) {
+          // Create a temporary element to parse the HTML
+          const tempDoc = document.implementation.createHTMLDocument()
+          tempDoc.documentElement.innerHTML = html
+
+          const contentElement = tempDoc.querySelector('.module-blueprint-list') ||
+            tempDoc.querySelector('.blueprint-dialog__body') ||
+            tempDoc.querySelector('main')
+
+          if (contentElement) {
+            // Extract only the content we need
+            html = contentElement.innerHTML
+          } else {
+            console.warn('Could not extract content from full page response')
+          }
+        }
+
+        dialog.querySelector('.blueprint-dialog__body').innerHTML = html
+        dialog.showModal()
+      })
+      .catch(error => console.error('Error loading dialog content:', error))
+  })
+
+  const closeButtons = dialog.querySelectorAll("[data-action='close-dialog']")
+  closeButtons.forEach(btn => {
+    btn.addEventListener('click', function () {
+      dialog.close()
+    })
+  })
+
+  dialog.addEventListener('click', handleBackdropClick)
+  function handleBackdropClick (event) {
+    if (event.target === dialog) {
+      dialog.close()
+    }
+  }
+}

--- a/meinberlin/assets/js/blueprint-picker.js
+++ b/meinberlin/assets/js/blueprint-picker.js
@@ -1,9 +1,0 @@
-function init () {
-  // This function populates blueprint modal with the list from the link
-  $('#module-blueprint-btn').on('click', function (e) {
-    e.preventDefault()
-    $('#module-blueprint-list').modal('show').find('.modal-body').load($(this).attr('href'))
-  })
-}
-
-document.addEventListener('DOMContentLoaded', init, false)

--- a/meinberlin/assets/scss/components_dashboard/_blueprint-dialog.scss
+++ b/meinberlin/assets/scss/components_dashboard/_blueprint-dialog.scss
@@ -1,0 +1,14 @@
+.blueprint-dialog {
+    border: none;
+    max-width: 1000px;
+}
+
+.blueprint-dialog__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+
+    h2 {
+        margin: 1em 0;
+    }
+}

--- a/meinberlin/assets/scss/style_dashboard.scss
+++ b/meinberlin/assets/scss/style_dashboard.scss
@@ -29,6 +29,7 @@
 // Components - Dashboard Specific
 @import "components_dashboard/a4-editpoll";
 @import "components_dashboard/alert";
+@import "components_dashboard/blueprint-dialog";
 @import "components_dashboard/breadcrumbs";
 @import "components_dashboard/button";
 @import "components_dashboard/commenting";

--- a/meinberlin/templates/a4dashboard/includes/nav_modules.html
+++ b/meinberlin/templates/a4dashboard/includes/nav_modules.html
@@ -9,8 +9,7 @@
     type="button"
     id="module-blueprint-btn"
     href="{% url 'a4dashboard:module-blueprint-list' project_slug=project.slug %}"
-    data-bs-toggle="modal"
-    data-bs-target="#module-blueprint-list">
+    data-target="#module-blueprint-list">
     {% translate 'Create Module' %}
 </button>
 
@@ -22,22 +21,19 @@
 </div>
 {% endfor %}
 
-<div class="modal" tabindex="-1" role="dialog" id="module-blueprint-list">
-    <div class="modal-dialog modal-xl" role="document">
-        <div class="modal-content modal-content--rounded modal-content--padding">
-            <div class="modal-header">
-                <h2 class="u-no-margin-bottom u-spacer-top-one-half">{% translate "Choose Participation Module" %}</h2>
-                <button type="button" class="close" data-bs-dismiss="modal" aria-label="{% translate 'Close' %}">
-                  <i class="fa fa-times" aria-hidden="true"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-            </div>
-        </div>
-    </div>
-</div>
+<dialog id="module-blueprint-list" class="blueprint-dialog">
+    <header class="blueprint-dialog__header">
+        <h2>
+            {% translate "Choose Participation Module" %}
+        </h2>
+        <button type="button" data-action="close-dialog" aria-label="{% translate 'Close' %}">
+            <i class="fa fa-times" aria-hidden="true"></i>
+        </button>
+    </header>
+    <div class="blueprint-dialog__body"></div>
+</dialog>
 
 <!-- must load in order to populate the modal with blueprint list -->
 {% block extra_js %}
-    <script src="{% static 'blueprint_picker.js' %}"></script>
+    <script src="{% static 'blueprint_dialog.js' %}"></script>
 {% endblock extra_js %}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -48,14 +48,11 @@ module.exports = {
       ],
       dependOn: 'adhocracy4'
     },
-    blueprint_picker: {
-      import: [
-        './meinberlin/assets/js/blueprint-picker.js'
-      ],
-      dependOn: 'adhocracy4'
-    },
     // these do not rely on adhocracy and adding the depend causes console error
     // error possibly due to needing to be loaded at specific time
+    blueprint_dialog: {
+      import: './meinberlin/assets/js/blueprint-dialog.js'
+    },
     documents: {
       import: './meinberlin/react/documents/react_documents_init.js'
     },


### PR DESCRIPTION
Fixes issue with body element being overwritten by Bootstrap modal classes https://github.com/liqd/a4-meinberlin/issues/6061 and https://github.com/liqd/a4-meinberlin/issues/6136
Also modernizing the modal by removing jQuery, Bootstrap and going for native HTML dialog and vanilla JS.