### PR TITLE
filters: fix filter selections & saving as search profile

### DIFF
--- a/meinberlin/apps/plans/forms.py
+++ b/meinberlin/apps/plans/forms.py
@@ -139,9 +139,9 @@ class PlanForm(PointFormMixin, ImageMetadataMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["district"].empty_label = _("City wide")
         self.fields["contact_address_text"].widget.attrs["rows"] = 6
         self.fields["participation_explanation"].widget.attrs["rows"] = 1
+        self.fields["district"].required = True
 
     def get_geojson_properties(self):
         return {"strname": "street_name", "hsnr": "house_number", "plz": "zip_code"}

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -8,7 +8,6 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django.views.generic.detail import SingleObjectMixin
@@ -103,7 +102,6 @@ class PlanListView(rules_mixins.PermissionRequiredMixin, generic.ListView):
     def get_districts(self):
         districts = AdministrativeDistrict.objects.values("id", "name")
         districts_list = [district for district in districts]
-        districts_list.append({"id": -1, "name": gettext("City wide")})
         return json.dumps(districts_list)
 
     def get_topics(self):
@@ -119,7 +117,11 @@ class PlanListView(rules_mixins.PermissionRequiredMixin, generic.ListView):
 
     def get_participation_choices(self):
         project_types = [
-            {"id": project_type.id, "name": project_type.get_participation_display()}
+            {
+                "id": project_type.id,
+                "name": project_type.get_participation_display(),
+                "value": project_type.participation,
+            }
             for project_type in ProjectType.objects.all()
         ]
         return json.dumps(project_types)

--- a/meinberlin/apps/projects/forms.py
+++ b/meinberlin/apps/projects/forms.py
@@ -108,15 +108,11 @@ class PointForm(PointFormMixin, ProjectDashboardForm):
             "house_number",
             "zip_code",
         ]
-        required_for_project_publish = []
+        required_for_project_publish = ["administrative_district"]
         widgets = {
             "administrative_district": Select2Widget,
             "point": maps_widgets.MapChoosePointWidget(polygon=settings.BERLIN_POLYGON),
         }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["administrative_district"].empty_label = _("City wide")
 
     def get_geojson_properties(self):
         return {"strname": "street_name", "hsnr": "house_number", "plz": "zip_code"}

--- a/meinberlin/fixtures/administrative_districts.json
+++ b/meinberlin/fixtures/administrative_districts.json
@@ -82,5 +82,12 @@
     "fields": {
       "name": "Reinickendorf"
     }
+  },
+  {
+    "model": "a4administrative_districts.administrativedistrict",
+    "pk": 13,
+    "fields": {
+      "name": "Gesamtstädtisch"
+    }
   }
 ]

--- a/meinberlin/react/contrib/ControlBarFilterPills.jsx
+++ b/meinberlin/react/contrib/ControlBarFilterPills.jsx
@@ -9,7 +9,7 @@ const getFilterRemoveText = (label) => {
 }
 
 export const ControlBarFilterPills = ({ filters: _filters, onRemove }) => {
-  const filters = _filters.filter(f => f.value && f.value !== '')
+  const filters = _filters.filter(f => f.value !== null && f.value !== false && f.value !== '')
   if (!filters.length) {
     return null
   }

--- a/meinberlin/react/projects/ProjectsControlBar.jsx
+++ b/meinberlin/react/projects/ProjectsControlBar.jsx
@@ -15,7 +15,7 @@ const translated = {
   showFilters: django.gettext('Show more'),
   hideFilters: django.gettext('Show less'),
   districtsKieze: django.gettext('Kiezes & Districts'),
-  allDistrictsKieze: django.gettext('Choose district or Kiez'),
+  allDistrictsKieze: django.gettext('All districts'),
   savedKieze: django.gettext('Your saved Kieze'),
   createKiez: django.gettext('Create a Kiez to use this filter'),
   districts: django.gettext('Districts'),
@@ -72,7 +72,8 @@ const getAlteredFilters = (
     projectState,
     organisation,
     participations,
-    kiezradars
+    kiezradars,
+    plansOnly
   },
   topicChoices,
   participationChoices
@@ -91,12 +92,16 @@ const getAlteredFilters = (
   projectState.forEach(s => filters.push({ label: statusNames[s], type: 'projectState', value: s }))
   organisation.forEach(o => filters.push({ label: o, type: 'organisation', value: o }))
   participations.forEach(participationId => {
-    const choice = participationChoices.find(choice => choice.id === participationId)
-    if (choice) {
+    const choice = participationChoices.find(choice => choice.value === participationId)
+    if (typeof choice !== 'undefined') {
       filters.push({ label: choice.name, type: 'participations', value: participationId })
     }
   })
   kiezradars.forEach(k => filters.push({ label: k, type: 'kiezradars', value: k }))
+
+  if (typeof plansOnly === 'boolean') {
+    filters.push({ label: translated.plans, type: 'plansOnly', value: plansOnly })
+  }
 
   return filters
 }
@@ -286,7 +291,7 @@ export const ProjectsControlBar = ({
                           <MultiSelect
                             label={translated.participations}
                             placeholder={translated.allParticipation}
-                            choices={participationChoices.map((choice) => ({ value: choice.id, name: choice.name }))}
+                            choices={participationChoices.map((choice) => ({ value: choice.value, name: choice.name }))}
                             onChange={(choices) => onFilterChange('participations', choices)}
                             values={filters.participations}
                           />

--- a/meinberlin/react/projects/filter-projects.js
+++ b/meinberlin/react/projects/filter-projects.js
@@ -30,7 +30,6 @@ export const filterProjects = (items, appliedFilters, kiezradars, topics, projec
       )
 
     return (activeTopics.length === 0 || activeTopics.some(topic => item.topics.includes(topic))) &&
-           (districts.length === 0 || districts.includes(item.district)) &&
            (participations.length === 0 || participations.includes(item.participation)) &&
            (organisation.length === 0 || organisation.includes(item.organisation)) &&
            (search === '' ||
@@ -41,6 +40,9 @@ export const filterProjects = (items, appliedFilters, kiezradars, topics, projec
              isInTopic(topics, item.topics, search)) &&
            (projectState.includes(statusNames[item.status])) &&
            (!plansOnly || item.type === 'plan') &&
-           (activeKiezradars.length === 0 || isWithinAnyRadius)
+           (
+             activeKiezradars.length === 0 || isWithinAnyRadius ||
+             districts.length === 0 || districts.includes(item.district)
+           )
   })
 }

--- a/meinberlin/react/projects/getDefaultState.js
+++ b/meinberlin/react/projects/getDefaultState.js
@@ -29,8 +29,8 @@ export const getDefaultState = (searchParams, {
         .filter((organisation) => searchParams.getAll('organisation').includes(organisation.name))
         .map((organisation) => organisation.name),
       participations: participationChoices
-        .filter((participation) => searchParams.getAll('participations').includes(participation.id.toString()))
-        .map((participation) => participation.id),
+        .filter((participation) => searchParams.getAll('participations').includes(participation.value.toString()))
+        .map((participation) => participation.value),
       topics: topicChoices
         .filter((topic) => searchParams.getAll('topics').includes(topic.code))
         .map((topic) => topic.code),

--- a/tests/plans/test_dashboard_views.py
+++ b/tests/plans/test_dashboard_views.py
@@ -7,8 +7,14 @@ from adhocracy4.test.helpers import redirect_target
 from meinberlin.apps.plans.models import Plan
 
 
+@pytest.fixture
+def district(administrative_district_factory):
+    district = administrative_district_factory()
+    return district.id
+
+
 @pytest.mark.django_db
-def test_initiator_can_edit(client, plan_factory):
+def test_initiator_can_edit(client, plan_factory, district):
     plan = plan_factory()
     initiator = plan.organisation.initiators.first()
     url = reverse(
@@ -30,7 +36,7 @@ def test_initiator_can_edit(client, plan_factory):
         "contact_url": "https://liqd.net/",
         "point": "",
         "point_label": "",
-        "district": "",
+        "district": district,
         "cost": "1.000",
         "description": "this is a description",
         "topics": Topic.objects.first().pk,
@@ -50,7 +56,7 @@ def test_initiator_can_edit(client, plan_factory):
 
 @pytest.mark.django_db
 def test_group_member_can_edit(
-    client, plan_factory, user_factory, group_factory, organisation
+    client, plan_factory, user_factory, group_factory, organisation, district
 ):
     group1 = group_factory()
     group2 = group_factory()
@@ -73,7 +79,7 @@ def test_group_member_can_edit(
         "contact_address_text": "me@example.com",
         "point": "",
         "point_label": "",
-        "district": "",
+        "district": district,
         "cost": "1.000",
         "description": "this is a description",
         "topics": Topic.objects.first().pk,
@@ -94,7 +100,7 @@ def test_group_member_can_edit(
 
 
 @pytest.mark.django_db
-def test_initiator_can_create(client, organisation):
+def test_initiator_can_create(client, organisation, district):
     initiator = organisation.initiators.first()
     url = reverse(
         "a4dashboard:plan-create", kwargs={"organisation_slug": organisation.slug}
@@ -114,7 +120,7 @@ def test_initiator_can_create(client, organisation):
         "contact_url": "https://liqd.net/",
         "point": "",
         "point_label": "",
-        "district": "",
+        "district": district,
         "cost": "1.000",
         "description": "this is a description",
         "topics": Topic.objects.first().pk,
@@ -135,7 +141,9 @@ def test_initiator_can_create(client, organisation):
 
 
 @pytest.mark.django_db
-def test_group_member_can_create(client, organisation, user_factory, group_factory):
+def test_group_member_can_create(
+    client, organisation, user_factory, group_factory, district
+):
     group1 = group_factory()
     group2 = group_factory()
     group_member = user_factory.create(groups=(group1, group2))
@@ -158,7 +166,7 @@ def test_group_member_can_create(client, organisation, user_factory, group_facto
         "contact_url": "https://liqd.net/",
         "point": "",
         "point_label": "",
-        "district": "",
+        "district": district,
         "cost": "1.000",
         "description": "this is a description",
         "topics": Topic.objects.first().pk,
@@ -167,6 +175,7 @@ def test_group_member_can_create(client, organisation, user_factory, group_facto
         "participation_explanation": "Some explanation",
         "duration": "1 month",
     }
+    print(data)
     response = client.post(url, data)
     assert redirect_target(response) == "plan-update"
     plan = Plan.objects.all().first()

--- a/tests/plans/test_forms.py
+++ b/tests/plans/test_forms.py
@@ -39,9 +39,10 @@ def test_plan_form_missing_alt_text(organisation, plan_factory):
 
 @pytest.mark.django_db
 def test_plan_form_with_point_as_dict_and_alt_text(
-    organisation, plan_factory, geojson_point
+    organisation, plan_factory, geojson_point, administrative_district_factory
 ):
     plan = plan_factory(organisation=organisation)
+    district = administrative_district_factory()
     form = PlanForm(
         instance=plan,
         data={
@@ -54,6 +55,7 @@ def test_plan_form_with_point_as_dict_and_alt_text(
             "status": "0",
             "participation": "0",
             "participation_explanation": "exp",
+            "district": district.id,
         },
     )
     assert "description" not in form.errors
@@ -62,9 +64,10 @@ def test_plan_form_with_point_as_dict_and_alt_text(
 
 @pytest.mark.django_db
 def test_plan_form_with_point_as_str_and_alt_text(
-    organisation, plan_factory, geojson_point_str
+    organisation, plan_factory, geojson_point_str, administrative_district_factory
 ):
     plan = plan_factory(organisation=organisation)
+    district = administrative_district_factory()
     form = PlanForm(
         instance=plan,
         data={
@@ -77,6 +80,7 @@ def test_plan_form_with_point_as_str_and_alt_text(
             "status": "0",
             "participation": "0",
             "participation_explanation": "exp",
+            "district": district.id,
         },
     )
     assert "description" not in form.errors


### PR DESCRIPTION
**Describe your changes**

fixes #6147, #5976, #6014, #6015

You can install "Gesamtstädtisch" as a selection again by running `./manage.py loaddata meinberlin/fixtures/administrative_districts.json`

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog