### PR TITLE
St-627 Fix archived proposal dropdown

### DIFF
--- a/changelog/627.md
+++ b/changelog/627.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Styling for dropdown menu in archived proposals

--- a/meinberlin/assets/scss/components_user_facing/_item_detail.scss
+++ b/meinberlin/assets/scss/components_user_facing/_item_detail.scss
@@ -213,12 +213,12 @@ dl.item-detail__factsheet-table dd {
 
 .item-detail--archived .moderator-feedback *,
 .item-detail--archived .moderator-notes *,
-.item-detail--archived .item-detail__header .dropdown * {
+.item-detail--archived .item-detail__header * {
     filter: none!important;
     pointer-events: auto!important;
 }
 
-.item-detail--archived *:not(.moderator-feedback, .moderator-notes, .item-detail__header .dropdown *) {
+.item-detail--archived *:not(.moderator-feedback, .moderator-notes, .item-detail__header *) {
     filter: grayscale(100%);
     pointer-events: none;
 }


### PR DESCRIPTION
**Describe your changes**
Fixed Dropdown in Archived Proposal

Original Github Issue: [Link](https://github.com/liqd/a4-meinberlin/issues/6275)

**Test**
- Visit an archived proposal, switch to mobile view in dev tools, click the dropdown

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog