### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-04 12:03+0100\n"
-"PO-Revision-Date: 2025-03-06 13:15+0000\n"
-"Last-Translator: MarleyMi <m.mittmann@liqd.net>\n"
+"PO-Revision-Date: 2025-03-13 10:41+0000\n"
+"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -828,12 +828,12 @@ msgstr "gefällt nicht"
 #: adhocracy4/ratings/static/ratings/RatingButton.jsx:5
 #: adhocracy4/ratings/static/ratings/RatingButton.jsx:5
 msgid "Click to like"
-msgstr "klicken für \"gefällt mir\""
+msgstr "Klicken für gefällt mir"
 
 #: adhocracy4/ratings/static/ratings/RatingButton.jsx:6
 #: adhocracy4/ratings/static/ratings/RatingButton.jsx:6
 msgid "Click to dislike"
-msgstr "klicken für \"gefällt mir nicht\""
+msgstr "Klicken für gefällt mir nicht"
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:7
 #: adhocracy4/reports/static/reports/ReportModal.jsx:7


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main](https://weblate.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://weblate.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main/horizontal-auto.svg)