### PR TITLE
email-form: fix error with adding a new email address

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_submit_flex_end.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/form_submit_flex_end.html
@@ -4,5 +4,5 @@
     {% if secondary_button_text %}
         <button class="link form-submit-flex-end__link" type="submit" name="reject">{% translate secondary_button_text %}</button>
     {% endif %}
-    <button class="button button--fullwidth-palm" type="submit" name="accept">{% translate button_text %}</button>
+    <button class="button button--fullwidth-palm" type="submit" name="{% firstof button_name "accept" %}">{% translate button_text %}</button>
 </div>

--- a/meinberlin/templates/account/email.html
+++ b/meinberlin/templates/account/email.html
@@ -70,6 +70,6 @@
       {{ form.email|add_class:"form-control"|add_error_attr:"aria-invalid:true" }}
     </div>
 
-    {% include 'meinberlin_contrib/includes/form_submit_flex_end.html' with button_text='Add' %}
+    {% include 'meinberlin_contrib/includes/form_submit_flex_end.html' with button_text='Add' button_name="action_add" %}
   </form>
 {% endblock dashboard_content %}


### PR DESCRIPTION
**Describe your changes**
fixes #5934

allauth view expects "action_add" in the post data, i suppose it got removed at one point

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog