### PR TITLE
ST628 kiezradar search scroll

### DIFF
--- a/changelog/628.md
+++ b/changelog/628.md
@@ -1,0 +1,3 @@
+### Changed
+
+- In Kiezradar, when the user clicks 'filter', the page will auto scroll to the results

--- a/meinberlin/react/projects/ProjectsListMapBox.jsx
+++ b/meinberlin/react/projects/ProjectsListMapBox.jsx
@@ -60,6 +60,7 @@ const ProjectsListMapBox = ({
   const [projectState, setProjectState] = useState(getDefaultProjectState(searchParams))
   const [items, setItems] = useState([])
   const fetchCache = useRef({})
+  const resultRef = useRef({})
   const [appliedFilters, setAppliedFilters] = useState(getDefaultState(searchParams, { districts, organisations, participationChoices, topicChoices, kiezradars }))
   const [alert, setAlert] = useState(null)
   const [error, setError] = useState(null)
@@ -147,6 +148,7 @@ const ProjectsListMapBox = ({
         onFiltered={({ projectState, ...filters }) => {
           setProjectState(projectState)
           setAppliedFilters(filters)
+          resultRef && resultRef.current.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
         }}
         onResetClick={() => {
           setAppliedFilters(getDefaultState(null, { districts, organisations, participationChoices, topicChoices, kiezradars }))
@@ -165,6 +167,7 @@ const ProjectsListMapBox = ({
         <h1 className="aural">{pageHeader}</h1>
         <div className={classNames('projects-list__list-meta', filteredItems.length === 0 && 'projects-list__list-meta--no-results')}>
           <div
+            ref={resultRef}
             role="status"
             className="projects-list__status"
           >

--- a/meinberlin/react/projects/filter-projects.js
+++ b/meinberlin/react/projects/filter-projects.js
@@ -21,7 +21,8 @@ const statusNames = ['active', 'future', 'past']
 
 export const filterProjects = (items, appliedFilters, kiezradars, topics, projectState) => {
   const { search, topics: activeTopics, districts, organisation, participations, plansOnly, kiezradars: activeKiezradars } = appliedFilters
-  return items.filter((item) => {
+
+  const filterItem = (item) => {
     const isWithinAnyRadius =
       item.point && kiezradars.some(kiezradar =>
         activeKiezradars.includes(kiezradar.name) &&
@@ -29,19 +30,26 @@ export const filterProjects = (items, appliedFilters, kiezradars, topics, projec
       )
     const hasKiezradarAndDistrict = activeKiezradars.length > 0 && districts.length > 0
 
-    return (
-      (activeTopics.length === 0 || activeTopics.some(topic => item.topics.includes(topic))) &&
-      (participations.length === 0 || participations.includes(item.participation)) &&
-      (organisation.length === 0 || organisation.includes(item.organisation)) &&
-      (search === '' ||
+    const hasRelevantOrEmptyActiveTopics = (activeTopics.length === 0 || activeTopics.some(topic => item.topics.includes(topic)))
+    const hasRelevantOrEmptyParticipation = (participations.length === 0 || participations.includes(item.participation))
+    const hasRelevantOrEmptyOrganisation = (organisation.length === 0 || organisation.includes(item.participation))
+
+    const isTextSearchMatch = (search === '' ||
         isInTitle(item.title, search) ||
         isInTitle(item.district, search) ||
         isInTitle(item.organisation, search) ||
         isInTitle(item.description, search) ||
         isInTitle(item.identifier, search) ||
-        isInTopic(topics, item.topics, search)) &&
-      (projectState.includes(statusNames[item.status])) &&
-      (!plansOnly || item.type === 'plan') &&
+        isInTopic(topics, item.topics, search))
+
+    const isStatusMatch = (projectState.includes(statusNames[item.status])) && (!plansOnly || item.type === 'plan')
+
+    return (
+      hasRelevantOrEmptyActiveTopics &&
+      hasRelevantOrEmptyParticipation &&
+      hasRelevantOrEmptyOrganisation &&
+      isTextSearchMatch &&
+      isStatusMatch &&
       (hasKiezradarAndDistrict
         // if we have both active we want to include projects that are within kiez
         // OR projects that are in the selected district
@@ -54,5 +62,7 @@ export const filterProjects = (items, appliedFilters, kiezradars, topics, projec
           )
       )
     )
-  })
+  }
+
+  return items.filter(filterItem)
 }


### PR DESCRIPTION
**Describe your changes**
Solution for issue described [here](https://github.com/liqd/a4-meinberlin/issues/6091). When the user filters, the page will scroll to the search results

Reproduce:

Go to Kiezradar, filter the results

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog