### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-04 12:03+0100\n"
-"PO-Revision-Date: 2025-04-08 15:15+0000\n"
-"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
+"PO-Revision-Date: 2025-06-20 16:15+0000\n"
+"Last-Translator: Steffen Blindow <s.blindow@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main/de/>"
 "\n"
 "Language: de_DE\n"
@@ -3335,7 +3335,7 @@ msgstr "Link zur Veranstaltung eingeben"
 
 #: meinberlin/apps/livequestions/templates/meinberlin_livequestions/question_present_list.html:39
 msgid "Like questions"
-msgstr "Fragen liken"
+msgstr "Fragen bewerten"
 
 #: meinberlin/apps/livequestions/templates/meinberlin_livequestions/question_present_list.html:53
 msgid "Ask a question yourself!"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-04 12:03+0100\n"
-"PO-Revision-Date: 2025-03-14 14:15+0000\n"
-"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
+"PO-Revision-Date: 2025-06-20 16:15+0000\n"
+"Last-Translator: Steffen Blindow <s.blindow@liqd.net>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -1275,7 +1275,7 @@ msgstr "Anzahl der Unterstützenden"
 #: meinberlin/apps/livequestions/assets/QuestionPresent.jsx:29
 #: meinberlin/apps/livequestions/assets/QuestionUser.jsx:52
 msgid "likes"
-msgstr "likes"
+msgstr "gefällt"
 
 #: meinberlin/apps/livequestions/assets/QuestionUser.jsx:51
 msgid "on shortlist"
@@ -1283,11 +1283,11 @@ msgstr "auf Redeliste"
 
 #: meinberlin/apps/livequestions/assets/QuestionUser.jsx:53
 msgid "add like"
-msgstr "like hinzufügen"
+msgstr "gefällt mir"
 
 #: meinberlin/apps/livequestions/assets/QuestionUser.jsx:54
 msgid "undo like"
-msgstr "like zurück nehmen"
+msgstr "gefällt mir nicht mehr"
 
 #: meinberlin/apps/livequestions/assets/StatisticsBox.jsx:44
 msgid "Questions Answered"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main](https://weblate.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://weblate.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main/horizontal-auto.svg)