### PR TITLE
[ST-624] assets/js: fix swiper bullet ios safari with inline css

### DIFF
--- a/changelog/6432.md
+++ b/changelog/6432.md
@@ -4,3 +4,7 @@
 - emails: added striptags to email subject containing project name and kiezradar name so special characters display properly
 - emails: added white background mB logo
 - search profile notification email: updated text in German and English
+
+### Fixed
+
+- fix swiper pagination bullets for multi-phase participatory budgeting wrong size on ios safari due to shadow dom, by adding inline css injection

--- a/meinberlin/assets/js/swiper_phases.js
+++ b/meinberlin/assets/js/swiper_phases.js
@@ -37,7 +37,23 @@ const initSwiper = () => {
         clickable: true,
         bulletElement: 'button',
         renderBullet: function (index, className) {
-          return '<button class="' + className + '">' + (index + 1) + '</button>'
+          /*
+          These styles already in _swiper.scss but iOS Safari needs them inline
+          because of how swiper adds these bullets to the shadow DOM.
+          Also: width of 22px needed to make computed with 20px for some reason.
+          */
+          return (
+            '<span class="' + className + '" style="' +
+            'display: flex;' +
+            'justify-content: center;' +
+            'background: transparent;' +
+            'color: #fff;' +
+            'width: 22px !important;' +
+            'height: 22px !important;' +
+            'border: 1.5px solid #fff;' +
+            'opacity: 1;' +
+            '">' + (index + 1) + '</span>'
+          )
         }
       }
     }


### PR DESCRIPTION
Because swiper.js adds some elements via shadow DOM, and shadow DOM implementation different for ios Safari, a css class was not getting applied to pagination bullets, resulting in them being the wrong size.

Fix needed to be adding inline css to the existing injection of the element which the swiper initialization handles.

Issue reported on multi-phase participatory budgeting projects, like: https://meinberlin-design-dev.liqd.net/projekte/module/burgerinnenhaushalt-2-phasen-17/