### PR TITLE
plans: change serializer to return 2 in case status = 1

### DIFF
--- a/changelog/0000.md
+++ b/changelog/0000.md
@@ -1,6 +1,7 @@
 # Changed
 
 - plans admin changed to GISModelAdmin
+- planSerializer to return status of 2 in case it's 1 (because for projects: 2 == "past") for consistency
 
 # Added
 

--- a/meinberlin/apps/plans/serializers.py
+++ b/meinberlin/apps/plans/serializers.py
@@ -22,6 +22,7 @@ class PlanSerializer(PointSerializerMixin, serializers.ModelSerializer, CommonFi
     topics = serializers.SerializerMethodField()
     type = serializers.ReadOnlyField(default="plan")
     url = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
 
     def get_geojson_properties(self):
         return {"strname": "street_name", "hsnr": "house_number", "plz": "zip_code"}
@@ -104,3 +105,8 @@ class PlanSerializer(PointSerializerMixin, serializers.ModelSerializer, CommonFi
             return instance.image_copyright
         else:
             return ""
+
+    def get_status(self, instance: Plan):
+        if instance.status == 1:
+            return 2
+        return instance.status


### PR DESCRIPTION
**Describe your changes**
For projects we have the status as:

> past is 2, future is 1, active is 0

this is a quick fix to change the status of plans to represent the same numbering.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog