### PR TITLE
assets/js: fix filter projects organisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 
 ## Unreleased
 
+### Fixed
+
+- Kiezradar filter projects by organisation
+
 ## v2509.1
 
 ### Added

--- a/meinberlin/react/projects/filter-projects.js
+++ b/meinberlin/react/projects/filter-projects.js
@@ -32,7 +32,7 @@ export const filterProjects = (items, appliedFilters, kiezradars, topics, projec
 
     const hasRelevantOrEmptyActiveTopics = (activeTopics.length === 0 || activeTopics.some(topic => item.topics.includes(topic)))
     const hasRelevantOrEmptyParticipation = (participations.length === 0 || participations.includes(item.participation))
-    const hasRelevantOrEmptyOrganisation = (organisation.length === 0 || organisation.includes(item.participation))
+    const hasRelevantOrEmptyOrganisation = (organisation.length === 0 || organisation.includes(item.organisation))
 
     const isTextSearchMatch = (search === '' ||
         isInTitle(item.title, search) ||


### PR DESCRIPTION
one-line fix for a bug in the filters where organisations were not being filtered by the correct attribute
