### PR TITLE
Fix map tile panel spacing

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_projects_map.scss
+++ b/meinberlin/assets/scss/components_user_facing/_projects_map.scss
@@ -51,6 +51,7 @@
 
     .leaflet-popup-content a {
         color: $text-base;
+        padding: 1rem 1rem 0.38rem;
     }
 
     .leaflet-popup-tip-container {


### PR DESCRIPTION
**Describe your changes**
This PR fixes the map tile panel spacing.

Resolves #6377.

<img width="481" alt="Screenshot 2025-04-04 at 11 16 57" src="https://github.com/user-attachments/assets/eaae3173-1151-4eda-baa7-3f423e223e3d" />

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog