### PR TITLE
[#8997] breadcrumbs: add template tag and streamline breadcrumbs

### DIFF
--- a/changelog/8997.md
+++ b/changelog/8997.md
@@ -1,0 +1,5 @@
+### Added
+- template tag for breadcrumbs
+
+### Removed
+- static breadcrumbs 

--- a/meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/account_dashboard.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n socialaccount %}
+{% load i18n socialaccount breadcrumbs_tags %}
 
 {% block title %}
   {% translate "User Dashboard" %}
@@ -8,16 +8,8 @@
 {% endblock title %}
 
 {% block breadcrumbs %}
-  <div id="content-header">
-    <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-      <ol>
-        <li>
-          <a href="{% url 'wagtail_serve' '' %}">{% translate 'meinBerlin Homepage' %}</a>
-        </li>
-        <li class="active" aria-current="page">{% translate 'Account Settings' %}</li>
-      </ol>
-    </nav>
-  </div>
+    {% translate 'Account & Security' as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/account/templates/meinberlin_account/notification-settings.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/notification-settings.html
@@ -1,8 +1,13 @@
 {% extends "base.html" %}
 
-{% load i18n static %}
+{% load i18n static breadcrumbs_tags %}
 
 {% block title %}{% translate 'Your user profile' %} — {{ block.super }}{% endblock title %}
+
+{% block breadcrumbs %}
+    {% translate "Notification settings" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
+{% endblock breadcrumbs %}
 
 {% block content %}
   <h1>{% translate "Notification settings" %}</h1>

--- a/meinberlin/apps/account/templates/meinberlin_account/notifications.html
+++ b/meinberlin/apps/account/templates/meinberlin_account/notifications.html
@@ -1,8 +1,13 @@
 {% extends "base.html" %}
 
-{% load i18n static %}
+{% load i18n static breadcrumbs_tags %}
 
 {% block title %}{% translate 'Notifications' %} — {{ block.super }}{% endblock title %}
+
+{% block breadcrumbs %}
+    {% translate "Notifications" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
+{% endblock breadcrumbs %}
 
 {% block content %}
   {% url "notifications" as notifications_url %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_create_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_create_form.html
@@ -1,20 +1,13 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}{% translate 'Create a new proposal' %} - {{ block.super }}{% endblock title %}
+
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{% translate 'Submit a new proposal for this project' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Create proposal" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
+
 {% block content %}
 <div id="layout-grid__area--maincontent">
     <h1>{% translate 'Submit a new proposal for this project' %}</h1>

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_moderate_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}
     {% translate 'Moderate' %}
@@ -9,28 +9,8 @@
 {% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li>
-                    <a href="{% url 'wagtail_serve' '' %}">meinBerlin</a>
-                </li>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                </li>
-                <li>
-                    <a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">{% translate 'Proposal' %}</a>
-                </li>
-                <li class="active" aria-current="page">{% translate 'Moderate proposal' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Moderate proposal" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_update_form.html
+++ b/meinberlin/apps/budgeting/templates/meinberlin_budgeting/proposal_update_form.html
@@ -1,21 +1,11 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}{% blocktranslate with title=object.name %}Edit {{ title }}{% endblocktranslate %} – {{ block.super }}{% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ object.get_absolute_url }}">{% translate 'Proposal' %}</a></li>
-                <li class="active" aria-current="page">{% translate 'Edit proposal' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Edit proposal" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/breadcrumbs.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/includes/breadcrumbs.html
@@ -1,0 +1,13 @@
+{% load i18n widget_tweaks %}
+
+<div id="content-header">
+    <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
+        <ol>
+            {% for page in pages %}
+                <li{% if forloop.last %} class="active" aria-current="page"{% endif %}>
+                    <a href="{{ page.url }}">{{ page.title }}</a>
+                </li>
+            {% endfor %}
+        </ol>
+    </nav>
+</div>

--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -5,27 +5,6 @@
     —
     {{ block.super }}
 {% endblock title %}
-{% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li>
-                    <a href="{% url 'wagtail_serve' '' %}">meinBerlin</a>
-                </li>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                </li>
-                <li>
-                    <a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a>
-                </li>
-                <li class="active" aria-current="page">{{ object.name }}</li>
-            </ol>
-        </nav>
-    </div>
-{% endblock breadcrumbs %}
 {% block content %}
     <div id="layout-grid__area--maincontent">
         {% if object.is_archived %}

--- a/meinberlin/apps/contrib/templatetags/breadcrumbs_tags.py
+++ b/meinberlin/apps/contrib/templatetags/breadcrumbs_tags.py
@@ -1,0 +1,155 @@
+from django import template
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+register = template.Library()
+
+
+ACCOUNT_VIEWS = (
+    "ProfileUpdateView",
+    "PasswordChangeView",
+    "EmailView",
+    "NotificationSettingsView",
+    "KiezRadarView",
+    "SearchProfileListView",
+)
+
+
+@register.inclusion_tag(
+    "meinberlin_contrib/includes/breadcrumbs.html", takes_context=True
+)
+def render_breadcrumbs(context, final_title=None):
+    pages = []
+
+    # Gather all the variables we need
+    request = context["request"]
+    project = context.get("project")
+    module = context.get("module")
+    obj = context.get("object")
+    paragraph = context.get("paragraph")
+
+    view_name = None
+    if "view" in context:
+        view_name = context["view"].__class__.__name__
+
+    # Populate pages
+    add_home_page(pages)
+    module = obtain_module_if_none(module, obj)
+    add_account_page_if_needed(pages, view_name)
+    add_kiezradar_if_needed(pages, view_name, project)
+    add_project_plan_if_needed(pages, project)
+    add_project_page_if_needed(pages, project)
+    add_module_page_if_needed(pages, module)
+    add_paragraph_page_if_needed(pages, paragraph)
+    add_object_page_if_needed(pages, obj, module, project)
+    add_final_title_if_needed(pages, final_title, request)
+
+    return {"pages": pages}
+
+
+def add_home_page(pages):
+    pages.append(
+        {
+            "title": _("Home page"),
+            "url": reverse("wagtail_serve", args=[""]),
+        }
+    )
+
+
+def obtain_module_if_none(module, obj):
+    if not module and hasattr(obj, "module"):
+        return obj.module
+    return module
+
+
+def add_account_page_if_needed(pages, view_name):
+    if view_name in ACCOUNT_VIEWS:
+        pages.append(
+            {
+                "title": _("User Account Settings"),
+                "url": reverse("account_profile"),
+            }
+        )
+
+
+def add_kiezradar_if_needed(pages, view_name, project):
+    if view_name in ("PlanListView", "PlanDetailView") or project:
+        pages.append(
+            {
+                "title": _("Kiezradar"),
+                "url": reverse("meinberlin_plans:plan-list"),
+            }
+        )
+
+
+def add_project_plan_if_needed(pages, project):
+    if project and project.plans.exists():
+        plan = project.plans.first()
+        pages.append(
+            {
+                "title": plan.title,
+                "url": reverse(
+                    "meinberlin_plans:plan-detail",
+                    kwargs={
+                        "pk": "{:05d}".format(plan.pk),
+                        "year": plan.created.year,
+                    },
+                ),
+            }
+        )
+
+
+def add_project_page_if_needed(pages, project):
+    if project:
+        pages.append(
+            {
+                "title": project.name,
+                "url": reverse("project-detail", args=[project.slug]),
+            }
+        )
+
+
+def add_module_page_if_needed(pages, module):
+    if module:
+        pages.append(
+            {
+                "title": module.name,
+                "url": module.get_absolute_url(),
+            }
+        )
+
+
+def add_paragraph_page_if_needed(pages, paragraph):
+    if paragraph:
+        pages.append(
+            {
+                "title": paragraph.chapter.name,
+                "url": paragraph.chapter.get_absolute_url(),
+            }
+        )
+
+
+def add_object_page_if_needed(pages, obj, module, project):
+    if (
+        obj
+        and hasattr(obj, "module")
+        and hasattr(obj, "name")
+        and obj != module
+        and obj != project
+    ):
+        pages.append(
+            {
+                "title": obj.name,
+                "url": obj.get_absolute_url(),
+            }
+        )
+
+
+def add_final_title_if_needed(pages, final_title, request):
+    if final_title:
+        pages.append(
+            {
+                "title": final_title,
+                "url": request.path,
+            }
+        )

--- a/meinberlin/apps/documents/templates/meinberlin_documents/paragraph_detail.html
+++ b/meinberlin/apps/documents/templates/meinberlin_documents/paragraph_detail.html
@@ -3,20 +3,6 @@
 
 {% block title %}{{ paragraph.name }} — {{ paragraph.chapter.project.name }} — {{ block.super }}{% endblock title %}
 
-{% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{{ project.get_absolute_url }}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ chapter.get_absolute_url }}">{{ chapter.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{{ paragraph.name|truncatechars:50 }}</li>
-            </ol>
-        </nav>
-    </div>
-{% endblock breadcrumbs %}
-
 {% block content %}
 <div id="layout-grid__area--maincontent">
 

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_create_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_create_form.html
@@ -1,20 +1,11 @@
 {% extends "base.html" %}
-{% load i18n meinberlin_project_tags %}
+{% load i18n meinberlin_project_tags breadcrumbs_tags %}
 
 {% block title %}{% translate 'Create a new proposal' %} - {{ block.super }}{% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{% translate 'Submit a new idea for this project ' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Create idea" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_moderate_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_moderate_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}
     {{ object.name }}
@@ -8,28 +8,8 @@
 {% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li>
-                    <a href="{% url 'wagtail_serve' '' %}">meinBerlin</a>
-                </li>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                </li>
-                <li>
-                    <a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a>
-                </li>
-                <li>
-                    <a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a>
-                </li>
-                <li class="active" aria-current="page">{% translate 'Moderate idea' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Moderate idea" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_update_form.html
+++ b/meinberlin/apps/ideas/templates/meinberlin_ideas/idea_update_form.html
@@ -1,21 +1,11 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}{% blocktranslate with title=object.name %}Edit {{ title }}{% endblocktranslate %} - {{ block.super }}{% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a></li>
-                <li class="active" aria-current="page">{% translate 'Edit idea' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Edit idea" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_create_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_create_form.html
@@ -1,20 +1,13 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}{% translate 'Create a new proposal' %}{% endblock title %}
+
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{% translate 'Submit a new proposal for this project' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Create proposal" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
+
 {% block content %}
 <div id="layout-grid__area--maincontent">
     <h1>{% translate 'Submit a new proposal for this project' %}</h1>

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_moderate_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_moderate_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}
     {% blocktranslate with name=object.name %}
@@ -8,27 +8,8 @@
 {% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="layout-grid__area--contentheader">
-        <div id="content-header">
-            <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-                <ol>
-                    <li>
-                        <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a>
-                    </li>
-                    <li>
-                        <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                    </li>
-                    <li>
-                        <a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a>
-                    </li>
-                    <li>
-                        <a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a>
-                    </li>
-                    <li class="active" aria-current="page">{% translate 'Moderate proposal' %}</li>
-                </ol>
-            </nav>
-        </div>
-    </div>
+    {% translate "Moderate proposal" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_update_form.html
+++ b/meinberlin/apps/kiezkasse/templates/meinberlin_kiezkasse/proposal_update_form.html
@@ -1,21 +1,11 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}{% blocktranslate with title=object.name %}Edit {{ title }}{% endblocktranslate %} - {{ block.super }}{% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ object.get_absolute_url }}">{% translate 'Proposal' %}</a></li>
-                <li class="active" aria-current="page">{% translate 'Edit proposal' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Edit proposal" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/kiezradar/templates/meinberlin_kiezradar/kiezradar.html
+++ b/meinberlin/apps/kiezradar/templates/meinberlin_kiezradar/kiezradar.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
-{% load static i18n react_kiezradar %}
+{% load static i18n react_kiezradar breadcrumbs_tags %}
 
 {% block title %}{% translate 'Kiez selection' %} - {{ block.super }}{% endblock title %}
+
+{% block breadcrumbs %}
+    {% translate 'Kiez selection' as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
+{% endblock breadcrumbs %}
 
 {% block extra_js %}
     {{ block.super }}

--- a/meinberlin/apps/kiezradar/templates/meinberlin_kiezradar/search_profile_list.html
+++ b/meinberlin/apps/kiezradar/templates/meinberlin_kiezradar/search_profile_list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static i18n react_kiezradar_search_profiles %}
+{% load static i18n react_kiezradar_search_profiles breadcrumbs_tags %}
 
 {% block title %}{% translate 'Search profiles' %} - {{ block.super }}{% endblock title %}
 
@@ -8,7 +8,10 @@
     {{ block.super }}
 {% endblock extra_js %}
 
-{% block breadcrumbs %}{% endblock breadcrumbs %}
+{% block breadcrumbs %}
+    {% translate "Search Profiles" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
+{% endblock breadcrumbs %}
 
 {% block content %}
 <div id="layout-grid__area--maincontent">

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_create_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_create_form.html
@@ -1,20 +1,13 @@
 {% extends "base.html" %}
-{% load i18n meinberlin_project_tags %}
+{% load i18n meinberlin_project_tags breadcrumbs_tags %}
 
 {% block title %}{% translate 'Create a new proposal' %} - {{ block.super }}{% endblock title %}
+
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{% translate 'Submit a new idea for this project' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Create idea" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
+
 {% block content %}
 <div id="layout-grid__area--maincontent">
     <h1>{% translate 'Submit a new idea for this project' %}</h1>

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_moderate_form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}
     {% blocktranslate with name=object.name %}
@@ -8,18 +8,8 @@
 {% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a></li>
-                <li class="active" aria-current="page">{% translate 'Moderate idea' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Moderate idea" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_update_form.html
+++ b/meinberlin/apps/mapideas/templates/meinberlin_mapideas/mapidea_update_form.html
@@ -1,21 +1,11 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 
 {% block title %}{% blocktranslate with title=object.name %}Edit {{ title }}{% endblocktranslate %} - {{ block.super }}{% endblock title %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ object.get_absolute_url }}">{% translate 'Idea' %}</a></li>
-                <li class="active" aria-current="page">{% translate 'Edit idea' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% translate "Edit idea" as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %} 

--- a/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
+++ b/meinberlin/apps/maptopicprio/templates/meinberlin_maptopicprio/maptopic_detail.html
@@ -13,20 +13,6 @@
 
 {% block title %}{{ object.name }} — {{ block.super }}{% endblock title %}
 
-{% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{{ object.name }}</li>
-            </ol>
-        </nav>
-    </div>
-{% endblock breadcrumbs %}
-
 {% block content %}
 <div id="layout-grid__area--maincontent">
     <article class="item-detail">

--- a/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
+++ b/meinberlin/apps/plans/templates/meinberlin_plans/plan_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static rules wagtailcore_tags maps_tags thumbnail ckeditor_tags contrib_tags plan_tags %}
+{% load i18n static rules wagtailcore_tags maps_tags thumbnail ckeditor_tags contrib_tags plan_tags breadcrumbs_tags %}
 
 {% block title %}{{ object.title }} – {{ block.super }}{% endblock title %}
 
@@ -27,19 +27,9 @@
         </ul>
     {% endif %}
 {% endblock extra_messages %}
-
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li class="active" aria-current="page">{{ object.title|truncatechars:50 }}</li>
-            </ol>
-        </nav>
-    </div>
+    {% render_breadcrumbs final_title=object.title %}
 {% endblock breadcrumbs %}
-
 {% block content %}
 <div id="layout-grid__area--maincontent">
     {% modify_hero_content object as modified_content %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_bplan_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_bplan_detail.html
@@ -3,18 +3,6 @@
 
 {% block title %}{{ project.name }} — {{ block.super }}{% endblock title %}
 
-{% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li class="active" aria-current="page">{{ project.name|truncatechars:50 }}</li>
-            </ol>
-        </nav>
-    </div>
-{% endblock breadcrumbs %}
-
 {% block content %}
 <div id="layout-grid__area--maincontent">
     <div>

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_detail.html
@@ -14,21 +14,7 @@
         {% include 'meinberlin_contrib/components/info-box.html' with info_message=info %}
     {% endif %}
 {% endblock extra_messages %}
-{% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label='{% translate "You are here:" %}'>
-            <ol>
-                <li>
-                    <a href="{% url 'wagtail_serve' '' %}">meinBerlin</a>
-                </li>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate "Kiezradar" %}</a>
-                </li>
-                <li class="active" aria-current="page">{{ project.name|truncatechars:50 }}</li>
-            </ol>
-        </nav>
-    </div>
-{% endblock breadcrumbs %}
+
 {% block content %}
     <div class="layout-grid__area--maincontent">
         {% url 'project-information' slug=project.slug as info_page %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_event.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_event.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n %}
+{% load i18n breadcrumbs_tags %}
 {% block title %}
     {{ project.name }} - {{ event.name }}
 {% endblock title %}
@@ -11,22 +11,7 @@
     {% endif %}
 {% endblock extra_messages %}
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label='{% translate "You are here:" %}'>
-            <ol>
-                <li>
-                    <a href="{% url 'wagtail_serve' '' %}">meinBerlin</a>
-                </li>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate "Kiezradar" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                </li>
-                <li class="active" aria-current="page">{{ event.name|truncatechars:50 }}</li>
-            </ol>
-        </nav>
-    </div>
+    {% render_breadcrumbs final_title=event.name %}
 {% endblock breadcrumbs %}
 {% block content %}
     <div class="layout-grid__area--maincontent">

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_information.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_information.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n ckeditor_tags static %}
+{% load i18n ckeditor_tags static breadcrumbs_tags %}
 
 {% block title %}
     {{ project.name }} -{% trans 'Information' %}
@@ -19,22 +19,8 @@
 {% endblock extra_js %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label='{% translate "You are here:" %}'>
-            <ol>
-                <li>
-                    <a href="{% url 'wagtail_serve' '' %}">meinBerlin</a>
-                </li>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate "Kiezradar" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                </li>
-                <li class="active" aria-current="page">{% trans 'Project Information' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% trans 'Project Information' as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_results.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_results.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n ckeditor_tags static %}
+{% load i18n ckeditor_tags static breadcrumbs_tags %}
 
 {% block title %}
     {{ project.name }} -{% trans 'Results' %}
@@ -19,22 +19,8 @@
 {% endblock extra_js %}
 
 {% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label='{% translate "You are here:" %}'>
-            <ol>
-                <li>
-                    <a href="{% url 'wagtail_serve' '' %}">meinBerlin</a>
-                </li>
-                <li>
-                    <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate "Kiezradar" %}</a>
-                </li>
-                <li>
-                    <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                </li>
-                <li class="active" aria-current="page">{% trans 'Results' %}</li>
-            </ol>
-        </nav>
-    </div>
+    {% trans 'Results' as final_title %}
+    {% render_breadcrumbs final_title=final_title %}
 {% endblock breadcrumbs %}
 
 {% block content %}

--- a/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
+++ b/meinberlin/apps/topicprio/templates/meinberlin_topicprio/topic_detail.html
@@ -3,20 +3,6 @@
 
 {% block title %}{{ object.name }} — {{ block.super }}{% endblock title %}
 
-{% block breadcrumbs %}
-    <div id="content-header">
-        <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-            <ol>
-                <li><a href="{% url 'wagtail_serve' '' %}">meinBerlin</a></li>
-                <li><a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a></li>
-                <li><a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a></li>
-                <li><a href="{{ module.get_absolute_url }}">{{ module.name|truncatechars:50 }}</a></li>
-                <li class="active" aria-current="page">{{ object.name }}</li>
-            </ol>
-        </nav>
-    </div>
-{% endblock breadcrumbs %}
-
 {% block content %}
 <div id="layout-grid__area--maincontent">
     <article class="item-detail">

--- a/meinberlin/templates/a4dashboard/base_dashboard.html
+++ b/meinberlin/templates/a4dashboard/base_dashboard.html
@@ -3,11 +3,12 @@
 
 {% block extra_css %}
     <link rel="stylesheet" type="text/css" href="{% static 'adhocracy4.css' %}" />
-{% endblock %}
+{% endblock extra_css %}
 
 {% block header %}
-{% endblock %}
-{% block menu %}{% endblock %}
+{% endblock header %}
+{% block menu %}{% endblock menu %}
+{% block breadcrumbs %}{% endblock breadcrumbs %}
 
 {% block content %}
 
@@ -71,14 +72,14 @@
                 </nav>
             </div>
         </div>
-    {% endblock %}
+    {% endblock dashboard_nav %}
 {% endif %}
 
 <div class="container">
-    {% block dashboard_content %}{% endblock %}
+    {% block dashboard_content %}{% endblock dashboard_content %}
 </div>
 
-{% endblock %}
+{% endblock content %}
 
 {% block footer %}
-{% endblock %}
+{% endblock footer %}

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -22,26 +22,6 @@
     {% endif %}
 {% endblock extra_messages %}
 
-<!-- Breadcrumbs are only necessary for multimodule projects with simultaneously running modules since the project detail
-     template correctly displays breadcrumbs for other project -->
-{% if module.is_in_module_cluster %}
-    {% block breadcrumbs %}
-        <div id="content-header">
-            <nav class="breadcrumb" aria-label="{% translate 'You are here:' %}">
-                <ol>
-                    <li>
-                        <a href="{% url 'meinberlin_plans:plan-list' %}">{% translate 'Kiezradar' %}</a>
-                    </li>
-                    <li>
-                        <a href="{% url 'project-detail' project.slug %}">{{ project.name|truncatechars:50 }}</a>
-                    </li>
-                    <li class="active" aria-current="page">{{ module.name|truncatechars:50 }}</li>
-                </ol>
-            </nav>
-        </div>
-    {% endblock breadcrumbs %}
-{% endif %}
-
 {% block content %}
     <div id="layout-grid__area--maincontent">
         <div class="modul-video">

--- a/meinberlin/templates/base.html
+++ b/meinberlin/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load i18n static contrib_tags wagtailuserbar %}
+{% load i18n static contrib_tags wagtailuserbar breadcrumbs_tags %}
 {% get_current_language as LANGUAGE_CODE %}
 <html lang="{{ LANGUAGE_CODE }}">
 <head>
@@ -53,7 +53,7 @@
     <!-- FIXME we don't currently want their grid in dashboard however this does not work if someone names wagtail, project or plan page 'dashboard' -->
     <main tabindex="-1" {% if '/dashboard' not in request.path or '/components' not in request.path %} id="layout-grid" {% endif %}>
         <div id="layout-grid__area--contentheader">
-            {% block breadcrumbs %}{% endblock breadcrumbs %}
+            {% block breadcrumbs %}{% render_breadcrumbs %}{% endblock breadcrumbs %}
         </div>
 
         {% if messages %}

--- a/tests/contrib/conftest.py
+++ b/tests/contrib/conftest.py
@@ -1,0 +1,5 @@
+from pytest_factoryboy import register
+
+from meinberlin.test.factories import ideas as ideas_factories
+
+register(ideas_factories.IdeaFactory)

--- a/tests/contrib/test_breadcrumbs.py
+++ b/tests/contrib/test_breadcrumbs.py
@@ -1,0 +1,171 @@
+import pytest
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from adhocracy4.test.helpers import setup_phase
+from meinberlin.apps.ideas import phases
+
+
+def extract_data(response):
+    data = response.context["pages"]
+
+    return {
+        "length": len(data),
+        "first": data[0],
+        "last": data[-1],
+        "pages": data,
+    }
+
+
+@pytest.fixture()
+def superuser_client(client, user_factory):
+    admin = user_factory(is_superuser=True, is_staff=True)
+    client.force_login(admin)
+    return client
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_kiezradar(client):
+    data = extract_data(client.get("/kiezradar/"))
+
+    assert data["length"] == 2
+    assert data["first"]["title"] == _("Home page")
+    assert data["first"]["url"] == "/"
+    assert data["last"]["title"] == _("Kiezradar")
+    assert data["last"]["url"] == "/kiezradar/"
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_project(
+    phase_factory,
+    client,
+):
+    phase, module, project, item = setup_phase(phase_factory, None, phases.CollectPhase)
+    data = extract_data(client.get(project.get_absolute_url()))
+
+    assert data["length"] == 3
+    assert data["first"]["title"] == _("Home page")
+    assert data["first"]["url"] == "/"
+    assert data["pages"][1]["title"] == _("Kiezradar")
+    assert data["pages"][1]["url"] == "/kiezradar/"
+    assert data["last"]["title"] == project.name
+    assert data["last"]["url"] == project.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_plan(
+    plan_factory,
+    client,
+):
+    plan = plan_factory()
+    data = extract_data(client.get(plan.get_absolute_url()))
+
+    assert data["length"] == 3
+    assert data["first"]["title"] == _("Home page")
+    assert data["first"]["url"] == "/"
+    assert data["pages"][1]["title"] == _("Kiezradar")
+    assert data["pages"][1]["url"] == "/kiezradar/"
+    assert data["last"]["title"] == plan.title
+    assert data["last"]["url"] == plan.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_module_in_plan(
+    plan_factory,
+    phase_factory,
+    client,
+):
+    phase, module, project, item = setup_phase(phase_factory, None, phases.CollectPhase)
+    plan = plan_factory(projects=[project])
+    data = extract_data(client.get(module.get_absolute_url()))
+
+    assert data["length"] == 5
+    assert data["pages"][2]["title"] == plan.title
+    assert data["last"]["title"] == module.name
+    assert data["last"]["url"] == module.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_module(
+    phase_factory,
+    client,
+):
+    phase, module, project, item = setup_phase(phase_factory, None, phases.CollectPhase)
+    data = extract_data(client.get(module.get_absolute_url()))
+
+    assert data["length"] == 4
+    assert data["last"]["title"] == module.name
+    assert data["last"]["url"] == module.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_item(
+    phase_factory,
+    idea_factory,
+    client,
+):
+    phase, module, project, item = setup_phase(
+        phase_factory, idea_factory, phases.CollectPhase
+    )
+    data = extract_data(client.get(item.get_absolute_url()))
+
+    assert data["length"] == 5
+    assert data["last"]["title"] == item.name
+    assert data["last"]["url"] == item.get_absolute_url()
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_item_edit(
+    phase_factory,
+    idea_factory,
+    superuser_client,
+):
+    phase, module, project, idea = setup_phase(
+        phase_factory, idea_factory, phases.CollectPhase
+    )
+    url = reverse(
+        "meinberlin_ideas:idea-update",
+        kwargs={"pk": idea.pk, "year": idea.created.year},
+    )
+    data = extract_data(superuser_client.get(url))
+
+    assert data["length"] == 6
+    assert data["last"]["title"] == _("Edit idea")
+    assert data["last"]["url"] == url
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_item_moderate(
+    phase_factory,
+    idea_factory,
+    superuser_client,
+):
+    phase, module, project, idea = setup_phase(
+        phase_factory, idea_factory, phases.CollectPhase
+    )
+    url = reverse(
+        "meinberlin_ideas:idea-moderate",
+        kwargs={"pk": idea.pk, "year": idea.created.year},
+    )
+    data = extract_data(superuser_client.get(url))
+
+    assert data["length"] == 6
+    assert data["last"]["title"] == _("Moderate idea")
+    assert data["last"]["url"] == url
+
+
+@pytest.mark.django_db
+def test_render_breadcrumbs_item_create(
+    phase_factory,
+    idea_factory,
+    superuser_client,
+):
+    phase, module, project, idea = setup_phase(
+        phase_factory, idea_factory, phases.CollectPhase
+    )
+    url = reverse("meinberlin_ideas:idea-create", kwargs={"module_slug": module.slug})
+    data = extract_data(superuser_client.get(url))
+
+    assert data["length"] == 5
+    assert data["last"]["title"] == _("Create idea")
+    assert data["last"]["url"] == url

--- a/tests/projects/test_insights.py
+++ b/tests/projects/test_insights.py
@@ -1,5 +1,6 @@
 import pytest
 from django.urls import reverse
+from django.utils.translation import gettext as _
 from rest_framework import status
 
 from adhocracy4.polls import phases
@@ -26,7 +27,7 @@ def test_draft_modules_do_not_trigger_show_results(
     answer_factory,
 ):
     n_answers = 2
-    expected_label = "poll answers"
+    expected_label = _("poll answers")
 
     project = project_factory()
     module = module_factory(project=project, is_draft=False, blueprint_type="PO")
@@ -59,9 +60,9 @@ def test_create_insight_context(
     module_factory,
 ):
     expected_label = {
-        "brainstorming": "written ideas",
-        "poll": "poll answers",
-        "interactive-event": "interactive event questions",
+        "brainstorming": _("written ideas"),
+        "poll": _("poll answers"),
+        "interactive-event": _("interactive event questions"),
     }
 
     blueprint_type = None


### PR DESCRIPTION
**Describe your changes**
- streamlines breadcrumbs by using a templatetag
- removes truncation as requested in the story
- renames the first node of the breadcrumb to "home page"

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog