### PR TITLE
[ST-733] assets/js: add default map view for non-budget modules

### DIFF
--- a/meinberlin/react/budgeting/react_proposals_init.jsx
+++ b/meinberlin/react/budgeting/react_proposals_init.jsx
@@ -19,7 +19,7 @@ function init () {
         <React.StrictMode>
           <BrowserRouter>
             <FetchItemsProvider {...props} isMapAndList>
-              <ListMapView {...props} listStr={translations.list} />
+              <ListMapView {...props} listStr={translations.list} mode="list" />
             </FetchItemsProvider>
           </BrowserRouter>
         </React.StrictMode>

--- a/meinberlin/react/contrib/ControlBar.jsx
+++ b/meinberlin/react/contrib/ControlBar.jsx
@@ -26,7 +26,7 @@ const getResultCountText = (count) => {
   return django.interpolate(foundProposalsText, [count])
 }
 
-export const ControlBar = () => {
+export const ControlBar = ({ mapListViewMode }) => {
   // grab the results for the list from the useFetchedItems hook
   const { results: { list }, isMapAndList, viewMode } = useFetchedItems()
   const [expandFilters, setExpandFilters] = useState(true)
@@ -196,7 +196,7 @@ export const ControlBar = () => {
         </div>
         {isMapAndList &&
           <div className="span6 align--right">
-            <ControlBarListMapSwitch query={queryParams} />
+            <ControlBarListMapSwitch mapListViewMode={mapListViewMode} query={queryParams} />
           </div>}
       </div>
     </nav>

--- a/meinberlin/react/contrib/ControlBarListMapSwitch.jsx
+++ b/meinberlin/react/contrib/ControlBarListMapSwitch.jsx
@@ -11,9 +11,9 @@ const translated = {
   map: django.gettext('Map')
 }
 
-export const ControlBarListMapSwitch = () => {
+export const ControlBarListMapSwitch = ({ mapListViewMode }) => {
   const [queryParams, setQueryParams] = useSearchParams()
-  const viewMode = queryParams.get('mode') || 'list'
+  const viewMode = queryParams.get('mode') || mapListViewMode || 'list'
 
   const handleClick = () => {
     queryParams.set('mode', viewMode === 'list' ? 'map' : 'list')

--- a/meinberlin/react/contrib/map/ListMapView.jsx
+++ b/meinberlin/react/contrib/map/ListMapView.jsx
@@ -11,10 +11,10 @@ import { MapWithMarkers } from './Map'
  * @param {Object} map - props that are passed to the Map component.
  * @param {string} listStr - accessible text for the list
  */
-export const ListMapView = ({ map, listStr }) => {
+export const ListMapView = ({ map, listStr, mode }) => {
   const [queryParams] = useSearchParams()
   const { results } = useFetchedItems()
-  const viewMode = queryParams.get('mode') || 'list'
+  const viewMode = queryParams.get('mode') || mode || 'list'
 
   const switchDisplays = () => {
     if (viewMode === 'map') {
@@ -34,7 +34,7 @@ export const ListMapView = ({ map, listStr }) => {
   return (
     <>
       <div className="block block--halfgap">
-        <ControlBar />
+        <ControlBar mapListViewMode={viewMode} />
       </div>
       {switchDisplays()}
     </>

--- a/meinberlin/react/kiezkasse/react_kiezkasse_proposals_init.jsx
+++ b/meinberlin/react/kiezkasse/react_kiezkasse_proposals_init.jsx
@@ -15,7 +15,7 @@ function init () {
         <React.StrictMode>
           <BrowserRouter>
             <FetchItemsProvider {...props} isMapAndList>
-              <ListMapView {...props} listStr={django.gettext('Proposals list')} />
+              <ListMapView {...props} listStr={django.gettext('Proposals list')} mode="list" />
             </FetchItemsProvider>
           </BrowserRouter>
         </React.StrictMode>

--- a/meinberlin/react/mapideas/react_mapideas_init.jsx
+++ b/meinberlin/react/mapideas/react_mapideas_init.jsx
@@ -15,7 +15,7 @@ function init () {
         <React.StrictMode>
           <BrowserRouter>
             <FetchItemsProvider {...props} isMapAndList>
-              <ListMapView {...props} listStr={django.gettext('Map Ideas list')} />
+              <ListMapView {...props} listStr={django.gettext('Map Ideas list')} mode="map" />
             </FetchItemsProvider>
           </BrowserRouter>
         </React.StrictMode>

--- a/meinberlin/react/maptopicprio/react_map_topics_init.jsx
+++ b/meinberlin/react/maptopicprio/react_map_topics_init.jsx
@@ -15,7 +15,7 @@ function init () {
         <React.StrictMode>
           <BrowserRouter>
             <FetchItemsProvider {...props} isMapAndList>
-              <ListMapView {...props} listStr={django.gettext('Map topics list')} />
+              <ListMapView {...props} listStr={django.gettext('Map topics list')} mode="map" />
             </FetchItemsProvider>
           </BrowserRouter>
         </React.StrictMode>


### PR DESCRIPTION
> All map-based modules default to map view on initial load, EXCEPT all the Bürgerhaushalt modules

Therefore these default to map view:
- Ideensammlung mit Karte
- Brainstorming mit Karte
- Priorisierung mit Karte