### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-04 14:01+0200\n"
-"PO-Revision-Date: 2025-04-05 15:15+0000\n"
-"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main-"
-"design-dev/de/>\n"
+"PO-Revision-Date: 2025-06-20 16:15+0000\n"
+"Last-Translator: Steffen Blindow <s.blindow@liqd.net>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
+"main-design-dev/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3366,7 +3366,7 @@ msgstr "Link zur Veranstaltung eingeben"
 
 #: meinberlin/apps/livequestions/templates/meinberlin_livequestions/question_present_list.html:48
 msgid "Like questions"
-msgstr "Fragen liken"
+msgstr "Fragen bewerten"
 
 #: meinberlin/apps/livequestions/templates/meinberlin_livequestions/question_present_list.html:61
 msgid "Ask a question yourself!"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-04 14:01+0200\n"
-"PO-Revision-Date: 2025-05-20 15:15+0000\n"
-"Last-Translator: Tietje Khieu <t.khieu@liqd.net>\n"
+"PO-Revision-Date: 2025-06-20 16:15+0000\n"
+"Last-Translator: Steffen Blindow <s.blindow@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
 "js-design-dev/de/>\n"
 "Language: de_DE\n"
@@ -1408,15 +1408,15 @@ msgstr "Pillenliste"
 #: meinberlin/react/contrib/map/ItemPopup.jsx:18
 msgid "Like"
 msgid_plural "Likes"
-msgstr[0] "Like"
-msgstr[1] "Likes"
+msgstr[0] "gefällt"
+msgstr[1] "gefällt"
 
 #: meinberlin/react/contrib/card/CardStats.jsx:8
 #: meinberlin/react/contrib/map/ItemPopup.jsx:22
 msgid "Dislike"
 msgid_plural "Dislikes"
-msgstr[0] "Dislike"
-msgstr[1] "Dislikes"
+msgstr[0] "gefällt nicht"
+msgstr[1] "gefällt nicht"
 
 #: meinberlin/react/contrib/card/CardStats.jsx:9
 msgid "Supporter"
@@ -1812,11 +1812,11 @@ msgstr "gefällt"
 
 #: meinberlin/react/livequestions/LikeCard.jsx:8
 msgid "add like"
-msgstr "like hinzufügen"
+msgstr "gefällt mir"
 
 #: meinberlin/react/livequestions/LikeCard.jsx:9
 msgid "undo like"
-msgstr "like zurück nehmen"
+msgstr "gefällt mir nicht mehr"
 
 #: meinberlin/react/livequestions/LikeCard.jsx:10
 msgid "bookmarked"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-04-04 14:01+0200\n"
-"PO-Revision-Date: 2025-05-19 13:13+0000\n"
+"PO-Revision-Date: 2025-05-20 15:15+0000\n"
 "Last-Translator: Tietje Khieu <t.khieu@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
 "js-design-dev/de/>\n"
@@ -149,7 +149,7 @@ msgstr "Melden"
 #: adhocracy4/comments_async/static/comments_async/ai_report.jsx:6
 msgctxt "defakts"
 msgid "The defakt AI has found evidence of disinformation."
-msgstr "Die defakt KI hat Hinweise auf Desinformation gefunden."
+msgstr "Die Defakts KI hat Hinweise auf Desinformation gefunden."
 
 #: adhocracy4/comments_async/static/comments_async/ai_report.jsx:7
 msgctxt "defakts"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main-design-dev](https://weblate.liqd.net/projects/meinberlin/main-design-dev/).


It also includes following components:

* [meinBerlin/js-design-dev](https://weblate.liqd.net/projects/meinberlin/js-design-dev/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main-design-dev/horizontal-auto.svg)