### PR TITLE
[#9001] Add menu notification counter

### DIFF
--- a/meinberlin/apps/cms/templatetags/menu.py
+++ b/meinberlin/apps/cms/templatetags/menu.py
@@ -1,6 +1,7 @@
 from django import template
 
 from meinberlin.apps.cms import models as cms_models
+from meinberlin.apps.notifications.models import Notification
 
 register = template.Library()
 
@@ -11,6 +12,21 @@ def get_header_menu(title):
 
     if menu is not None:
         return menu.items.all()
+
+
+@register.simple_tag(takes_context=True)
+def get_notifications_count(context):
+    request = context.get("request")
+    if not request or not request.user.is_authenticated:
+        return 0
+
+    unread_count = (
+        Notification.objects.filter(recipient=request.user, read=False)
+        .exclude(action__actor=request.user)
+        .count()
+    )
+
+    return unread_count
 
 
 @register.simple_tag

--- a/meinberlin/assets/scss/components_user_facing/_header.scss
+++ b/meinberlin/assets/scss/components_user_facing/_header.scss
@@ -3,3 +3,15 @@
     padding-top: 0.8em !important;
     padding-bottom: 0.8em !important;
 }
+
+.header__notification-count,
+ul.navigation-tree span.header__notification-count {
+    display: inline;
+    color: $white !important;
+    border-radius: 20px;
+    padding: 0.2rem 0.4rem;
+    background-color: $link-color;
+    font-size: 0.8rem;
+    font-weight: bold;
+    text-decoration: none;
+}

--- a/meinberlin/templates/header.html
+++ b/meinberlin/templates/header.html
@@ -1,5 +1,7 @@
 {% load menu static i18n %}
 
+{% get_notifications_count as notifications_count %}
+
 <header id="header" class="header">
 
     <!-- Portallogo Berlin Brand -->
@@ -30,6 +32,9 @@
                 {% url "notifications" as notifications_url %}
                 <li class="{% if request.path == notifications_url %}active{% endif %}">
                     <a href="{{ notifications_url }}">{% translate 'Notifications' %}</a>
+                    {% if notifications_count > 0 %}
+                        <span class="header__notification-count">{{ notifications_count }}</span>
+                    {% endif %}
                 </li>
                 {% get_header_menu "topnav" as topnav %}
                 {% for item in topnav %}

--- a/meinberlin/templates/navigation_primary.html
+++ b/meinberlin/templates/navigation_primary.html
@@ -9,7 +9,12 @@
             </li>
             {% url 'notifications' as notifications_url %}
             <li class="{% if request.path == notifications_url %}active{% endif %}">
-                <a href="{{ notifications_url }}">{% translate 'Notifications' %}</a>
+                <a href="{{ notifications_url }}">
+                    {% translate 'Notifications' %}
+                    {% if notifications_count > 0 %}
+                        <span class="header__notification-count">{{ notifications_count }}</span>
+                    {% endif %}
+                </a>
             </li>
             {% if settings.meinberlin_cms.HeaderPages.help_page %}
                 <li class="{% if request.path == settings.meinberlin_cms.HeaderPages.help_page.get_url %}active{% endif %}">


### PR DESCRIPTION
**Describe your changes**
This PR adds a menu notification counter.

### Page Header

<img width="558" alt="Screenshot 2025-03-28 at 12 55 07" src="https://github.com/user-attachments/assets/d720464f-1fa4-4d7c-9450-9bd10815c64b" />

### Burger menu

<img width="559" alt="Screenshot 2025-03-28 at 12 55 16" src="https://github.com/user-attachments/assets/9ff8491f-4c2e-4b89-933b-496dd6f8ead3" />

**Tasks**
- [X] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog