### PR TITLE
[#9000] project-actions: overhaul back button and add to other pages

### DIFF
--- a/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
+++ b/meinberlin/apps/contrib/templates/meinberlin_contrib/item_detail.html
@@ -7,6 +7,8 @@
 {% endblock title %}
 {% block content %}
     <div id="layout-grid__area--maincontent">
+        {% include 'meinberlin_projects/project_actions.html' %}
+
         {% if object.is_archived %}
             {% translate 'This idea has been archived.' as archived_message %}
             {% translate 'Archived' as archived_title %}

--- a/meinberlin/apps/projects/templates/meinberlin_projects/project_actions.html
+++ b/meinberlin/apps/projects/templates/meinberlin_projects/project_actions.html
@@ -3,7 +3,7 @@
 
 <div class="project-actions block">
   {% if request.resolver_match.url_name != 'project-detail' %}
-    <a href="{% url 'project-detail' project.slug %}" class="link--back">{% translate 'Back' %}</a>
+    <a href="javascript:history.back()" class="link--back">{% translate 'Back' %}</a>
   {% endif %}
   {% if edit_link and user_may_change %}
     <a href="{{ edit_link }}" target="_blank" class="project-actions__right">

--- a/meinberlin/templates/a4modules/module_detail.html
+++ b/meinberlin/templates/a4modules/module_detail.html
@@ -24,6 +24,7 @@
 
 {% block content %}
     <div id="layout-grid__area--maincontent">
+        {% include 'meinberlin_projects/project_actions.html' %}
         <div class="modul-video">
             <h1>
                 {{ module.name }}


### PR DESCRIPTION
**Describe your changes**
uses `history.back` instead of hardcoded links 

**Tasks**
- [x] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog