### PR TITLE
ST643: apps/kiezradar: Make deletion alerts consistent in their wording

### DIFF
--- a/changelog/643.md
+++ b/changelog/643.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Changed wording of deletion alerts (Saved Search, custom Kiez) to make them consistent

--- a/meinberlin/react/kiezradar/Kiezradars.jsx
+++ b/meinberlin/react/kiezradar/Kiezradars.jsx
@@ -36,10 +36,14 @@ const translations = {
     ),
   kiezSavedText: django.gettext('Your changes have been saved.'),
   kiezDeletedTitle: (title) =>
-    django.interpolate(django.gettext('%(title)s deleted'), { title }, true),
+    django.interpolate(
+      django.gettext('%(title)s has been deleted successfully.'),
+      { title },
+      true
+    ),
   kiezDeletedText: (title) =>
     django.interpolate(
-      django.gettext('%(title)s has been permanently deleted.'),
+      django.gettext('The Kiez %(title)s will no longer be shown in the Kiezradar under the "Kieze & Bezirke" filter.'),
       { title },
       true
     ),

--- a/meinberlin/react/kiezradar/SearchProfiles.jsx
+++ b/meinberlin/react/kiezradar/SearchProfiles.jsx
@@ -12,12 +12,15 @@ const errorText = django.gettext('Error')
 const errorSearchProfilesText = django.gettext(
   'Failed to fetch search profiles'
 )
-const searchProfileDeletedTitle = django.gettext(
-  'Search profile successfully deleted'
+const searchProfileDeletedTitle = (name) => django.interpolate(
+  django.gettext('%(name)s has been deleted successfully'),
+  { name },
+  true
 )
 const searchProfileDeletedText = django.gettext(
-  'Your changes have been deleted.'
+  'You will no longer receive notifications about projects that correspond to the filters of this Saved Search.'
 )
+
 const findProjectsText = django.gettext('Find projects')
 const limitExceededTitle = django.gettext('You have reached the limit of saved search profiles')
 const limitExceededText = django.gettext('You are using the maximum number of 10 search profiles. To save a new one, you must delete an existing profile.')
@@ -120,7 +123,7 @@ export default function SearchProfiles (props) {
                           )
 
                           handleAlert({
-                            title: searchProfileDeletedTitle,
+                            title: searchProfileDeletedTitle(searchProfile.name),
                             message: searchProfileDeletedText
                           })
                         }}


### PR DESCRIPTION
**Describe your changes**
Made wording of deletion alerts consistent

**Reproduce**:

Delete a Search Profile / Saved Search, and delete a custom Kiez

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [x] Changelog