### PR TITLE
[ST-626] assets/scss: Correct tab focus styling on answer navigation arrows

### DIFF
--- a/changelog/6290.md
+++ b/changelog/6290.md
@@ -1,0 +1,2 @@
+### Changed
+- Correct tab focus styling on answer navigation arrows

--- a/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-poll.scss
+++ b/meinberlin/assets/scss/components_user_facing/adhocracy4/_a4-poll.scss
@@ -240,10 +240,12 @@
 
     .slick-next {
         right: 0;
+        margin-right: 3px;
     }
 
     .slick-prev,
     .slick-next {
+        margin-bottom: 3px;
         position: absolute;
         bottom: 0;
         text-align: center;
@@ -266,6 +268,7 @@
             font-family: "Font Awesome 5 Free", sans-serif;
             font-weight: 900;
             font-size: 1.2em;
+            line-height: 40px;
         }
     }
 


### PR DESCRIPTION


#6290 

Describe your changes
assets/scss: Correct tab focus styling on answer navigation arrows

Tasks

PR name contains story or task reference
Changelog