### PR TITLE
project-search: add identifer to search field

### DIFF
--- a/meinberlin/apps/kiezradar/models.py
+++ b/meinberlin/apps/kiezradar/models.py
@@ -259,6 +259,9 @@ def get_search_profiles_for_project(project: Project) -> QuerySet[SearchProfile]
 
     if project.administrative_district:
         search_term += f" {project.administrative_district.name}"
+    if hasattr(project, "externalproject"):
+        if hasattr(project.externalproject, "bplan"):
+            search_term += f" {project.externalproject.bplan.identifier}"
     for topic in project.topic_names:
         search_term += f" {topic}"
 

--- a/meinberlin/apps/projects/api.py
+++ b/meinberlin/apps/projects/api.py
@@ -29,7 +29,9 @@ def get_public_projects() -> QuerySet[Project]:
             is_archived=False,
         )
         .order_by("created")
-        .select_related("administrative_district", "organisation")
+        .select_related(
+            "administrative_district", "organisation", "externalproject__bplan"
+        )
         .prefetch_related(
             "moderators",
             "plans",

--- a/meinberlin/apps/projects/serializers.py
+++ b/meinberlin/apps/projects/serializers.py
@@ -65,6 +65,7 @@ class ProjectSerializer(
     type = serializers.SerializerMethodField()
     url = serializers.SerializerMethodField()
     topics = serializers.SerializerMethodField()
+    identifier = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
         self.now = kwargs.pop("now")
@@ -84,6 +85,7 @@ class ProjectSerializer(
             "description",
             "district",
             "future_phase",
+            "identifier",
             "organisation",
             "participation",
             "participation_active",
@@ -247,6 +249,11 @@ class ProjectSerializer(
 
     def get_cost(self, instance):
         return ""
+
+    def get_identifier(self, instance):
+        if hasattr(instance, "externalproject"):
+            if hasattr(instance.externalproject, "bplan"):
+                return instance.externalproject.bplan.identifier
 
 
 class ActiveProjectSerializer(ProjectSerializer):

--- a/meinberlin/react/projects/filter-projects.js
+++ b/meinberlin/react/projects/filter-projects.js
@@ -21,7 +21,6 @@ const statusNames = ['active', 'future', 'past']
 
 export const filterProjects = (items, appliedFilters, kiezradars, topics, projectState) => {
   const { search, topics: activeTopics, districts, organisation, participations, plansOnly, kiezradars: activeKiezradars } = appliedFilters
-
   return items.filter((item) => {
     const isWithinAnyRadius =
       item.point && kiezradars.some(kiezradar =>
@@ -39,6 +38,7 @@ export const filterProjects = (items, appliedFilters, kiezradars, topics, projec
         isInTitle(item.district, search) ||
         isInTitle(item.organisation, search) ||
         isInTitle(item.description, search) ||
+        isInTitle(item.identifier, search) ||
         isInTopic(topics, item.topics, search)) &&
       (projectState.includes(statusNames[item.status])) &&
       (!plansOnly || item.type === 'plan') &&

--- a/tests/kiezradar/test_search_profile.py
+++ b/tests/kiezradar/test_search_profile.py
@@ -316,6 +316,21 @@ def test_searchprofile_filter_query(
 
 
 @pytest.mark.django_db
+def test_searchprofile_filter_query_bplan(
+    search_profile_factory,
+    kiezradar_query_factory,
+    bplan_factory,
+):
+    bplan = bplan_factory(identifier="B30-1 A30-bplan 2024")
+    bplan_profile = search_profile_factory(
+        query=kiezradar_query_factory(text="A30-bplan")
+    )
+
+    result = get_search_profiles_for_project(bplan).order_by("pk")
+    assert list(result) == [bplan_profile]
+
+
+@pytest.mark.django_db
 def test_searchprofile_filter_kiezradar(
     user, phase_factory, search_profile_factory, kiez_radar_factory
 ):

--- a/tests/projects/test_serializer.py
+++ b/tests/projects/test_serializer.py
@@ -35,7 +35,7 @@ def test_project_serializer(
         tile_image_alt_text="img_alt",
     )
     external_project_factory()
-    bplan_factory()
+    bplan_factory(identifier="bplan 2013-01-01")
 
     now = parse("2013-01-01 18:00:00+01:00")
     yesterday = now - timezone.timedelta(days=1)
@@ -165,3 +165,5 @@ def test_project_serializer(
         assert not project_data[5]["tile_image_alt_text"]
 
         assert project_data[0]["point"] == geojson_point
+
+        assert project_data[5]["identifier"] == "bplan 2013-01-01"


### PR DESCRIPTION
**Describe your changes**
include filtering bplans by identifier in project search/kiezradar

fixes #6207

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog