### PR TITLE
[#8984] notifications: add offlineevent timestamp

### DIFF
--- a/meinberlin/apps/actions/serializers.py
+++ b/meinberlin/apps/actions/serializers.py
@@ -1,6 +1,7 @@
 from django.template.defaultfilters import truncatechars
 from django.utils import timezone
 from django.utils.html import strip_tags
+from django.utils.timezone import localtime
 from rest_framework import serializers
 
 from adhocracy4.actions.models import Action
@@ -10,6 +11,7 @@ from meinberlin.apps.projects.serializers import ProjectSerializer
 class ActionSerializer(serializers.ModelSerializer):
     type = serializers.SerializerMethodField()
     source = serializers.SerializerMethodField()
+    source_timestamp = serializers.SerializerMethodField()
     body = serializers.SerializerMethodField()
     link = serializers.SerializerMethodField()
     item = serializers.SerializerMethodField()
@@ -114,6 +116,13 @@ class ActionSerializer(serializers.ModelSerializer):
             return trigger.name
         elif trigger and hasattr(trigger, "content_object"):
             return trigger.content_object.__class__.__name__.lower()
+
+    def get_source_timestamp(self, obj):
+        trigger, _ = self.get_cached_trigger(obj)
+
+        if trigger and hasattr(trigger, "date"):
+            return localtime(trigger.date)
+        return None
 
     def is_moderator(self, obj):
         return obj.actor in obj.project.moderators.all()

--- a/meinberlin/react/account/Notifications.jsx
+++ b/meinberlin/react/account/Notifications.jsx
@@ -188,8 +188,9 @@ function getSearchProfileText (searchProfile, action) {
 }
 
 function getFollowedProjectsText (action) {
-  const { type, project } = action
+  const { type, source, source_timestamp: sourceTimestamp, project } = action
   const date = new Date(project.active_phase[2])
+  const sourceDate = new Date(sourceTimestamp).toLocaleString()
 
   switch (type) {
     case 'phase_started':
@@ -201,6 +202,12 @@ function getFollowedProjectsText (action) {
     case 'phase_soon_over':
       return {
         title: notificationsData.followedProjects.phaseEndedText(project.title, date.toLocaleDateString()),
+        linkText: notificationsData.viewProjectText
+      }
+
+    case 'offlineevent':
+      return {
+        title: notificationsData.followedProjects.offlineEvent(source, project.title, sourceDate.toLocaleString()),
         linkText: notificationsData.viewProjectText
       }
   }

--- a/meinberlin/react/account/notification_data.js
+++ b/meinberlin/react/account/notification_data.js
@@ -74,6 +74,11 @@ export const notificationsData = {
       django.gettext('%(title)s will end soon. You can still participate until %(date)s'),
       { title, date },
       true
+    ),
+    offlineEvent: (eventName, title, date) => django.interpolate(
+      django.gettext('The event %(eventName)s is coming up for the project %(title)s. It will take place on %(date)s'),
+      { eventName, title, date },
+      true
     )
   },
   viewIdeaText: django.gettext('View idea'),

--- a/tests/notifications/test_api.py
+++ b/tests/notifications/test_api.py
@@ -73,6 +73,7 @@ def test_shows_notification_for_followed_project(
     assert response.status_code == 200
     assert len(response.data["results"]) == 1
     assert notification["action"]["type"] == "offlineevent"
+    assert notification["action"]["source_timestamp"] == event.date
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Describe your changes**
Adds a timestamp to the `ActionSerializer` to allow displaying the timestamp of offlineevents.
![CleanShot 2025-03-04 at 14 36 37](https://github.com/user-attachments/assets/26b7b59a-6ac0-4dfb-8236-8803fafb4650)

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog