### PR TITLE
[ST-622] Custom Kieze change Notification behaviar

### DIFF
--- a/changelog/622.md
+++ b/changelog/622.md
@@ -1,0 +1,2 @@
+### Fixed
+- Custom Kieze dont get Notifications for Projects without Points anymore. #622 

--- a/meinberlin/apps/kiezradar/matchers.py
+++ b/meinberlin/apps/kiezradar/matchers.py
@@ -158,7 +158,10 @@ def get_common_filters(obj: Project | Plan) -> Q:
             & (kiezradar_filter | Q(kiezradars__isnull=True))
         )
     else:
-        location_filter = Q(districts__in=[district]) | Q(districts__isnull=True)
+        # If the SearchProfile has a Kiezradar, but the project has no Point, then no match!
+        location_filter = (Q(districts__in=[district]) | Q(districts__isnull=True)) & Q(
+            kiezradars__isnull=True
+        )
     return filters & location_filter
 
 

--- a/tests/kiezradar/test_search_profile.py
+++ b/tests/kiezradar/test_search_profile.py
@@ -368,6 +368,7 @@ def test_searchprofile_filter_kiezradar_and_district(
     search_profile_factory,
     kiez_radar_factory,
     administrative_district_factory,
+    project_factory,
 ):
     district = administrative_district_factory()
     phase, module, project, item = setup_phase(
@@ -398,3 +399,18 @@ def test_searchprofile_filter_kiezradar_and_district(
         assert len(result) == 2
         assert result.first() == search_profile
         assert result.last() == search_profile1
+
+    # Project without Point
+    project_no_point = project_factory(point=None, administrative_district=district)
+
+    search_profile3 = search_profile_factory()
+    search_profile3.districts.add(district)
+
+    # Expectation: No match with SearchProfiles that have a Kiezradar
+    with freeze_phase(phase):
+        result = get_search_profiles_for_obj(project_no_point).order_by("pk")
+        # search_profile and search_profile1 both have a Kiezradar
+        # search_profile2 only has a Kiezradar_no_match
+        assert (
+            len(result) == 1
+        ), "Project without Point must not be matched to Kiezradar profiles!"


### PR DESCRIPTION
Fixes #6463 
Ticket: https://app.asana.com/1/1175467295883992/project/1208559589495764/task/1210636917477153?focus=true

Custom Kieze dont get Notifications for Projects without Points (Coordinates) anymore. 

**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog