### PR TITLE
notifications: add logic for plan matching to notifications for search profiles

### DIFF
--- a/meinberlin/apps/actions/apps.py
+++ b/meinberlin/apps/actions/apps.py
@@ -16,6 +16,8 @@ class Config(AppConfig):
             ("meinberlin_bplan", "bplan"),
             ("meinberlin_externalproject", "externalproject"),
         )
+
+        configure_type("plan", ("meinberlin_plans", "plan"))
         configure_type("phase", ("a4phases", "phase"))
         configure_type("comment", ("a4comments", "comment"))
         configure_type("rating", ("a4ratings", "rating"))

--- a/meinberlin/apps/actions/serializers.py
+++ b/meinberlin/apps/actions/serializers.py
@@ -5,6 +5,7 @@ from django.utils.timezone import localtime
 from rest_framework import serializers
 
 from adhocracy4.actions.models import Action
+from meinberlin.apps.plans.serializers import PlanSerializer
 from meinberlin.apps.projects.serializers import ProjectSerializer
 
 
@@ -16,6 +17,7 @@ class ActionSerializer(serializers.ModelSerializer):
     link = serializers.SerializerMethodField()
     item = serializers.SerializerMethodField()
     actor = serializers.SerializerMethodField()
+    plan = serializers.SerializerMethodField()
     target_creator = serializers.CharField(
         source="target_creator.username", default=None
     )
@@ -54,6 +56,12 @@ class ActionSerializer(serializers.ModelSerializer):
         )
 
         return target
+
+    def get_plan(self, obj):
+        obj, class_name = self.get_cached_trigger(obj)
+        if class_name == "Plan":
+            return PlanSerializer(instance=obj).data
+        return None
 
     def get_body(self, obj):
         trigger, trigger_class = self.get_cached_trigger(obj)

--- a/meinberlin/apps/kiezradar/matchers.py
+++ b/meinberlin/apps/kiezradar/matchers.py
@@ -1,0 +1,166 @@
+from functools import reduce
+from typing import Optional
+
+from django.conf import settings
+from django.contrib.gis.db.models.functions import Distance
+from django.contrib.postgres.search import SearchQuery
+from django.contrib.postgres.search import SearchVector
+from django.db import connection
+from django.db.models import Q
+from django.db.models import QuerySet
+
+from adhocracy4.projects.models import Project
+from meinberlin.apps.plans.models import Plan
+
+from .models import ProjectType
+from .models import SearchProfile
+
+Organisation = settings.A4_ORGANISATIONS_MODEL
+
+
+def full_text_search(
+    search_term: str,
+    search_queryset: Optional[QuerySet[SearchProfile]] = None,
+    language: str = "german",
+) -> QuerySet[SearchProfile]:
+    """
+    Performs a full-text search on the given SearchProfile QuerySet.
+    To be used with postgresql-only database connection.
+
+    Args:
+        search_term (str): The user-provided search input.
+        search_queryset (Optional[QuerySet[SearchProfile]]):
+            A base QuerySet to apply the search on (default: all SearchProfile records).
+        language (str, optional): The PostgreSQL full-text search language configuration. Defaults to "german". If more languages need to be supported than german, the config would need a library like nltk to sanitize multiple languages.
+
+    Returns:
+        QuerySet[SearchProfile]: A queryset of matching search profiles.
+    """
+
+    # Default to all search profiles if no QuerySet is provided
+    search_queryset = search_queryset or SearchProfile.objects.all()
+
+    query = " or ".join(search_term.split())
+    search_query = SearchQuery(query, search_type="websearch", config=language)
+
+    search_queryset = search_queryset.annotate(
+        search=SearchVector("query__text", config=language)
+    )
+    search_queryset = search_queryset.filter(
+        Q(search=search_query) | Q(query__isnull=True)
+    )
+    return search_queryset
+
+
+def sqlite_text_search(
+    search_term: str,
+    search_queryset: Optional[QuerySet[SearchProfile]] = None,
+) -> QuerySet[SearchProfile]:
+    """
+    Filters search profiles based on a search term using partial matches (icontains).
+    This is a hack to make full text search somewhat useful on sqlite database connections.
+
+    Args:
+        search_profiles (QuerySet): The queryset of SearchProfile to filter.
+        search_term (str): The search term to use for filtering, split into individual words.
+
+    Returns:
+        QuerySet: The filtered queryset based on the search term.
+    """
+    search_queryset = search_queryset or SearchProfile.objects.all()
+
+    query = reduce(
+        lambda a, b: a | b,
+        (
+            Q(query__text__icontains=term)
+            for term in search_term.split()
+            if len(term) > 2
+        ),
+    )
+    return search_queryset.filter(query | Q(query__isnull=True))
+
+
+def filter_by_term(obj: Project | Plan) -> QuerySet[SearchProfile]:
+    search_term = ""
+    # f"{obj.name} {obj.description} {obj.organisation.name}"
+
+    if isinstance(obj, Project):
+        search_term = f"{obj.name} {obj.description} {obj.organisation.name}"
+
+        if obj.administrative_district:
+            search_term += f" {obj.administrative_district.name}"
+
+        if hasattr(obj, "externalproject"):
+            if hasattr(obj.externalproject, "bplan"):
+                search_term += f" {obj.externalproject.bplan.identifier}"
+
+    elif isinstance(obj, Plan):
+        search_term = f"{obj.title} {obj.description} {obj.organisation.name}"
+
+        if obj.district:
+            search_term += f" {obj.district.name}"
+
+    for topic in obj.topic_names:
+        search_term += f" {topic}"
+
+    if connection.vendor == "postgresql":
+        search_profiles = full_text_search(search_term)
+    else:
+        search_profiles = sqlite_text_search(search_term)
+
+    return search_profiles
+
+
+def get_search_profile_filters_for_plan(plan: Plan) -> Q:
+    status = 0
+    if plan.status == Plan.STATUS_DONE:
+        status = 2
+
+    return (Q(status__status=status) | Q(status__isnull=True)) & (
+        Q(project_types__participation=plan.participation)
+        | Q(project_types__isnull=True)
+    )
+
+
+def get_search_profile_filters_for_project(project: Project) -> Q:
+    status = 2
+    if project.phases.active_phases():
+        status = 0
+    elif project.phases.future_phases():
+        status = 1
+
+    return (
+        (
+            Q(project_types__participation=ProjectType.PARTICIPATION_CONSULTATION)
+            | Q(project_types__isnull=True)
+        )
+        & Q(plans_only=False)
+        & (Q(status__status=status) | Q(status__isnull=True))
+    )
+
+
+def get_common_filters(obj: Project | Plan) -> Q:
+    district = obj.district if isinstance(obj, Plan) else obj.administrative_district
+    filters = (
+        (Q(topics__in=obj.topics.all()) | Q(topics__isnull=True))
+        & (Q(organisations__in=[obj.organisation]) | Q(organisations__isnull=True))
+        & (Q(districts__in=[district]) | Q(districts__isnull=True))
+        & Q(disabled=False)
+    )
+
+    if obj.point:
+        filters = filters & (
+            Q(kiezradars__radius__gte=Distance("kiezradars__point", obj.point))
+            | Q(kiezradars__isnull=True)
+        )
+    return filters
+
+
+def get_search_profiles_for_obj(obj: Project | Plan) -> QuerySet[SearchProfile]:
+    qs = filter_by_term(obj)
+    if isinstance(obj, Plan):
+        filters = get_search_profile_filters_for_plan(obj)
+    else:
+        filters = get_search_profile_filters_for_project(obj)
+
+    return qs.filter(filters & get_common_filters(obj))

--- a/meinberlin/apps/kiezradar/models.py
+++ b/meinberlin/apps/kiezradar/models.py
@@ -1,23 +1,13 @@
-from functools import reduce
-from typing import Optional
-
 from django.conf import settings
 from django.contrib.gis.db import models as gis_models
-from django.contrib.gis.db.models.functions import Distance
-from django.contrib.postgres.search import SearchQuery
-from django.contrib.postgres.search import SearchVector
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
 from django.core.validators import MinValueValidator
-from django.db import connection
 from django.db import models
-from django.db.models import Q
-from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.administrative_districts.models import AdministrativeDistrict
 from adhocracy4.models.base import UserGeneratedContentModel
-from adhocracy4.projects.models import Project
 from adhocracy4.projects.models import Topic
 
 Organisation = settings.A4_ORGANISATIONS_MODEL
@@ -170,111 +160,5 @@ class SearchProfile(UserGeneratedContentModel):
     def __str__(self):
         return f"kiezradar search profile - {self.name}, disabled {self.disabled}"
 
-
-def full_text_search(
-    search_term: str,
-    search_queryset: Optional[QuerySet[SearchProfile]] = None,
-    language: str = "german",
-) -> QuerySet[SearchProfile]:
-    """
-    Performs a full-text search on the given SearchProfile QuerySet.
-    To be used with postgresql-only database connection.
-
-    Args:
-        search_term (str): The user-provided search input.
-        search_queryset (Optional[QuerySet[SearchProfile]]):
-            A base QuerySet to apply the search on (default: all SearchProfile records).
-        language (str, optional): The PostgreSQL full-text search language configuration. Defaults to "german". If more languages need to be supported than german, the config would need a library like nltk to sanitize multiple languages.
-
-    Returns:
-        QuerySet[SearchProfile]: A queryset of matching search profiles.
-    """
-
-    # Default to all search profiles if no QuerySet is provided
-    search_queryset = search_queryset or SearchProfile.objects.all()
-
-    query = " or ".join(search_term.split())
-    search_query = SearchQuery(query, search_type="websearch", config=language)
-
-    search_queryset = search_queryset.annotate(
-        search=SearchVector("query__text", config=language)
-    )
-    search_queryset = search_queryset.filter(
-        Q(search=search_query) | Q(query__isnull=True)
-    )
-    return search_queryset
-
-
-def sqlite_text_search(
-    search_term: str,
-    search_queryset: Optional[QuerySet[SearchProfile]] = None,
-) -> QuerySet[SearchProfile]:
-    """
-    Filters search profiles based on a search term using partial matches (icontains).
-    This is a hack to make full text search somewhat useful on sqlite database connections.
-
-    Args:
-        search_profiles (QuerySet): The queryset of SearchProfile to filter.
-        search_term (str): The search term to use for filtering, split into individual words.
-
-    Returns:
-        QuerySet: The filtered queryset based on the search term.
-    """
-    search_queryset = search_queryset or SearchProfile.objects.all()
-
-    query = reduce(
-        lambda a, b: a | b,
-        (
-            Q(query__text__icontains=term)
-            for term in search_term.split()
-            if len(term) > 2
-        ),
-    )
-    return search_queryset.filter(query | Q(query__isnull=True))
-
-
-def get_search_profiles_for_project(project: Project) -> QuerySet[SearchProfile]:
-    status = 2
-    if project.phases.active_phases():
-        status = 0
-    elif project.phases.future_phases():
-        status = 1
-
-    search_profiles = SearchProfile.objects.filter(
-        (Q(topics__in=project.topics.all()) | Q(topics__isnull=True))
-        & (Q(status__status=status) | Q(status__isnull=True))
-        & Q(plans_only=False)
-        & (Q(organisations__in=[project.organisation]) | Q(organisations__isnull=True))
-        & (
-            Q(districts__in=[project.administrative_district])
-            | Q(districts__isnull=True)
-        )
-        & (
-            Q(project_types__participation=ProjectType.PARTICIPATION_CONSULTATION)
-            | Q(project_types__isnull=True)
-        )
-        & Q(disabled=False)
-    )
-    search_term = f"{project.name} {project.description} {project.organisation.name}"
-
-    if project.administrative_district:
-        search_term += f" {project.administrative_district.name}"
-    if hasattr(project, "externalproject"):
-        if hasattr(project.externalproject, "bplan"):
-            search_term += f" {project.externalproject.bplan.identifier}"
-    for topic in project.topic_names:
-        search_term += f" {topic}"
-
-    if connection.vendor == "postgresql":
-        search_profiles = full_text_search(search_term, search_queryset=search_profiles)
-    else:
-        search_profiles = sqlite_text_search(
-            search_term, search_queryset=search_profiles
-        )
-
-    if project.point:
-        search_profiles = search_profiles.filter(
-            Q(kiezradars__radius__gte=Distance("kiezradars__point", project.point))
-            | Q(kiezradars__isnull=True)
-        )
-    return search_profiles
+    def get_name(self):
+        return self.name or _("Searchprofile %d") % self.number

--- a/meinberlin/apps/kiezradar/serializers.py
+++ b/meinberlin/apps/kiezradar/serializers.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.utils.module_loading import import_string
-from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from adhocracy4.administrative_districts.models import AdministrativeDistrict
@@ -159,5 +158,5 @@ class SearchProfileSerializer(serializers.ModelSerializer):
         representation["query_text"] = instance.query.text if instance.query else ""
 
         if not instance.name:
-            representation["name"] = _("Searchprofile %d") % instance.number
+            representation["name"] = instance.get_name()
         return representation

--- a/meinberlin/apps/notifications/api.py
+++ b/meinberlin/apps/notifications/api.py
@@ -136,6 +136,7 @@ class NotificationViewSet(
             self.get_queryset()
             .filter(
                 Q(action__obj_content_type__model="project", action__verb="publish")
+                | Q(action__obj_content_type__model="plan", action__verb="publish")
             )
             .order_by("-action__timestamp")
         )

--- a/meinberlin/apps/notifications/emails.py
+++ b/meinberlin/apps/notifications/emails.py
@@ -1,6 +1,6 @@
 from django.contrib import auth
 
-from adhocracy4.projects.models import Project
+from adhocracy4.actions.models import Action
 from meinberlin.apps.contrib.emails import Email
 
 User = auth.get_user_model()
@@ -166,5 +166,12 @@ class NotifyUserOnSearchProfileMatch(Email):
 
     def get_context(self):
         context = super().get_context()
-        context["project"] = Project.objects.get(pk=self.kwargs["project_pk"])
+        action = Action.objects.get(pk=self.kwargs["action_pk"])
+        if action.type == "project":
+            context["object"] = action.project
+            context["is_plan"] = False
+        else:
+            context["object"] = action.obj
+            context["is_plan"] = True
+
         return context

--- a/meinberlin/apps/notifications/signals.py
+++ b/meinberlin/apps/notifications/signals.py
@@ -8,6 +8,7 @@ from adhocracy4.actions.verbs import Verbs
 from adhocracy4.dashboard import signals as dashboard_signals
 from adhocracy4.follows.models import Follow
 from adhocracy4.projects.models import Project
+from meinberlin.apps.plans import signals as plan_signals
 
 from . import emails
 from .tasks import send_action_notifications
@@ -42,6 +43,15 @@ def create_project_published_action(**kwargs):
         verb=Verbs.PUBLISH.value,
         obj=project,
         project=project,
+    )
+
+
+@receiver(plan_signals.plan_published)
+def create_plan_published_action(**kwargs):
+    plan = kwargs.get("plan")
+    Action.objects.create(
+        verb=Verbs.PUBLISH.value,
+        obj=plan,
     )
 
 

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_new_search_profile_project.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_new_search_profile_project.de.email
@@ -1,25 +1,29 @@
 {% extends 'email_base.'|add:part_type %}
 
-{% block subject %}New Project on meinBerlin matching your Search Profile: {{ project.name }}{% endblock %}
+{% block subject %}Neues {% if is_plan %}Vorhaben{% else %}Projekt{% endif %} entsprechend Ihrem Suchprofil: {{ searchprofile.get_name }}{% endblock %}
 
-{% block headline %}New Project{% endblock %}
-{% block sub-headline %}{{ project.name }}{% endblock  %}
+{% block headline %}Neues {% if is_plan %}Vorhaben{% else %}Projekt{% endif %}{% endblock %}
+{% block sub-headline %}{% firstof object.name object.title %}{% endblock  %}
 
-{% block greeting %}Hello  {{ receiver.username }},{% endblock %}
+{% block greeting %}Hallo {{ receiver.username }},{% endblock %}
 
 {% block content_html %}
 <p>
-wording
-{{ searchprofile }}
-{{ project }}
+Ein neues {% if is_plan %}Vorhaben{% else %}Projekt{% endif %}, {% firstof object.name object.title %},
+entspricht Ihrem Suchprofil "{{ searchprofile.get_name }}".
+</p>
+<p>
+Möchten Sie es sich ansehen?
 </p>
 {% endblock %}
 
 {% block content_text %}
-wording
+Ein neues {% if is_plan %}Vorhaben{% else %}Projekt{% endif %}, {% firstof object.name object.title %},
+entspricht Ihrem Suchprofil "{{ searchprofile.get_name }}".
+Möchten Sie es sich ansehen?
 {% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ project.get_absolute_url }}{% endblock %}
-{% block cta_label %}Visit the project{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ object.get_absolute_url }}{% endblock %}
+{% block cta_label %}{% if is_plan %}Vorhaben{% else %}Projekt{% endif %} anzeigen{% endblock %}
 
-{% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you added a contribution to the above project. If you no longer want to receive notifications, change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}
+{% block reason %}Diese E-Mail wurde an {{ receiver.email }} gesendet. Die E-Mail wurde an Sie gesendet, da Sie sich ein Suchprofil angelegt haben.{% endblock %}

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_new_search_profile_project.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_new_search_profile_project.en.email
@@ -1,23 +1,29 @@
 {% extends 'email_base.'|add:part_type %}
 
-{% block subject %}New Project on meinBerlin matching your Search Profile: {{ project.name }}{% endblock %}
+{% block subject %}New {% if is_plan %}Plan{% else %}Project{% endif %} matching your search profile: {{ searchprofile.get_name }}{% endblock %}
 
-{% block headline %}New Project{% endblock %}
-{% block sub-headline %}{{ project.name }}{% endblock  %}
+{% block headline %}New {% if is_plan %}Plan{% else %}Project{% endif %}{% endblock %}
+{% block sub-headline %}{% firstof object.name object.title %}{% endblock  %}
 
-{% block greeting %}Hello  {{ receiver.username }},{% endblock %}
+{% block greeting %}Hello {{ receiver.username }},{% endblock %}
 
 {% block content_html %}
 <p>
-wording
+A new {% if is_plan %}plan{% else %}project{% endif %}, {% firstof object.name object.title %},
+matches your search profile "{{ searchprofile.get_name }}".
+</p>
+<p>
+Would you like to take a look?
 </p>
 {% endblock %}
 
 {% block content_text %}
-wording
+A new {% if is_plan %}plan{% else %}project{% endif %}, {% firstof object.name object.title %},
+matches your search profile "{{ searchprofile.get_name }}".
+Would you like to take a look?
 {% endblock %}
 
-{% block cta_url %}{{ email.get_host }}{{ project.get_absolute_url }}{% endblock %}
-{% block cta_label %}Visit the project{% endblock %}
+{% block cta_url %}{{ email.get_host }}{{ object.get_absolute_url }}{% endblock %}
+{% block cta_label %}View {% if is_plan %}plan{% else %}project{% endif %}{% endblock %}
 
-{% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you added a contribution to the above project. If you no longer want to receive notifications, change the settings for your <a href="{{ email.get_host }}{% url 'account' %}">account</a>.{% endblock %}
+{% block reason %}This email was sent to {{ receiver.email }}. You have received the e-mail because you created a search profile.{% endblock %}

--- a/meinberlin/apps/plans/signals.py
+++ b/meinberlin/apps/plans/signals.py
@@ -1,3 +1,4 @@
+from django import dispatch
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -13,3 +14,6 @@ def reset_cache(sender, instance, *args, **kwargs):
     set_cache_for_projects.delay_on_commit(
         projects=False, get_next_projects=False, ext_projects=False, plans=True
     )
+
+
+plan_published = dispatch.Signal()

--- a/meinberlin/apps/plans/views.py
+++ b/meinberlin/apps/plans/views.py
@@ -33,6 +33,7 @@ from meinberlin.apps.kiezradar.serializers import SearchProfileSerializer
 from meinberlin.apps.maps.models import MapPreset
 from meinberlin.apps.organisations.models import Organisation
 from meinberlin.apps.plans import models
+from meinberlin.apps.plans import signals
 from meinberlin.apps.plans.forms import PlanForm
 from meinberlin.apps.plans.models import Plan
 from meinberlin.apps.projects.serializers import ProjectSerializer
@@ -336,6 +337,8 @@ class PlanPublishView(
 
         plan.is_draft = False
         plan.save()
+
+        signals.plan_published.send(sender=None, plan=plan, user=self.request.user)
 
         messages.success(self.request, _("The plan is published."))
 

--- a/meinberlin/react/account/Notifications.jsx
+++ b/meinberlin/react/account/Notifications.jsx
@@ -57,16 +57,17 @@ function SearchProfilesFeed ({ searchProfilesApiUrl, notificationsApiUrl, planLi
       apiUrl={searchProfilesApiUrl}
       link={planListUrl}
       renderFeedItem={({ id, search_profile: searchProfile, read, action }, index, handleMarkAsRead) => {
-        const { timestamp, project, link, ...rest } = action
-        const text = getSearchProfileText(searchProfile, { project, ...rest })
+        const { timestamp, project, plan, link } = action
+        const text = getSearchProfileText(searchProfile, action)
         const filterList = toFilterList(searchProfile).map((names) => names.join(', ')).slice(0, 3)
+        const obj = project || plan
 
         const { title, body, linkText } = text
 
-        const thumbnail = project.tile_image
+        const thumbnail = obj.tile_image
           ? {
-              url: project.tile_image,
-              alt: project.tile_image_alt_text
+              url: obj.tile_image,
+              alt: obj.tile_image_alt_text
             }
           : null
 
@@ -201,12 +202,14 @@ function getInteractionText (action, totalRatings) {
 }
 
 function getSearchProfileText (searchProfile, action) {
-  const { project } = action
+  const { project, plan } = action
+  const obj = project || plan
+  const isProject = !!project
 
   return {
-    title: notificationsData.searchProfiles.projectMatchesSearchProfileText(project.title, project.url, searchProfile.name),
-    body: project.title,
-    linkText: notificationsData.viewProjectText
+    title: notificationsData.searchProfiles.projectMatchesSearchProfileText(obj.title, obj.url, searchProfile.name, isProject),
+    body: obj.title,
+    linkText: isProject ? notificationsData.viewProjectText : notificationsData.viewPlanText
   }
 }
 

--- a/meinberlin/react/account/notification_data.js
+++ b/meinberlin/react/account/notification_data.js
@@ -60,9 +60,9 @@ export const notificationsData = {
       'No results from your saved searches yet. Add new saved searches and wait for a matching project to be published.'
     ),
     buttonText: django.gettext('Save a search'),
-    projectMatchesSearchProfileText: (title, url, name) => django.interpolate(
-      django.gettext('A new project, <a href="' + url + '">%(title)s</a>, matches your search profile %(name)s'),
-      { title, name },
+    projectMatchesSearchProfileText: (title, url, name, isProject) => django.interpolate(
+      django.gettext('A new %(obj)s, <a href="' + url + '">%(title)s</a>, matches your search profile %(name)s'),
+      { title, name, obj: isProject ? django.gettext('project') : django.gettext('plan') },
       true
     )
   },
@@ -93,7 +93,8 @@ export const notificationsData = {
   },
   viewIdeaText: django.gettext('View idea'),
   viewCommentText: django.gettext('View comment'),
-  viewProjectText: django.gettext('View project')
+  viewProjectText: django.gettext('View project'),
+  viewPlanText: django.gettext('View plan')
 }
 
 export const notificationSettingsData = [

--- a/tests/kiezradar/test_full_text_search.py
+++ b/tests/kiezradar/test_full_text_search.py
@@ -1,9 +1,9 @@
 import pytest
 from django.db import connection
 
+from meinberlin.apps.kiezradar.matchers import full_text_search
+from meinberlin.apps.kiezradar.matchers import sqlite_text_search
 from meinberlin.apps.kiezradar.models import SearchProfile
-from meinberlin.apps.kiezradar.models import full_text_search
-from meinberlin.apps.kiezradar.models import sqlite_text_search
 
 
 @pytest.mark.django_db

--- a/tests/kiezradar/test_search_profile.py
+++ b/tests/kiezradar/test_search_profile.py
@@ -7,10 +7,10 @@ from adhocracy4.test.helpers import freeze_phase
 from adhocracy4.test.helpers import freeze_post_phase
 from adhocracy4.test.helpers import setup_phase
 from meinberlin.apps.ideas.phases import CollectFeedbackPhase
+from meinberlin.apps.kiezradar.matchers import get_search_profiles_for_obj
 from meinberlin.apps.kiezradar.models import ProjectStatus
 from meinberlin.apps.kiezradar.models import ProjectType
 from meinberlin.apps.kiezradar.models import SearchProfile
-from meinberlin.apps.kiezradar.models import get_search_profiles_for_project
 
 
 @pytest.mark.django_db
@@ -111,7 +111,7 @@ def test_searchprofile_filter_topics(phase_factory, search_profile_factory):
     search_profile1.topics.set([list(topics)[2]])
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile2
@@ -128,12 +128,12 @@ def test_searchprofile_filter_project_status(phase_factory, search_profile_facto
     assert search_profile1.status.first().status == ProjectStatus.STATUS_DONE
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile2
     with freeze_post_phase(phase):
-        result = get_search_profiles_for_project(project)
+        result = get_search_profiles_for_obj(project)
         assert len(result) == 1
         assert result.first() == search_profile1
 
@@ -148,7 +148,7 @@ def test_searchprofile_filter_plan_only(phase_factory, search_profile_factory):
     search_profile2 = search_profile_factory()
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile2
@@ -171,7 +171,7 @@ def test_searchprofile_filter_organisation(
     search_profile2 = search_profile_factory()
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile2
@@ -195,7 +195,7 @@ def test_searchprofile_filter_districts(
     search_profile2 = search_profile_factory()
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile2
@@ -216,7 +216,7 @@ def test_searchprofile_filter_project_type(phase_factory, search_profile_factory
     search_profile2.project_types.clear()
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2  # still two, because we also filter for isnull=True
         assert result.first() == search_profile
 
@@ -231,7 +231,7 @@ def test_searchprofile_filter_disabled(phase_factory, search_profile_factory):
     search_profile2 = search_profile_factory()
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile2
@@ -290,7 +290,7 @@ def test_searchprofile_filter_query(
 
     # Execute search
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
 
         if connection.vendor == "postgresql":
             expected_profiles = [
@@ -326,7 +326,7 @@ def test_searchprofile_filter_query_bplan(
         query=kiezradar_query_factory(text="A30-bplan")
     )
 
-    result = get_search_profiles_for_project(bplan).order_by("pk")
+    result = get_search_profiles_for_obj(bplan).order_by("pk")
     assert list(result) == [bplan_profile]
 
 
@@ -355,7 +355,7 @@ def test_searchprofile_filter_kiezradar(
     search_profile2 = search_profile_factory()
 
     with freeze_phase(phase):
-        result = get_search_profiles_for_project(project).order_by("pk")
+        result = get_search_profiles_for_obj(project).order_by("pk")
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile2

--- a/tests/notifications/test_emails.py
+++ b/tests/notifications/test_emails.py
@@ -147,9 +147,8 @@ def test_search_profile_matches(search_factories, phase_factory, user):
 
     assert len(mail.outbox) == 2
     recipients = mail.outbox[0].recipients() + mail.outbox[1].recipients()
-    assert (
-        mail.outbox[0].subject
-        == f"New Project on meinBerlin matching your Search Profile: {project.name}"
+    assert mail.outbox[0].subject.startswith(
+        "Neues Projekt entsprechend Ihrem Suchprofil:"
     )
     assert matching_profile.creator.email in recipients
     assert matching_profile_other_user.creator.email in recipients

--- a/tests/projects/test_insights.py
+++ b/tests/projects/test_insights.py
@@ -1,5 +1,6 @@
 import pytest
 from django.urls import reverse
+from django.utils.translation import gettext as _
 from rest_framework import status
 
 from adhocracy4.polls import phases
@@ -26,7 +27,7 @@ def test_draft_modules_do_not_trigger_show_results(
     answer_factory,
 ):
     n_answers = 2
-    expected_label = "poll answers"
+    expected_label = _("poll answers")
 
     project = project_factory()
     module = module_factory(project=project, is_draft=False, blueprint_type="PO")
@@ -59,9 +60,9 @@ def test_create_insight_context(
     module_factory,
 ):
     expected_label = {
-        "brainstorming": "written ideas",
-        "poll": "poll answers",
-        "interactive-event": "interactive event questions",
+        "brainstorming": _("written ideas"),
+        "poll": _("poll answers"),
+        "interactive-event": _("interactive event questions"),
     }
 
     blueprint_type = None


### PR DESCRIPTION
**Describe your changes**
This changes the previous `get_search_profiles_for_project` logic to also match plans and updates all related code to handle notifications for when a plan is published that matches a search profile.

this fixes #6259

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog