### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-05 13:23+0100\n"
-"PO-Revision-Date: 2025-03-05 15:55+0000\n"
+"PO-Revision-Date: 2025-03-05 16:26+0000\n"
 "Last-Translator: MarleyMi <m.mittmann@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
 "main-design-dev/de/>\n"
@@ -1530,7 +1530,7 @@ msgstr "Ihr Nutzerprofil"
 
 #: meinberlin/apps/account/templates/meinberlin_account/notification-settings.html:8
 msgid "Notification settings"
-msgstr "Benachrichtigungseinstellungen"
+msgstr "Benachrichtigungs - Einstellungen"
 
 #: meinberlin/apps/account/templates/meinberlin_account/notifications.html:5
 #: meinberlin/apps/account/templates/meinberlin_account/notifications.html:12
@@ -4442,7 +4442,7 @@ msgstr ""
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_module_tile.html:22
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:102
 msgid "Participation ended"
-msgstr ""
+msgstr "Beteiligung abgeschlossen"
 
 #: meinberlin/apps/projects/templates/meinberlin_projects/includes/project_tile.html:40
 msgid "Plan"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-05 13:23+0100\n"
-"PO-Revision-Date: 2025-02-28 14:15+0000\n"
+"PO-Revision-Date: 2025-03-05 16:26+0000\n"
 "Last-Translator: MarleyMi <m.mittmann@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js-"
-"design-dev/de/>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
+"js-design-dev/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -316,7 +316,7 @@ msgstr "Hervorgehoben"
 #: meinberlin/react/contrib/ControlBar.jsx:12
 #: meinberlin/react/projects/ProjectsControlBar.jsx:15
 msgid "Show more"
-msgstr "mehr anzeigen"
+msgstr "Mehr anzeigen"
 
 #: adhocracy4/comments_async/static/comments_async/comment_control_bar.jsx:8
 #: adhocracy4/comments_async/static/comments_async/comment_filters.jsx:15
@@ -926,7 +926,7 @@ msgstr "E-Mail"
 
 #: meinberlin/react/account/NotificationToggle.jsx:6
 msgid "In-App Notification"
-msgstr "In-App-Benachrichtigungen"
+msgstr "In-App"
 
 #: meinberlin/react/account/notification_data.js:5
 msgid "Interactions"
@@ -1506,7 +1506,7 @@ msgstr ""
 #: meinberlin/react/kiezradar/KiezradarList.jsx:18
 #: meinberlin/react/kiezradar/SearchProfile.jsx:14
 msgid "View projects"
-msgstr ""
+msgstr "Projekte anzeigen"
 
 #: meinberlin/react/kiezradar/KiezradarList.jsx:21
 #: meinberlin/react/kiezradar/SearchProfile.jsx:24
@@ -1912,7 +1912,7 @@ msgstr "©"
 
 #: meinberlin/react/projects/ProjectTile.jsx:11
 msgid "Participation ended"
-msgstr ""
+msgstr "Beteiligung abgeschlossen"
 
 #: meinberlin/react/projects/ProjectTile.jsx:12
 msgid "Begins on the"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main-design-dev](https://weblate.liqd.net/projects/meinberlin/main-design-dev/).


It also includes following components:

* [meinBerlin/js-design-dev](https://weblate.liqd.net/projects/meinberlin/js-design-dev/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main-design-dev/horizontal-auto.svg)