### PR TITLE
ST-634: Remove breadcrumbs from blueprints dialog

### DIFF
--- a/changelog/634.md
+++ b/changelog/634.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Remove breadcrumbs from blueprint dialog dashboard.

--- a/meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html
+++ b/meinberlin/apps/dashboard/templates/meinberlin_dashboard/module_blueprint_list_dashboard.html
@@ -4,7 +4,7 @@
 {% block header %}{% endblock header %}
 
 {% block title %}{% translate "New Module" %} — {{ block.super }}{% endblock title %}
-
+{% block breadcrumbs %}{% endblock breadcrumbs %}
 {% block content %}
 {% block menu %}{% endblock menu %}
 <div id="module-blueprint-list">


### PR DESCRIPTION
**Describe your changes**
Removed breadcrumbs from Module creation dialog 

**Reproduce**

Edit a project, click "Add module"

**Tasks**
- [x] PR name contains story or task reference
- [x] Steps to recreate and test the changes
- [x] Changelog