### PR TITLE
notifications: show notifications for comments on polls

### DIFF
--- a/meinberlin/apps/actions/serializers.py
+++ b/meinberlin/apps/actions/serializers.py
@@ -102,7 +102,10 @@ class ActionSerializer(serializers.ModelSerializer):
         if target and hasattr(target, "name"):
             return target.name
         elif target and hasattr(target, "content_object"):
-            return target.content_object.name
+            if hasattr(target.content_object, "name"):
+                return target.content_object.name
+            elif hasattr(target.content_object, "module"):
+                return target.content_object.module.name
         return None
 
     def get_type(self, obj):

--- a/meinberlin/react/account/Notifications.jsx
+++ b/meinberlin/react/account/Notifications.jsx
@@ -183,6 +183,13 @@ function getInteractionText (action, totalRatings) {
             linkText: notificationsData.viewCommentText
           }
 
+        case 'poll':
+          return {
+            title: notificationsData.interactions.userRepliedPollText(project.title, project.url),
+            body,
+            linkText: notificationsData.viewCommentText
+          }
+
         case 'comment':
           if (actor.is_moderator) {
             return {

--- a/meinberlin/react/account/notification_data.js
+++ b/meinberlin/react/account/notification_data.js
@@ -40,6 +40,11 @@ export const notificationsData = {
       { title },
       true
     ),
+    userRepliedPollText: (title, url) => django.interpolate(
+      django.gettext('A user has replied to your poll in <a href="' + url + '">%(title)s</a>'),
+      { title },
+      true
+    ),
     moderatorRepliedCommentText: (title, url) => django.interpolate(
       django.gettext('A moderator has responded to your comment in <a href="' + url + '">%(title)s</a>'),
       { title },


### PR DESCRIPTION
**Describe your changes**
Fixes an error that occurs when users are commenting on polls, because those are module-items and the notification system thinks that its an interaction with the creator of the poll. This will display that notification to the initiator; later on we will implement a fix that prevents that notification from being created in the first place and a migration to remove all existing notifications of that type.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog