### PR TITLE
notifications: fix task causing it to delete new notifications instead of old ones

### DIFF
--- a/changelog/6441.md
+++ b/changelog/6441.md
@@ -1,0 +1,2 @@
+### fixed
+- notifications newer than 180 days being deleted instead of older than 180 days

--- a/meinberlin/apps/notifications/tasks.py
+++ b/meinberlin/apps/notifications/tasks.py
@@ -16,7 +16,7 @@ def periodic_notifications_cleanup():
     This task makes sure that any notification data older >6 months is deleted.
     """
     Notification.objects.filter(
-        action__timestamp__gt=timezone.now() - timedelta(days=180)
+        action__timestamp__lt=timezone.now() - timedelta(days=180)
     ).delete()
 
 

--- a/tests/notifications/test_tasks.py
+++ b/tests/notifications/test_tasks.py
@@ -9,7 +9,7 @@ from meinberlin.test.factories import CommentFactory
 @pytest.mark.django_db
 def test_notifications_deleted_after_180_days(idea_factory):
     with freeze_time("2020-01-01"):
-        CommentFactory.create_batch(10, content_object=idea_factory())
+        CommentFactory.create_batch(15, content_object=idea_factory())
 
     with freeze_time("2021-01-01"):
         CommentFactory.create_batch(10, content_object=idea_factory())


### PR DESCRIPTION
There was an issue with new notifications being deleted instead of old ones due to a logic error in the task code. This fixes it.

fixes #6441