### PR TITLE
bplan: add dispatch mixin to display statement form instead of project detail page

### DIFF
--- a/changelog/0000.md
+++ b/changelog/0000.md
@@ -1,0 +1,2 @@
+### added
+- dispatch mixin to display statement form instead of project detail page

--- a/meinberlin/apps/projects/views.py
+++ b/meinberlin/apps/projects/views.py
@@ -30,6 +30,7 @@ from adhocracy4.projects.mixins import PhaseDispatchMixin
 from adhocracy4.projects.mixins import ProjectMixin
 from meinberlin.apps.offlineevents.models import OfflineEvent
 
+from ..bplan.views import BplanProjectDispatchMixin
 from . import forms
 from . import models
 
@@ -338,7 +339,7 @@ class DashboardProjectParticipantsView(AbstractProjectUserInviteListView):
         return self.project
 
 
-class ProjectDetailView(PermissionRequiredMixin, generic.DetailView):
+class ProjectDetailView(PermissionRequiredMixin, BplanProjectDispatchMixin):
     model = models.Project
     permission_required = "a4projects.view_project"
 
@@ -353,10 +354,6 @@ class ProjectDetailView(PermissionRequiredMixin, generic.DetailView):
     @property
     def raise_exception(self):
         return self.request.user.is_authenticated
-
-    @cached_property
-    def project(self):
-        return self.get_object()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
**Describe your changes**
Briefly explain what you did and provide context for a clearer understanding.

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog