### PR TITLE
dashboard: remove participatory budgeting 3 phases

### DIFF
--- a/meinberlin/apps/dashboard/blueprints.py
+++ b/meinberlin/apps/dashboard/blueprints.py
@@ -109,28 +109,29 @@ blueprints = [
             type="PB2",
         ),
     ),
-    (
-        "participatory-budgeting-3-phases",
-        ProjectBlueprint(
-            title=_("Participatory budgeting (3 phase)"),
-            description=_(
-                "In a first phase, participants can submit their own "
-                "suggestions, mark them on a map, and add a budget. The "
-                "proposals of others can be discussed. In a second phase "
-                "proposals can be supported. In the third phase, participants "
-                "vote on the shortlisted proposals.  "
-            ),
-            content=[
-                budgeting_phases.CollectPhase(),
-                budgeting_phases.SupportPhase(),
-                budgeting_phases.VotingPhase(),
-            ],
-            # The icon has to be updated:
-            image="images/participatory-budgeting-3.svg",
-            settings_model=("a4maps", "AreaSettings"),
-            type="PB3",
-        ),
-    ),
+    # Taken out for now, see https://github.com/liqd/a4-meinberlin/issues/6128
+    # (
+    #     "participatory-budgeting-3-phases",
+    #     ProjectBlueprint(
+    #         title=_("Participatory budgeting (3 phase)"),
+    #         description=_(
+    #             "In a first phase, participants can submit their own "
+    #             "suggestions, mark them on a map, and add a budget. The "
+    #             "proposals of others can be discussed. In a second phase "
+    #             "proposals can be supported. In the third phase, participants "
+    #             "vote on the shortlisted proposals.  "
+    #         ),
+    #         content=[
+    #             budgeting_phases.CollectPhase(),
+    #             budgeting_phases.SupportPhase(),
+    #             budgeting_phases.VotingPhase(),
+    #         ],
+    #         # The icon has to be updated:
+    #         image="images/participatory-budgeting-3.svg",
+    #         settings_model=("a4maps", "AreaSettings"),
+    #         type="PB3",
+    #     ),
+    # ),
     (
         "prioritization",
         ProjectBlueprint(

--- a/meinberlin/apps/projects/models.py
+++ b/meinberlin/apps/projects/models.py
@@ -109,7 +109,6 @@ def create_insight_context(insight: ProjectInsight) -> dict:
     ("PO", _("poll")),
     ("PB", _("participatory budgeting")),
     ("PB2", _("participatory budgeting 2 phases")),
-    ("PB3", _("participatory budgeting 3 phases")),
     ("IE", _("interactive event")),
     ("TP", _("prioritization")),
     ("MTP", _("spatial prioritization")),
@@ -123,7 +122,7 @@ def create_insight_context(insight: ProjectInsight) -> dict:
     show_live_questions = "IE" in blueprint_types
     show_ideas = bool(
         blueprint_types.intersection(
-            {"BS", "IC", "MBS", "TP", "MTP", "MIC", "PB", "PB2", "PB3"}
+            {"BS", "IC", "MBS", "TP", "MTP", "MIC", "PB", "PB2"}
         )
     )
 

--- a/meinberlin/config/settings/base.py
+++ b/meinberlin/config/settings/base.py
@@ -518,7 +518,7 @@ A4_BLUEPRINT_TYPES = [
     ("MIC", "map idea collection"),
     ("PB", "participatory budgeting (1 phase)"),
     ("PB2", "participatory budgeting (2 phase)"),
-    ("PB3", "participatory budgeting (3 phase)"),
+    # ("PB3", "participatory budgeting (3 phase)"),
     ("KK", "kiezkasse"),
     ("TP", "topic prioritization"),
     ("MTP", "map topic prioritization"),


### PR DESCRIPTION
**Describe your changes**
remove participatory budgeting (3 phases) from selection modal

fixes #6128

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog