### PR TITLE
apps/bplan: strip tags from description

### DIFF
--- a/meinberlin/apps/bplan/serializers.py
+++ b/meinberlin/apps/bplan/serializers.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.images import ImageFile
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
@@ -128,6 +129,14 @@ class BplanSerializer(PointSerializerMixin, serializers.ModelSerializer):
         if instance.is_diplan:
             ret.pop("embed_code")
         return ret
+
+    def validate(self, attrs):
+        """Only add strip_tags (leave truncation in create/update)
+        There is additional validation code repeated between create and update
+        that could be refactored into this method."""
+        if "description" in attrs:
+            attrs["description"] = strip_tags(attrs["description"])
+        return attrs
 
     def create(self, validated_data):
         orga_pk = self._context.get("organisation_pk", None)


### PR DESCRIPTION
Users making requests against bplan api sometimes include html tags for the description. This change strips tags, per [ST-780](https://app.asana.com/1/1175467295883992/inbox/1209159381077685/item/1210823403244953/story/1210845596960795)

For another day: The create/update methods that were already existing for this serializer are not DRY -- ideally the sanitation, truncation, etc. that is duplicated in these should be moved to the validation method I've created here (which create/update both receive validated data from), leaving side-effect-heavy logic (images, signals) in create/update. 