### PR TITLE
notification-settings: fix error for non-admin users and master toggle issue

### DIFF
--- a/meinberlin/apps/account/templates/meinberlin_account/notification-settings.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/notification-settings.html
@@ -8,7 +8,7 @@
   <h1>{% translate "Notification settings" %}</h1>
   <div id="notification-settings-react"
        data-initial-notifications="{{ data }}"
-       data-show-restricted="{% if show_restricted %}true{% endif %}"
+       data-show-restricted="{% if show_restricted %}true{% else %}false{% endif %}"
        data-api-url="{{ api_url }}"
   ></div>
 {% endblock content %}

--- a/meinberlin/react/account/NotificationSettings.jsx
+++ b/meinberlin/react/account/NotificationSettings.jsx
@@ -6,7 +6,7 @@ import { updateItem } from '../contrib/helpers'
 import { notificationSettingsData } from './notification_data'
 import useNotifications from './useNotifications'
 
-const NotificationsList = ({
+const NotificationSettings = ({
   initialNotifications,
   apiUrl,
   showRestricted = false
@@ -37,7 +37,11 @@ const NotificationsList = ({
     const newState = { ...notificationsState }
 
     Object.keys(notificationGroup.notifications).forEach(key => {
+      const notificationSetting = notificationGroup.notifications[key]
       newState[key] = newValue
+      if ('activityFeedName' in notificationSetting) {
+        newState[notificationSetting.activityFeedName] = newValue
+      }
     })
 
     setNotificationsState(newState)
@@ -83,4 +87,4 @@ const NotificationsList = ({
   )
 }
 
-export default NotificationsList
+export default NotificationSettings

--- a/meinberlin/react/account/__tests__/NotificationSettings.jest.jsx
+++ b/meinberlin/react/account/__tests__/NotificationSettings.jest.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import NotificationsList from '../NotificationsList'
+import NotificationSettings from '../NotificationSettings'
 import { updateItem } from '../../contrib/helpers'
 import useNotifications from '../useNotifications'
 
@@ -29,7 +29,7 @@ const defaultProps = {
   showRestricted: false
 }
 
-describe('NotificationsList', () => {
+describe('NotificationSettings', () => {
   const mockSetNotificationsState = jest.fn()
 
   beforeEach(() => {
@@ -43,7 +43,7 @@ describe('NotificationsList', () => {
   })
 
   test('renders all non-restricted notification groups', () => {
-    render(<NotificationsList {...defaultProps} />)
+    render(<NotificationSettings {...defaultProps} />)
 
     expect(screen.getByText('Project-Related Notifications')).toBeInTheDocument()
     expect(screen.getByText('Interactions with Other Users or Moderation')).toBeInTheDocument()
@@ -57,13 +57,13 @@ describe('NotificationsList', () => {
       masterToggles: [true, false, false]
     }))
 
-    render(<NotificationsList {...defaultProps} showRestricted />)
+    render(<NotificationSettings {...defaultProps} showRestricted />)
 
     expect(screen.getByText('Notifications for Initiators and Moderators')).toBeInTheDocument()
   })
 
   test('toggles individual notification settings', () => {
-    render(<NotificationsList {...defaultProps} />)
+    render(<NotificationSettings {...defaultProps} />)
 
     const toggle = screen.getAllByRole('checkbox')[1] // First toggle after master toggle
     fireEvent.click(toggle)
@@ -83,7 +83,7 @@ describe('NotificationsList', () => {
       masterToggles: [false, false, false]
     }))
 
-    render(<NotificationsList {...defaultProps} />)
+    render(<NotificationSettings {...defaultProps} />)
 
     const masterToggle = screen.getAllByRole('checkbox')[0]
     fireEvent.click(masterToggle)
@@ -102,7 +102,7 @@ describe('NotificationsList', () => {
   })
 
   test('renders correct notification titles and descriptions', () => {
-    render(<NotificationsList {...defaultProps} />)
+    render(<NotificationSettings {...defaultProps} />)
 
     expect(screen.getByText('E-Mail Newsletter')).toBeInTheDocument()
     expect(screen.getByText('Participation Start')).toBeInTheDocument()
@@ -110,7 +110,7 @@ describe('NotificationsList', () => {
   })
 
   test('updates UI and calls API when toggling notifications', async () => {
-    render(<NotificationsList {...defaultProps} />)
+    render(<NotificationSettings {...defaultProps} />)
 
     const toggle = screen.getAllByRole('checkbox')[1]
     fireEvent.click(toggle)

--- a/meinberlin/react/account/react_notification_settings.jsx
+++ b/meinberlin/react/account/react_notification_settings.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import NotificationsList from './NotificationsList'
+import NotificationSettings from './NotificationSettings'
 
 function init () {
   const el = document.getElementById('notification-settings-react')
@@ -10,7 +10,7 @@ function init () {
   const apiUrl = el.getAttribute('data-api-url')
   root.render(
     <React.StrictMode>
-      <NotificationsList initialNotifications={notifications} showRestricted={showRestricted} apiUrl={apiUrl} />
+      <NotificationSettings initialNotifications={notifications} showRestricted={showRestricted} apiUrl={apiUrl} />
     </React.StrictMode>)
 }
 

--- a/meinberlin/react/account/useNotifications.js
+++ b/meinberlin/react/account/useNotifications.js
@@ -25,9 +25,17 @@ const useNotifications = (initialNotifications, showRestricted) => {
   )
 
   const getMasterToggles = useCallback(() => {
+    // return the state of each master toggle
     return notificationSettingsData
+      // filter out restricted notifications (for moderators)
       .filter((n) => !n.restricted || (n.restricted && showRestricted))
-      .map((n) => Object.keys(n.notifications).some((key) => notificationsState[key]))
+      .map((n) =>
+        // go over remaining notifications
+        Object.entries(n.notifications).some(
+          // check if either the email notification or in-app notification is toggled true
+          ([key, value]) => notificationsState[key] || notificationsState[value.activityFeedName]
+        )
+      )
   }, [notificationsState, showRestricted])
 
   return {


### PR DESCRIPTION
**Describe your changes**
Fixes #6218, #6216
Also renamed `NotificationList` to be more explicitly named `NotificationSettings`

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog