### PR TITLE
Translations update from LIQD Weblate

### DIFF
--- a/locale/de_DE/LC_MESSAGES/django.po
+++ b/locale/de_DE/LC_MESSAGES/django.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-05-19 15:21+0200\n"
-"PO-Revision-Date: 2026-03-26 07:50+0000\n"
+"PO-Revision-Date: 2026-05-20 14:18+0000\n"
 "Last-Translator: Tietje Khieu <t.khieu@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/main-"
-"design-dev/de/>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
+"main-design-dev/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -4420,7 +4420,7 @@ msgstr "unarchivieren"
 
 #: meinberlin/apps/projects/admin.py:25
 msgid "Send publish-results reminder email to initiators"
-msgstr ""
+msgstr "Projektergebnis-Reminder per Mail an Initiator:innen schicken"
 
 #: meinberlin/apps/projects/admin.py:58
 #, python-format
@@ -4431,7 +4431,11 @@ msgid_plural ""
 "Publish-results reminder sent for %(count)d projects (one e-mail per "
 "initiator of each organisation)."
 msgstr[0] ""
+"Publish-results reminder sent for %(count)d project (one e-mail per "
+"initiator of the organisation)."
 msgstr[1] ""
+"Publish-results reminder sent for %(count)d projects (one e-mail per "
+"initiator of each organisation)."
 
 #: meinberlin/apps/projects/admin.py:83
 #, python-format
@@ -4442,23 +4446,27 @@ msgid_plural ""
 "Skipped %(count)d projects (not standard live projects: draft, archived, or "
 "non-default project type)."
 msgstr[0] ""
+"Skipped %(count)d project (not a standard live project: draft, archived, or "
+"non-default project type)."
 msgstr[1] ""
+"Skipped %(count)d projects (not standard live projects: draft, archived, or "
+"non-default project type)."
 
 #: meinberlin/apps/projects/admin.py:97
 #, python-format
 msgid "Skipped %(count)d project (publish-results reminder was already sent)."
 msgid_plural ""
 "Skipped %(count)d projects (publish-results reminder was already sent)."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Skipped %(count)d project (publish-results reminder was already sent)."
+msgstr[1] "Skipped %(count)d projects (publish-results reminder was already sent)."
 
 #: meinberlin/apps/projects/admin.py:109
 #, python-format
 msgid "Skipped %(count)d project (project results field already has content)."
 msgid_plural ""
 "Skipped %(count)d projects (project results field already has content)."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Skipped %(count)d project (project results field already has content)."
+msgstr[1] "Skipped %(count)d projects (project results field already has content)."
 
 #: meinberlin/apps/projects/admin.py:121
 #, python-format
@@ -4469,7 +4477,11 @@ msgid_plural ""
 "Skipped %(count)d projects (reminder not due yet: participation timing, "
 "minimum last-end cutoff, or delay hours)."
 msgstr[0] ""
+"Skipped %(count)d project (reminder not due yet: participation timing, "
+"minimum last-end cutoff, or delay hours)."
 msgstr[1] ""
+"Skipped %(count)d projects (reminder not due yet: participation timing, "
+"minimum last-end cutoff, or delay hours)."
 
 #: meinberlin/apps/projects/admin.py:164
 msgid "Topic and location"

--- a/locale/de_DE/LC_MESSAGES/djangojs.po
+++ b/locale/de_DE/LC_MESSAGES/djangojs.po
@@ -8,10 +8,10 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-05-19 15:21+0200\n"
-"PO-Revision-Date: 2026-04-09 14:14+0000\n"
+"PO-Revision-Date: 2026-05-20 14:18+0000\n"
 "Last-Translator: Tietje Khieu <t.khieu@liqd.net>\n"
-"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/js-"
-"design-dev/de/>\n"
+"Language-Team: German <https://weblate.liqd.net/projects/meinberlin/"
+"js-design-dev/de/>\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1553,13 +1553,15 @@ msgstr ""
 
 #: meinberlin/react/account/notification_data.js:211
 msgid "Publish project results"
-msgstr ""
+msgstr "Projektergebnisse veröffentlichen"
 
 #: meinberlin/react/account/notification_data.js:213
 msgid ""
 "Receive a reminder to publish participation results after the participation "
 "phase has ended."
 msgstr ""
+"Erinnerung zur Veröffentlichung der Projektergebnisse nach Beendigung des "
+"Projekts erhalten."
 
 #: meinberlin/react/account/notification_data.js:217
 msgid "New Contribution in a Moderated Project"


### PR DESCRIPTION
Translations update from [LIQD Weblate](https://weblate.liqd.net) for [meinBerlin/main-design-dev](https://weblate.liqd.net/projects/meinberlin/main-design-dev/).


It also includes following components:

* [meinBerlin/js-design-dev](https://weblate.liqd.net/projects/meinberlin/js-design-dev/)



Current translation status:

![Weblate translation status](https://weblate.liqd.net/widget/meinberlin/main-design-dev/horizontal-auto.svg)