### PR TITLE
[ST-741] apps/kiezradar: add show completed projects

### DIFF
--- a/meinberlin/assets/scss/components_user_facing/_projects-list.scss
+++ b/meinberlin/assets/scss/components_user_facing/_projects-list.scss
@@ -21,6 +21,10 @@
     &.container {
         margin: 0 auto 1.5em;
     }
+
+    &__showCompletedHeading {
+        margin-top: 28px;
+    }
 }
 
 .projects-list--vertical {

--- a/meinberlin/react/projects/ProjectsList.jsx
+++ b/meinberlin/react/projects/ProjectsList.jsx
@@ -1,24 +1,54 @@
 import React from 'react'
+import django from 'django'
 import ProjectTile from './ProjectTile'
 import { classNames } from 'adhocracy4'
 
-const ProjectsList = ({ projects, topicChoices, isHorizontal }) => {
-  if (projects.length > 0) {
-    return (
-      <ul className={classNames('projects-list', isHorizontal ? 'projects-list--horizontal' : 'projects-list--vertical')}>
-        {projects.map((project) => (
-          <li key={project.id}>
+const translated = {
+  showCompletedProjectsHeading: django.gettext('Show completed projects too?'),
+  showCompletedProjectsBody: django.gettext('Expand your search to view completed projects and discover more possibilities.'),
+  showCompletedProjectsButton: django.gettext('Show completed')
+}
+
+const ProjectsList = ({
+  projects,
+  topicChoices,
+  isHorizontal,
+  searchCompletedProjects,
+  showSearchCompletedProjectsButton
+}) => {
+  return (
+    <ul className={classNames('projects-list', isHorizontal ? 'projects-list--horizontal' : 'projects-list--vertical')}>
+      {
+        projects.length > 0 &&
+        projects.map((project, index) => (
+          <li key={'project-' + project.id + '-' + index}>
             <ProjectTile
               project={project}
               isHorizontal={isHorizontal}
               topicChoices={topicChoices}
             />
           </li>
-        ))}
-      </ul>
-    )
-  } else {
-    return null
-  }
+        ))
+      }
+      {
+        showSearchCompletedProjectsButton && (
+          <li key="show-completed-projects">
+            <h3 className="projects-list__showCompletedHeading">{translated.showCompletedProjectsHeading}</h3>
+            <p>
+              {translated.showCompletedProjectsBody}
+            </p>
+            <button
+              onClick={searchCompletedProjects}
+              className="button button--light"
+              type="button"
+            >
+              {translated.showCompletedProjectsButton}
+            </button>
+          </li>
+        )
+      }
+    </ul>
+  )
 }
+
 export default ProjectsList

--- a/meinberlin/react/projects/ProjectsListMapBox.jsx
+++ b/meinberlin/react/projects/ProjectsListMapBox.jsx
@@ -67,7 +67,6 @@ const ProjectsListMapBox = ({
   const [error, setError] = useState(null)
 
   const setParams = (params) => {
-    console.log(params)
     const searchParams = toSearchParams(params)
     setSearchParams(searchParams, { replace: true })
   }


### PR DESCRIPTION
Adds button at bottom of search results allowing user to search past projects.

There was also an existing "bug" that when all projectStatus filter pills are removed, the UI just allows this faulty search to happen (there will always be 0 results because no projectStatus is specified). I fixed that as part of this, so if someone removes the 'abgeschlossen' pill it goes back to regular search.

Kiezradar react components are already showing some tech debt. Much of the `ProjectsControlBar` state needs to be hoisted into parent `ProjectsListMapBox`. Trying to edit state from another child `ProjectsList` reveals the problems with the current approach where state lives in the control bar - it's getting to be a little spaghetti and I got this feature done without the big refactor which would be required to clean this up.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210800684115866
  - https://app.asana.com/0/0/1210801058487329