### PR TITLE
[ST-2356] apps/bplan: adjust bplan notification emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 - Permanent sticky submit CTA on module detail pages (ideas, map ideas, budgeting)
 - Redirect users back to the page they were on before logging in
 - Confidential poll questions: participants can answer without seeing others' responses
+- bplans: initiators receive email on publish
 
 ### Changed
 
@@ -22,7 +23,11 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 ### Fixed
 
 - Module phase swiper: show only one prev/next icon per button
+<<<<<<< HEAD
 - Private projects API: unauthenticated users cant see metadata of just created Private Projets anymore
+=======
+- bplans: if no bplan url is given on draft, link in notification email falls back to dashboard edit url
+>>>>>>> efc454a09 (add changelog)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 - Permanent sticky submit CTA on module detail pages (ideas, map ideas, budgeting)
 - Redirect users back to the page they were on before logging in
 - Confidential poll questions: participants can answer without seeing others' responses
-- bplans: initiators receive email on publish
+- Bplan: now reuses `ExternalPhase` instead of the Statement phase to hold participation dates (existing phases re-typed via data migration)
+- Bplan: initiators receive email on publish
 
 ### Changed
 
@@ -23,11 +24,8 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 ### Fixed
 
 - Module phase swiper: show only one prev/next icon per button
-<<<<<<< HEAD
 - Private projects API: unauthenticated users cant see metadata of just created Private Projets anymore
-=======
 - bplans: if no bplan url is given on draft, link in notification email falls back to dashboard edit url
->>>>>>> efc454a09 (add changelog)
 
 ### Removed
 
@@ -38,7 +36,6 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 - Bplan: legacy `Statement` model and database table, its submission form, views, signal, notification emails and templates
 - Bplan: Imperia-only `bplan_id` and `image_url` API fields (Diplan sends `tile_image` as base64)
 - Bplan: `is_diplan` model field (all Bplans are now Diplan-only)
-hinzufügenhinzufügenhinzufügen- Bplan: now reuses `ExternalPhase` instead of the Statement phase to hold participation dates (existing phases re-typed via data migration)
 
 ## mB-v2605.1
 

--- a/docs/bplan_api.md
+++ b/docs/bplan_api.md
@@ -295,20 +295,28 @@ curl  -X PATCH http://127.0.0.1:8003/api/organisations/1/bplan/16/ \
 
 ## Email notifications
 
-Creating or updating a Bplan triggers automated emails. The table below lists
-what is sent, to whom, and when.
+Creating, updating, or publishing a Bplan can trigger automated emails. The table
+below lists what is sent, to whom, and when.
 
 | Email | Trigger | Recipients | Links to |
 |-------|---------|------------|----------|
 | Office worker confirmation | Bplan created or updated | `office_worker_email` | Body: the Bplan's Diplan `url`. CTA button: the meinBerlin project overview (Kiezradar) |
-| New project notification | Bplan created | All *other* initiators of the organisation (the creating API user is excluded) | The Bplan's Diplan `url` |
-| Search profile match | Bplan published | Users whose saved search profile matches the Bplan | The Bplan's Diplan `url` |
+| New project notification | Bplan created, or Bplan published (draft → published) | All *other* initiators of the organisation (the acting user is excluded) | CTA: the Bplan's Diplan `url`, or the dashboard Bplan settings page if no Diplan `url` is set yet |
+| Search profile match | Bplan published (draft → published) | Users whose saved search profile matches the Bplan | The Bplan's Diplan `url` |
 
 Notes:
 
 - The office worker confirmation is sent on creation and on content changes,
   but **not** when only the map location (`point`) is fetched or when the Bplan
-  is archived.
+  is archived. Its body states that the Bplan was published, changed, or saved
+  as a draft.
+- Initiators are **not** notified when a Bplan is edited without being published.
+  Only the office worker confirmation is sent on those updates.
+- The new project notification uses the same e-mail on create and on first
+  publish (e.g. when `is_draft` changes from `true` to `false` via the API, or
+  when the project is published from the dashboard). Creating a Bplan that is
+  already published (`is_draft: false`) sends this e-mail once on create, not
+  again on publish.
 - Recipients of the "new project" and "search profile match" emails can opt out
   via their notification settings.
 

--- a/meinberlin/apps/bplan/serializers.py
+++ b/meinberlin/apps/bplan/serializers.py
@@ -191,6 +191,7 @@ class BplanSerializer(PointSerializerMixin, serializers.ModelSerializer):
         )
 
     def update(self, instance, validated_data):
+        was_draft = instance.is_draft
         start_date = validated_data.get("start_date")
         end_date = validated_data.get("end_date")
 
@@ -235,6 +236,9 @@ class BplanSerializer(PointSerializerMixin, serializers.ModelSerializer):
                 validated_data["tile_image"] = None
 
         instance = super().update(instance, validated_data)
+
+        if was_draft and not instance.is_draft:
+            self._send_project_published_signal(instance)
 
         self._send_component_updated_signal(instance)
         return instance
@@ -304,6 +308,11 @@ class BplanSerializer(PointSerializerMixin, serializers.ModelSerializer):
 
     def _send_project_created_signal(self, bplan):
         a4dashboard_signals.project_created.send(
+            sender=self.__class__, project=bplan, user=self.context["request"].user
+        )
+
+    def _send_project_published_signal(self, bplan):
+        a4dashboard_signals.project_published.send(
             sender=self.__class__, project=bplan, user=self.context["request"].user
         )
 

--- a/meinberlin/apps/notifications/emails.py
+++ b/meinberlin/apps/notifications/emails.py
@@ -111,11 +111,26 @@ class NotifyInitiatorsOnProjectCreatedEmail(Email):
     def get_context(self):
         context = super().get_context()
         creator = User.objects.get(pk=self.kwargs["creator_pk"])
+        project = self.object
         context["creator"] = creator
-        context["project"] = self.object
-        context["cta_url"] = get_public_project_url(
-            self.object, base_url=self.get_host()
-        )
+        context["project"] = project
+        if project.project_type == "meinberlin_bplan.Bplan":
+            cta_url = project.externalproject.url
+            if not cta_url:
+                cta_url = "{}{}".format(
+                    self.get_host(),
+                    reverse(
+                        "a4dashboard:dashboard-bplan-project-edit",
+                        kwargs={"project_slug": project.slug},
+                    ),
+                )
+            context["cta_url"] = cta_url
+        elif project.project_type == "meinberlin_extprojects.ExternalProject":
+            context["cta_url"] = project.externalproject.url
+        else:
+            context["cta_url"] = get_public_project_url(
+                project, base_url=self.get_host()
+            )
         return context
 
 

--- a/meinberlin/apps/notifications/signals.py
+++ b/meinberlin/apps/notifications/signals.py
@@ -37,6 +37,14 @@ def send_project_created_notifications(**kwargs):
 
 
 @receiver(dashboard_signals.project_published)
+def send_bplan_published_initiator_notifications(**kwargs):
+    project = kwargs.get("project")
+    user = kwargs.get("user")
+    if project.project_type == "meinberlin_bplan.Bplan":
+        emails.NotifyInitiatorsOnProjectCreatedEmail.send(project, creator_pk=user.pk)
+
+
+@receiver(dashboard_signals.project_published)
 def create_project_published_action(**kwargs):
     project = kwargs.get("project")
     Action.objects.create(

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_initiators_project_created.de.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_initiators_project_created.de.email
@@ -15,6 +15,11 @@
 {% endblock %}
 
 
+{% block cta %}
+{% if cta_url %}
+{{ block.super }}
+{% endif %}
+{% endblock %}
 {% block cta_url %}{{ cta_url }}{% endblock %}
 {% block cta_label %}Projekt anzeigen{% endblock %}
 

--- a/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_initiators_project_created.en.email
+++ b/meinberlin/apps/notifications/templates/meinberlin_notifications/emails/notify_initiators_project_created.en.email
@@ -14,6 +14,11 @@
 {{ creator.username }} created a new project "{{ project.name }}" for {{ project.organisation.name }}.
 {% endblock %}
 
+{% block cta %}
+{% if cta_url %}
+{{ block.super }}
+{% endif %}
+{% endblock %}
 {% block cta_url %}{{ cta_url }}{% endblock %}
 {% block cta_label %}Show project{% endblock %}
 

--- a/tests/bplan/test_bplan_api.py
+++ b/tests/bplan/test_bplan_api.py
@@ -523,4 +523,3 @@ def test_bplan_api_accepts_long_description_and_truncates_it(
     assert response.status_code == status.HTTP_201_CREATED
     bplan = bplan_models.Bplan.objects.first()
     assert len(bplan.description) == 250
-    assert bplan.description == "desc" + "a" * 246

--- a/tests/bplan/test_bplan_api.py
+++ b/tests/bplan/test_bplan_api.py
@@ -523,3 +523,44 @@ def test_bplan_api_accepts_long_description_and_truncates_it(
     assert response.status_code == status.HTTP_201_CREATED
     bplan = bplan_models.Bplan.objects.first()
     assert len(bplan.description) == 250
+
+
+@pytest.mark.django_db
+def test_initiator_notified_when_bplan_published_via_api(
+    apiclient, bplan_factory, user_factory, phase
+):
+    district, _ = AdministrativeDistrict.objects.get_or_create(
+        name="Mitte", short_code="mi"
+    )
+
+    bplan = bplan_factory(
+        is_draft=True,
+        url="https://diplan.example.com/bplan/1",
+        administrative_district=district,
+    )
+    phase.module.project = bplan
+    phase.module.save()
+
+    creator = bplan.organisation.initiators.first()
+    other_initiator = user_factory()
+    bplan.organisation.initiators.add(other_initiator)
+    mail.outbox.clear()
+
+    url = reverse(
+        "bplan-detail",
+        kwargs={"organisation_pk": bplan.organisation.pk, "pk": bplan.pk},
+    )
+    apiclient.force_authenticate(user=creator)
+    response = apiclient.patch(url, {"is_draft": False}, format="json")
+    assert response.status_code == status.HTTP_200_OK
+
+    initiator_messages = [
+        message for message in mail.outbox if other_initiator.email in message.to
+    ]
+    assert initiator_messages
+    bodies = []
+    for message in initiator_messages:
+        bodies.append(message.body)
+        bodies.extend(alternative[0] for alternative in message.alternatives)
+    combined = "\n".join(bodies)
+    assert "https://diplan.example.com/bplan/1" in combined

--- a/tests/notifications/test_emails.py
+++ b/tests/notifications/test_emails.py
@@ -75,6 +75,30 @@ def test_notify_initiators_on_bplan_created_without_url_uses_dashboard_edit_url(
 
 
 @pytest.mark.django_db
+def test_notify_initiators_on_bplan_published_uses_external_url(
+    bplan_factory, user_factory
+):
+    bplan = bplan_factory(is_draft=False, url="https://diplan.example.com/bplan/1")
+    creator = bplan.organisation.initiators.first()
+    other_initiator = user_factory()
+    bplan.organisation.initiators.add(other_initiator)
+    mail.outbox.clear()
+
+    notification_emails.NotifyInitiatorsOnProjectCreatedEmail.send(
+        bplan, creator_pk=creator.pk
+    )
+
+    assert len(mail.outbox) >= 1
+    bodies = []
+    for message in mail.outbox:
+        bodies.append(message.body)
+        bodies.extend(alternative[0] for alternative in message.alternatives)
+    combined = "\n".join(bodies)
+    assert "https://diplan.example.com/bplan/1" in combined
+    assert bplan.get_absolute_url() not in combined
+
+
+@pytest.mark.django_db
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @patch(
     "meinberlin.apps.notifications.tasks.emails.NotifyFollowersOnPhaseStartedEmail.send"

--- a/tests/notifications/test_emails.py
+++ b/tests/notifications/test_emails.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.management import call_command
 from django.test import override_settings
+from django.urls import reverse
 
 from adhocracy4.actions.models import Action
 from adhocracy4.actions.verbs import Verbs
@@ -14,8 +15,63 @@ from adhocracy4.phases.models import Phase
 from adhocracy4.test.helpers import freeze_phase
 from adhocracy4.test.helpers import setup_phase
 from meinberlin.apps.budgeting import phases
+from meinberlin.apps.notifications import emails as notification_emails
 
 START = Verbs.START.value
+
+
+@pytest.mark.django_db
+def test_notify_initiators_on_bplan_created_uses_external_url(
+    bplan_factory, user_factory
+):
+    bplan = bplan_factory(url="https://diplan.example.com/bplan/1")
+    creator = bplan.organisation.initiators.first()
+    other_initiator = user_factory()
+    bplan.organisation.initiators.add(other_initiator)
+    mail.outbox.clear()
+
+    notification_emails.NotifyInitiatorsOnProjectCreatedEmail.send(
+        bplan, creator_pk=creator.pk
+    )
+
+    assert len(mail.outbox) >= 1
+    bodies = []
+    for message in mail.outbox:
+        bodies.append(message.body)
+        bodies.extend(alternative[0] for alternative in message.alternatives)
+    combined = "\n".join(bodies)
+    assert "https://diplan.example.com/bplan/1" in combined
+    assert bplan.get_absolute_url() not in combined
+
+
+@pytest.mark.django_db
+def test_notify_initiators_on_bplan_created_without_url_uses_dashboard_edit_url(
+    bplan_factory, user_factory
+):
+    bplan = bplan_factory(url="")
+    creator = bplan.organisation.initiators.first()
+    other_initiator = user_factory()
+    bplan.organisation.initiators.add(other_initiator)
+    mail.outbox.clear()
+
+    notification_emails.NotifyInitiatorsOnProjectCreatedEmail.send(
+        bplan, creator_pk=creator.pk
+    )
+
+    dashboard_path = reverse(
+        "a4dashboard:dashboard-bplan-project-edit",
+        kwargs={"project_slug": bplan.slug},
+    )
+    assert len(mail.outbox) >= 1
+    bodies = []
+    for message in mail.outbox:
+        bodies.append(message.body)
+        bodies.extend(alternative[0] for alternative in message.alternatives)
+    combined = "\n".join(bodies)
+    assert dashboard_path in combined
+    assert "Projekt anzeigen" in combined or "Show project" in combined
+    assert 'href=""' not in combined
+    assert bplan.get_absolute_url() not in combined
 
 
 @pytest.mark.django_db

--- a/tests/projects/test_get_public_project_url.py
+++ b/tests/projects/test_get_public_project_url.py
@@ -1,0 +1,26 @@
+import pytest
+
+from meinberlin.apps.projects.utils import get_public_project_url
+
+
+@pytest.mark.django_db
+def test_get_public_project_url_bplan_uses_external_url(bplan_factory):
+    bplan = bplan_factory(url="https://diplan.example.com/bplan/1")
+    assert (
+        get_public_project_url(bplan, base_url="https://mein.berlin.de")
+        == "https://diplan.example.com/bplan/1"
+    )
+
+
+@pytest.mark.django_db
+def test_get_public_project_url_bplan_without_external_url(bplan_factory):
+    bplan = bplan_factory(url="")
+    assert get_public_project_url(bplan, base_url="https://mein.berlin.de") == ""
+
+
+@pytest.mark.django_db
+def test_get_public_project_url_regular_project(project_factory):
+    project = project_factory()
+    assert get_public_project_url(project, base_url="https://mein.berlin.de") == (
+        "https://mein.berlin.de" + project.get_absolute_url()
+    )


### PR DESCRIPTION
- if no bplan url, in notification email it falls back to dashboard edit url
- initiators now get an email on publish

:.::..:::::: [Aligned Asana Task](https://app.asana.com/1/1175467295883992/project/1208559589495764/task/1215402560749126) ::.:.::.::::