### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-12-04 12:03+0100\n"
-"PO-Revision-Date: 2025-03-14 14:15+0000\n"
-"Last-Translator: Carolin Klingsporn <c.klingsporn@liqd.net>\n"
+"PO-Revision-Date: 2025-07-31 16:43+0000\n"
+"Last-Translator: josh <195121232+partizipation@users.noreply.github.com>\n"
 "Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -1516,7 +1516,7 @@ msgstr "Video abspielen"
 
 #: dsgvo-video-embed/js/dsgvo-video-embed.js:16
 msgid "External video"
-msgstr "Externes Video"
+msgstr "Externes video"
 
 #: dsgvo-video-embed/js/dsgvo-video-embed.js:17
 msgid ""


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main](https://weblate.liqd.net/projects/meinberlin/main/).


It also includes following components:

* [meinBerlin/js](https://weblate.liqd.net/projects/meinberlin/js/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main/horizontal-auto.svg)